### PR TITLE
[Feat] 소셜 (Kakao, Google) 로그인 기능 구현 및 Supabase 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ fastlane/test_output
 
 # Configuration Files
 *.xcconfig
+LeafLog/LeafLog/GoogleService-Info.plist

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ fastlane/test_output
 # Configuration Files
 *.xcconfig
 LeafLog/LeafLog/GoogleService-Info.plist
+LeafLog/LeafLog/Configuration/GoogleService-Info.plist

--- a/LeafLog/LeafLog.xcodeproj/project.pbxproj
+++ b/LeafLog/LeafLog.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		16AD0E3F2F7FAFE400C98732 /* Exceptions for "LeafLog" folder in "LeafLog" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				Config.xcconfig,
 				Info.plist,
 			);
 			target = 16AD0E2C2F7FAFE200C98732 /* LeafLog */;
@@ -248,7 +247,7 @@
 		16AD0E412F7FAFE400C98732 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 16AD0E2F2F7FAFE200C98732 /* LeafLog */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Configuration/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -266,9 +265,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-
 				PRODUCT_BUNDLE_IDENTIFIER = com.jooslin.leaflog;
-
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -287,7 +284,7 @@
 		16AD0E422F7FAFE400C98732 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 16AD0E2F2F7FAFE200C98732 /* LeafLog */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Configuration/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -305,9 +302,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-
 				PRODUCT_BUNDLE_IDENTIFIER = com.jooslin.leaflog;
-
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -326,7 +321,7 @@
 		16AD0E432F7FAFE400C98732 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 16AD0E2F2F7FAFE200C98732 /* LeafLog */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Configuration/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -393,7 +388,7 @@
 		16AD0E442F7FAFE400C98732 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 16AD0E2F2F7FAFE200C98732 /* LeafLog */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Configuration/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/LeafLog/LeafLog.xcodeproj/project.pbxproj
+++ b/LeafLog/LeafLog.xcodeproj/project.pbxproj
@@ -24,6 +24,11 @@
 		16AD0E702F7FB17000C98732 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 16AD0E6F2F7FB17000C98732 /* Then */; };
 		16AD0E732F7FB17D00C98732 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 16AD0E722F7FB17D00C98732 /* SnapKit */; };
 		16AD0E782F7FB1E600C98732 /* RxFlow in Frameworks */ = {isa = PBXBuildFile; productRef = 16AD0E772F7FB1E600C98732 /* RxFlow */; };
+		B9ED7F362F80EB59005CD3CB /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B9ED7F352F80EB59005CD3CB /* KakaoSDKAuth */; };
+		B9ED7F382F80EB59005CD3CB /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = B9ED7F372F80EB59005CD3CB /* KakaoSDKCommon */; };
+		B9ED7F3A2F80EB59005CD3CB /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = B9ED7F392F80EB59005CD3CB /* KakaoSDKUser */; };
+		B9ED7F3D2F80FD9B005CD3CB /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = B9ED7F3C2F80FD9B005CD3CB /* GoogleSignIn */; };
+		B9ED7F3F2F80FD9B005CD3CB /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B9ED7F3E2F80FD9B005CD3CB /* GoogleSignInSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +39,7 @@
 		16AD0E3F2F7FAFE400C98732 /* Exceptions for "LeafLog" folder in "LeafLog" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Config.xcconfig,
 				Info.plist,
 			);
 			target = 16AD0E2C2F7FAFE200C98732 /* LeafLog */;
@@ -61,8 +67,10 @@
 				16AD0E682F7FB10B00C98732 /* Alamofire in Frameworks */,
 				16AD0E4B2F7FB0BB00C98732 /* PostgREST in Frameworks */,
 				16AD0E492F7FB0BB00C98732 /* Functions in Frameworks */,
+				B9ED7F382F80EB59005CD3CB /* KakaoSDKCommon in Frameworks */,
 				16AD0E542F7FB0C700C98732 /* ReactorKit in Frameworks */,
 				16AD0E782F7FB1E600C98732 /* RxFlow in Frameworks */,
+				B9ED7F3A2F80EB59005CD3CB /* KakaoSDKUser in Frameworks */,
 				16AD0E572F7FB0D500C98732 /* Dependencies in Frameworks */,
 				16AD0E732F7FB17D00C98732 /* SnapKit in Frameworks */,
 				16AD0E512F7FB0BB00C98732 /* Supabase in Frameworks */,
@@ -73,6 +81,9 @@
 				16AD0E5E2F7FB0E000C98732 /* Kingfisher in Frameworks */,
 				16AD0E4F2F7FB0BB00C98732 /* Storage in Frameworks */,
 				16AD0E4D2F7FB0BB00C98732 /* Realtime in Frameworks */,
+				B9ED7F362F80EB59005CD3CB /* KakaoSDKAuth in Frameworks */,
+				B9ED7F3D2F80FD9B005CD3CB /* GoogleSignIn in Frameworks */,
+				B9ED7F3F2F80FD9B005CD3CB /* GoogleSignInSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,6 +144,11 @@
 				16AD0E6F2F7FB17000C98732 /* Then */,
 				16AD0E722F7FB17D00C98732 /* SnapKit */,
 				16AD0E772F7FB1E600C98732 /* RxFlow */,
+				B9ED7F352F80EB59005CD3CB /* KakaoSDKAuth */,
+				B9ED7F372F80EB59005CD3CB /* KakaoSDKCommon */,
+				B9ED7F392F80EB59005CD3CB /* KakaoSDKUser */,
+				B9ED7F3C2F80FD9B005CD3CB /* GoogleSignIn */,
+				B9ED7F3E2F80FD9B005CD3CB /* GoogleSignInSwift */,
 			);
 			productName = LeafLog;
 			productReference = 16AD0E2D2F7FAFE200C98732 /* LeafLog.app */;
@@ -146,7 +162,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 2610;
-				LastUpgradeCheck = 2610;
+				LastUpgradeCheck = 2620;
 				TargetAttributes = {
 					16AD0E2C2F7FAFE200C98732 = {
 						CreatedOnToolsVersion = 26.1;
@@ -173,6 +189,8 @@
 				16AD0E6E2F7FB17000C98732 /* XCRemoteSwiftPackageReference "Then" */,
 				16AD0E712F7FB17D00C98732 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				16AD0E762F7FB1E600C98732 /* XCRemoteSwiftPackageReference "RxFlow" */,
+				B9ED7F342F80EB59005CD3CB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
+				B9ED7F3B2F80FD9B005CD3CB /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 16AD0E2E2F7FAFE200C98732 /* Products */;
@@ -229,6 +247,8 @@
 /* Begin XCBuildConfiguration section */
 		16AD0E412F7FAFE400C98732 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 16AD0E2F2F7FAFE200C98732 /* LeafLog */;
+			baseConfigurationReferenceRelativePath = Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -246,7 +266,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = none.LeafLog;
+				PRODUCT_BUNDLE_IDENTIFIER = LeafLog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -264,6 +284,8 @@
 		};
 		16AD0E422F7FAFE400C98732 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 16AD0E2F2F7FAFE200C98732 /* LeafLog */;
+			baseConfigurationReferenceRelativePath = Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -281,7 +303,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = none.LeafLog;
+				PRODUCT_BUNDLE_IDENTIFIER = LeafLog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -299,6 +321,8 @@
 		};
 		16AD0E432F7FAFE400C98732 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 16AD0E2F2F7FAFE200C98732 /* LeafLog */;
+			baseConfigurationReferenceRelativePath = Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -332,6 +356,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = YSBKYH9JX6;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -355,6 +380,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -362,6 +388,8 @@
 		};
 		16AD0E442F7FAFE400C98732 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 16AD0E2F2F7FAFE200C98732 /* LeafLog */;
+			baseConfigurationReferenceRelativePath = Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -395,6 +423,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = YSBKYH9JX6;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -411,6 +440,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -520,6 +550,22 @@
 				minimumVersion = 2.13.2;
 			};
 		};
+		B9ED7F342F80EB59005CD3CB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.27.2;
+			};
+		};
+		B9ED7F3B2F80FD9B005CD3CB /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -607,6 +653,31 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 16AD0E762F7FB1E600C98732 /* XCRemoteSwiftPackageReference "RxFlow" */;
 			productName = RxFlow;
+		};
+		B9ED7F352F80EB59005CD3CB /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9ED7F342F80EB59005CD3CB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		B9ED7F372F80EB59005CD3CB /* KakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9ED7F342F80EB59005CD3CB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommon;
+		};
+		B9ED7F392F80EB59005CD3CB /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9ED7F342F80EB59005CD3CB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
+		};
+		B9ED7F3C2F80FD9B005CD3CB /* GoogleSignIn */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9ED7F3B2F80FD9B005CD3CB /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignIn;
+		};
+		B9ED7F3E2F80FD9B005CD3CB /* GoogleSignInSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9ED7F3B2F80FD9B005CD3CB /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignInSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/LeafLog/LeafLog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LeafLog/LeafLog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ec345e48ce69cac71905af5b6d043fcfbc6280e5eae970e10624f4293d161a53",
+  "originHash" : "a4f44703da4573cd69345e8eb30ff852670fac949445cd66f80a2dc97af3a065",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "3f99050e75bbc6fe71fc323adabb039756680016",
         "version" : "5.11.1"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "145104f5ea9d58ae21b60add007c33c1cc0c948e",
+        "version" : "2.0.0"
       }
     },
     {
@@ -20,12 +38,66 @@
       }
     },
     {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS",
+      "state" : {
+        "revision" : "913b4005ea26aebe1c97d54e35ad82a515924c71",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "56e0ccf09a6dd29dc7e68bdf729598240ca8aa16",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "5978979157a5a0521c9c56fd0156aec794caa21c",
+        "version" : "2.27.2"
+      }
+    },
+    {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",
       "state" : {
         "revision" : "c152c1915f60c51e4afa0752656993ee5b3c63db",
         "version" : "8.8.1"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {
@@ -49,7 +121,7 @@
     {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "location" : "https://github.com/ReactiveX/RxSwift",
       "state" : {
         "revision" : "132aea4f236ccadc51590b38af0357a331d51fa2",
         "version" : "6.10.2"

--- a/LeafLog/LeafLog/App/SupabaseManager.swift
+++ b/LeafLog/LeafLog/App/SupabaseManager.swift
@@ -1,0 +1,42 @@
+//
+//  SupabaseManager.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/6/26.
+//
+
+import Foundation
+import Supabase
+
+final class SupabaseManager {
+    
+    static let shared = SupabaseManager()
+    private init() {}
+    
+    let client: SupabaseClient = {
+        let baseURL = getSecret(for: "SUPABASE_URL")
+        let anonKey = getSecret(for: "SUPABASE_ANON_KEY")
+
+        guard let supabaseURL = URL(string: "https://\(baseURL)") else {
+            fatalError("유효하지 않은 Supabase URL입니다.")
+        }
+
+        return SupabaseClient(
+            supabaseURL: supabaseURL,
+            supabaseKey: anonKey,
+            options: SupabaseClientOptions(
+                auth: .init(
+                    emitLocalSessionAsInitialSession: true
+                )
+            )
+        )
+    }()
+
+    private static func getSecret(for key: String) -> String {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String,
+              !value.isEmpty else {
+            fatalError("\(key)를 Info.plist에서 찾을 수 없습니다.")
+        }
+        return value
+    }
+}

--- a/LeafLog/LeafLog/App/SupabaseManager.swift
+++ b/LeafLog/LeafLog/App/SupabaseManager.swift
@@ -9,27 +9,17 @@ import Foundation
 import Supabase
 
 final class SupabaseManager {
-    
     static let shared = SupabaseManager()
-    
-    private enum InfoKeys {
-        static let url = "SUPABASE_URL"
-        static let anonKey = "SUPABASE_ANON_KEY"
-    }
-    
     private init() {}
     
     let client: SupabaseClient = {
-        let baseURL = getSecret(for: InfoKeys.url)
-        let anonKey = getSecret(for: InfoKeys.anonKey)
-
-        guard let supabaseURL = URL(string: "https://\(baseURL)") else {
+        guard let supabaseURL = URL(string: "https://\(AppSecrets.supabaseURL)") else {
             fatalError("유효하지 않은 Supabase URL입니다.")
         }
 
         return SupabaseClient(
             supabaseURL: supabaseURL,
-            supabaseKey: anonKey,
+            supabaseKey: AppSecrets.supabaseAnonKey,
             options: SupabaseClientOptions(
                 auth: .init(
                     emitLocalSessionAsInitialSession: true
@@ -37,12 +27,4 @@ final class SupabaseManager {
             )
         )
     }()
-
-    private static func getSecret(for key: String) -> String {
-        guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String,
-              !value.isEmpty else {
-            fatalError("\(key)를 Info.plist에서 찾을 수 없습니다.")
-        }
-        return value
-    }
 }

--- a/LeafLog/LeafLog/App/SupabaseManager.swift
+++ b/LeafLog/LeafLog/App/SupabaseManager.swift
@@ -11,11 +11,17 @@ import Supabase
 final class SupabaseManager {
     
     static let shared = SupabaseManager()
+    
+    private enum InfoKeys {
+        static let url = "SUPABASE_URL"
+        static let anonKey = "SUPABASE_ANON_KEY"
+    }
+    
     private init() {}
     
     let client: SupabaseClient = {
-        let baseURL = getSecret(for: "SUPABASE_URL")
-        let anonKey = getSecret(for: "SUPABASE_ANON_KEY")
+        let baseURL = getSecret(for: InfoKeys.url)
+        let anonKey = getSecret(for: InfoKeys.anonKey)
 
         guard let supabaseURL = URL(string: "https://\(baseURL)") else {
             fatalError("유효하지 않은 Supabase URL입니다.")

--- a/LeafLog/LeafLog/AppDelegate.swift
+++ b/LeafLog/LeafLog/AppDelegate.swift
@@ -6,31 +6,37 @@
 //
 
 import UIKit
+import KakaoSDKCommon
+import GoogleSignIn
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        
+        // 구글 SDK 세팅
+        GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: AppSecrets.googleClientID)
+        
+        // 카카오 SDK 세팅
+        KakaoSDK.initSDK(appKey: AppSecrets.kakaoNativeAppKey)
+        
         return true
-    }
-
+        }
+    
     // MARK: UISceneSession Lifecycle
-
+    
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
+    
+    
 }
 

--- a/LeafLog/LeafLog/Auth/AuthError.swift
+++ b/LeafLog/LeafLog/Auth/AuthError.swift
@@ -1,0 +1,22 @@
+//
+//  AuthError.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/7/26.
+//
+
+import Foundation
+
+enum AuthError: Error {
+    /// 로그인 과정 자체에서 실패했을 때 (카카오/구글 SDK 에러 등)
+    case loginFailed(String)
+    
+    /// 사용자가 로그인 취소하였을때
+    case cancelled
+    
+    /// 로그인 후 앱으로 돌아오는 URL Scheme이 잘못되었을 때
+    case invalidCallbackURL
+    
+    /// 로그인은 성공했지만 Supabase 서버에 세션을 만들거나 유저 정보를 가져오는데 실패했을 때
+    case sessionFailed(String)
+}

--- a/LeafLog/LeafLog/Auth/AuthService.swift
+++ b/LeafLog/LeafLog/Auth/AuthService.swift
@@ -15,12 +15,24 @@ final class AuthService {
     // MARK: - Properties
     let supabase = SupabaseManager.shared.client
 
-    private let googleProvider = GoogleAuthProvider()
-    private let kakaoProvider = KakaoAuthProvider()
+    private let googleProvider: GoogleAuthProvider
+    private let kakaoProvider: KakaoAuthProvider
+    private let kakaoTokenExchanger: any KakaoTokenExchanging
 
     
     // MARK: - Initialization
-    private init() {}
+    init(
+        googleProvider: GoogleAuthProvider = GoogleAuthProvider(),
+        kakaoProvider: KakaoAuthProvider = KakaoAuthProvider(),
+        kakaoTokenExchanger: any KakaoTokenExchanging = KakaoSupabaseTokenExchanger(
+            supabaseURL: AppSecrets.supabaseURL,
+            anonKey: AppSecrets.supabaseAnonKey
+        )
+    ) {
+        self.googleProvider = googleProvider
+        self.kakaoProvider = kakaoProvider
+        self.kakaoTokenExchanger = kakaoTokenExchanger
+    }
 
     
     // MARK: - Google Login
@@ -42,11 +54,7 @@ final class AuthService {
     
     // MARK: - Exchange Kakao Token With Supabase
     private func exchangeKakaoTokenWithSupabase(idToken: String) async throws -> Supabase.User {
-        let exchanger = KakaoSupabaseTokenExchanger(
-            supabaseURL: AppSecrets.supabaseURL,
-            anonKey: AppSecrets.supabaseAnonKey
-        )
-        let tokens = try await exchanger.exchange(idToken: idToken)
+        let tokens = try await kakaoTokenExchanger.exchange(idToken: idToken)
         try await supabase.auth.setSession(accessToken: tokens.accessToken, refreshToken: tokens.refreshToken)
         return try await supabase.auth.user()
     }

--- a/LeafLog/LeafLog/Auth/AuthService.swift
+++ b/LeafLog/LeafLog/Auth/AuthService.swift
@@ -18,26 +18,14 @@ final class AuthService {
     private let googleProvider = GoogleAuthProvider()
     private let kakaoProvider = KakaoAuthProvider()
 
-    @MainActor
-    private var rootViewController: UIViewController? {
-        UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .first(where: { $0.activationState == .foregroundActive })?
-            .keyWindow?
-            .rootViewController
-    }
-
     
     // MARK: - Initialization
     private init() {}
 
     
     // MARK: - Google Login
-    func startGoogleNativeLogin() async throws -> Supabase.User {
-        guard let rootVC = rootViewController else {
-            throw AuthError.loginFailed("rootViewController를 찾을 수 없습니다.")
-        }
-        let credential = try await googleProvider.fetchCredential(presentingViewController: rootVC)
+    func startGoogleNativeLogin(presentingViewController: UIViewController) async throws -> Supabase.User {
+        let credential = try await googleProvider.fetchCredential(presentingViewController: presentingViewController)
         try await supabase.auth.signInWithIdToken(
             credentials: .init(provider: .google, idToken: credential.idToken, nonce: credential.rawNonce)
         )

--- a/LeafLog/LeafLog/Auth/AuthService.swift
+++ b/LeafLog/LeafLog/Auth/AuthService.swift
@@ -1,0 +1,72 @@
+//
+//  AuthService.swift
+//  LeafLog
+//
+//  Created by t2025-m0143 on 4/3/26.
+//
+
+import UIKit
+import Supabase
+
+final class AuthService {
+    static let shared = AuthService()
+
+    
+    // MARK: - Properties
+    let supabase = SupabaseManager.shared.client
+
+    private let googleProvider = GoogleAuthProvider()
+    private let kakaoProvider = KakaoAuthProvider()
+
+    @MainActor
+    private var rootViewController: UIViewController? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first(where: { $0.activationState == .foregroundActive })?
+            .keyWindow?
+            .rootViewController
+    }
+
+    
+    // MARK: - Initialization
+    private init() {}
+
+    
+    // MARK: - Google Login
+    func startGoogleNativeLogin() async throws -> Supabase.User {
+        guard let rootVC = rootViewController else {
+            throw AuthError.loginFailed("rootViewController를 찾을 수 없습니다.")
+        }
+        let credential = try await googleProvider.fetchCredential(presentingViewController: rootVC)
+        try await supabase.auth.signInWithIdToken(
+            credentials: .init(provider: .google, idToken: credential.idToken, nonce: credential.rawNonce)
+        )
+        return try await supabase.auth.user()
+    }
+
+    
+    // MARK: - Kakao Login
+    func startKakaoNativeLogin() async throws -> Supabase.User {
+        let idToken = try await kakaoProvider.fetchIDToken()
+        return try await exchangeKakaoTokenWithSupabase(idToken: idToken)
+    }
+
+    
+    // MARK: - Exchange Kakao Token With Supabase
+    private func exchangeKakaoTokenWithSupabase(idToken: String) async throws -> Supabase.User {
+        let exchanger = KakaoSupabaseTokenExchanger(
+            supabaseURL: AppSecrets.supabaseURL,
+            anonKey: AppSecrets.supabaseAnonKey
+        )
+        let tokens = try await exchanger.exchange(idToken: idToken)
+        try await supabase.auth.setSession(accessToken: tokens.accessToken, refreshToken: tokens.refreshToken)
+        return try await supabase.auth.user()
+    }
+    
+    
+    // MARK: - Sign Out
+    func signOut() async throws {
+        try await supabase.auth.signOut()
+        googleProvider.signOut()
+    }
+}

--- a/LeafLog/LeafLog/Auth/GoogleAuthProvider.swift
+++ b/LeafLog/LeafLog/Auth/GoogleAuthProvider.swift
@@ -1,0 +1,62 @@
+//
+//  GoogleAuthProvider.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/6/26.
+//
+
+import UIKit
+import GoogleSignIn
+
+final class GoogleAuthProvider {
+
+    // MARK: - Types
+    struct GoogleCredential {
+        let idToken: String
+        let rawNonce: String
+    }
+
+    
+    // MARK: - Login
+    // Google 로그인 UI를 띄우고, Supabase에 넘길 credential을 반환
+    @MainActor
+    func fetchCredential(presentingViewController: UIViewController) async throws -> GoogleCredential {
+        let rawNonce = NonceGenerator.randomNonceString()
+        let hashedNonce = NonceGenerator.sha256(rawNonce)
+        let hint = GIDSignIn.sharedInstance.currentUser?.profile?.email
+
+        return try await withCheckedThrowingContinuation { continuation in
+            // 구글 서버에 로그인 요청하기
+            GIDSignIn.sharedInstance.signIn(
+                withPresenting: presentingViewController,
+                hint: hint,
+                additionalScopes: nil,
+                nonce: hashedNonce
+            ) { result, error in
+                // error가 발생한 경우
+                if let error {
+                    let authError: AuthError = error.localizedDescription.contains("cancel")
+                        ? .cancelled
+                        : .loginFailed(error.localizedDescription)
+                    continuation.resume(throwing: authError)
+                    return
+                }
+
+                // 토큰 꺼내기
+                guard let idToken = result?.user.idToken?.tokenString else {
+                    continuation.resume(throwing: AuthError.loginFailed("Google ID Token을 가져올 수 없습니다."))
+                    return
+                }
+
+                // 성공 반환
+                continuation.resume(returning: GoogleCredential(idToken: idToken, rawNonce: rawNonce))
+            }
+        }
+    }
+
+    
+    // MARK: - Login
+    func signOut() {
+        GIDSignIn.sharedInstance.signOut()
+    }
+}

--- a/LeafLog/LeafLog/Auth/KakaoAuthProvider.swift
+++ b/LeafLog/LeafLog/Auth/KakaoAuthProvider.swift
@@ -17,8 +17,8 @@ final class KakaoAuthProvider {
     @MainActor
     func fetchIDToken() async throws -> String {
         return try await withCheckedThrowingContinuation { continuation in
-            let handler: (OAuthToken?, Error?) -> Void = { [weak self] oauthToken, error in
-                self?.handleResult(oauthToken: oauthToken, error: error, continuation: continuation)
+            let handler: (OAuthToken?, Error?) -> Void = { oauthToken, error in
+                self.handleResult(oauthToken: oauthToken, error: error, continuation: continuation)
             }
 
             if UserApi.isKakaoTalkLoginAvailable() {

--- a/LeafLog/LeafLog/Auth/KakaoAuthProvider.swift
+++ b/LeafLog/LeafLog/Auth/KakaoAuthProvider.swift
@@ -1,0 +1,56 @@
+//
+//  KakoAuthProvider.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/6/26.
+//
+
+import KakaoSDKAuth
+import KakaoSDKCommon
+import KakaoSDKUser
+import Foundation
+
+final class KakaoAuthProvider {
+
+    // MARK: - Login
+    // 카카오 로그인 후 Supabase 교환에 필요한 ID 토큰을 반환
+    @MainActor
+    func fetchIDToken() async throws -> String {
+        return try await withCheckedThrowingContinuation { continuation in
+            let handler: (OAuthToken?, Error?) -> Void = { [weak self] oauthToken, error in
+                self?.handleResult(oauthToken: oauthToken, error: error, continuation: continuation)
+            }
+
+            if UserApi.isKakaoTalkLoginAvailable() {
+                UserApi.shared.loginWithKakaoTalk(completion: handler)
+            } else {
+                UserApi.shared.loginWithKakaoAccount(completion: handler)
+            }
+        }
+    }
+
+    
+    // MARK: - Private
+    private func handleResult(
+        oauthToken: OAuthToken?,
+        error: Error?,
+        continuation: CheckedContinuation<String, Error>
+    ) {
+        if let error {
+            if let sdkError = error as? SdkError, sdkError.isClientFailed,
+               case .Cancelled = sdkError.getClientError().reason {
+                continuation.resume(throwing: AuthError.cancelled)
+            } else {
+                continuation.resume(throwing: AuthError.loginFailed(error.localizedDescription))
+            }
+            return
+        }
+
+        guard let idToken = oauthToken?.idToken else {
+            continuation.resume(throwing: AuthError.loginFailed("ID 토큰이 없습니다. OpenID Connect 활성화 여부를 확인하세요."))
+            return
+        }
+
+        continuation.resume(returning: idToken)
+    }
+}

--- a/LeafLog/LeafLog/Auth/KakaoSupabaseTokenExchanger.swift
+++ b/LeafLog/LeafLog/Auth/KakaoSupabaseTokenExchanger.swift
@@ -5,10 +5,21 @@
 //  Created by 김주희 on 4/5/26.
 //
 
+import Alamofire
 import Foundation
 
 // 카카오 토큰을 Supabase와 교환해 유저정보 받아오기
 struct KakaoSupabaseTokenExchanger {
+    private struct TokenExchangeResponse: Decodable {
+        let accessToken: String
+        let refreshToken: String
+
+        enum CodingKeys: String, CodingKey {
+            case accessToken = "access_token"
+            case refreshToken = "refresh_token"
+        }
+    }
+
     private let supabaseURL: String
     private let anonKey: String
     
@@ -18,33 +29,42 @@ struct KakaoSupabaseTokenExchanger {
     }
     
     func exchange(idToken: String) async throws -> (accessToken: String, refreshToken: String) {
-        guard let url = URL(string: "https://\(supabaseURL)/auth/v1/token?grant_type=id_token") else {
-            throw AuthError.loginFailed("잘못된 Supabase URL입니다.")
-        }
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue(anonKey, forHTTPHeaderField: "apikey")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: [
+        let endpoint = "https://\(supabaseURL)/auth/v1/token?grant_type=id_token"
+        let headers: HTTPHeaders = [
+            "Content-Type": "application/json",
+            "apikey": anonKey
+        ]
+        let parameters: Parameters = [
             "provider": "kakao",
             "id_token": idToken
-        ])
-        
-        let (data, response) = try await URLSession.shared.data(for: request)
-        
-        guard let httpResponse = response as? HTTPURLResponse,
-              (200...299).contains(httpResponse.statusCode) else {
-            let errorStr = String(data: data, encoding: .utf8) ?? "알 수 없는 에러"
-            throw AuthError.loginFailed("Supabase API 통신 에러: \(errorStr)")
+        ]
+
+        let response = await AF.request(
+            endpoint,
+            method: .post,
+            parameters: parameters,
+            encoding: JSONEncoding.default,
+            headers: headers
+        )
+        .validate(statusCode: 200..<300)
+        .serializingData()
+        .response
+
+        switch response.result {
+        case .success(let data):
+            do {
+                let tokenResponse = try JSONDecoder().decode(TokenExchangeResponse.self, from: data)
+                return (tokenResponse.accessToken, tokenResponse.refreshToken)
+            } catch {
+                throw AuthError.sessionFailed("토큰 파싱 실패: \(error.localizedDescription)")
+            }
+        case .failure(let error):
+            if let responseData = response.data,
+               let errorMessage = String(data: responseData, encoding: .utf8),
+               errorMessage.isEmpty == false {
+                throw AuthError.sessionFailed("Supabase API 통신 에러: \(errorMessage)")
+            }
+            throw AuthError.sessionFailed("카카오 세션 생성 실패: \(error.localizedDescription)")
         }
-        
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let accessToken = json["access_token"] as? String,
-              let refreshToken = json["refresh_token"] as? String else {
-            throw AuthError.loginFailed("토큰 파싱 실패")
-        }
-        
-        return (accessToken: accessToken, refreshToken: refreshToken)
     }
 }

--- a/LeafLog/LeafLog/Auth/KakaoSupabaseTokenExchanger.swift
+++ b/LeafLog/LeafLog/Auth/KakaoSupabaseTokenExchanger.swift
@@ -8,8 +8,12 @@
 import Alamofire
 import Foundation
 
+protocol KakaoTokenExchanging {
+    func exchange(idToken: String) async throws -> (accessToken: String, refreshToken: String)
+}
+
 // 카카오 토큰을 Supabase와 교환해 유저정보 받아오기
-struct KakaoSupabaseTokenExchanger {
+struct KakaoSupabaseTokenExchanger: KakaoTokenExchanging {
     private struct TokenExchangeResponse: Decodable {
         let accessToken: String
         let refreshToken: String

--- a/LeafLog/LeafLog/Auth/KakaoSupabaseTokenExchanger.swift
+++ b/LeafLog/LeafLog/Auth/KakaoSupabaseTokenExchanger.swift
@@ -1,0 +1,50 @@
+//
+//  KakaoSupabaseTokenExchanger.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/5/26.
+//
+
+import Foundation
+
+// 카카오 토큰을 Supabase와 교환해 유저정보 받아오기
+struct KakaoSupabaseTokenExchanger {
+    private let supabaseURL: String
+    private let anonKey: String
+    
+    init(supabaseURL: String, anonKey: String) {
+        self.supabaseURL = supabaseURL
+        self.anonKey = anonKey
+    }
+    
+    func exchange(idToken: String) async throws -> (accessToken: String, refreshToken: String) {
+        guard let url = URL(string: "https://\(supabaseURL)/auth/v1/token?grant_type=id_token") else {
+            throw AuthError.loginFailed("잘못된 Supabase URL입니다.")
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue(anonKey, forHTTPHeaderField: "apikey")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: [
+            "provider": "kakao",
+            "id_token": idToken
+        ])
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            let errorStr = String(data: data, encoding: .utf8) ?? "알 수 없는 에러"
+            throw AuthError.loginFailed("Supabase API 통신 에러: \(errorStr)")
+        }
+        
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["access_token"] as? String,
+              let refreshToken = json["refresh_token"] as? String else {
+            throw AuthError.loginFailed("토큰 파싱 실패")
+        }
+        
+        return (accessToken: accessToken, refreshToken: refreshToken)
+    }
+}

--- a/LeafLog/LeafLog/Configuration/AppSecrets.swift
+++ b/LeafLog/LeafLog/Configuration/AppSecrets.swift
@@ -12,7 +12,10 @@ enum AppSecrets {
     private enum InfoKeys {
         static let url = "SUPABASE_URL"
         static let anonKey = "SUPABASE_ANON_KEY"
+        static let kakaoNativeAppKey = "KAKAO_NATIVE_APP_KEY"
+        static let googleClientID = "CLIENT_ID"
     }
+    
     
     static func getSecret(_ key: String) -> String {
         guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String else {
@@ -21,6 +24,26 @@ enum AppSecrets {
         return value
     }
 
+    
     static var supabaseURL: String { Self.getSecret(InfoKeys.url) }
     static var supabaseAnonKey: String { Self.getSecret(InfoKeys.anonKey) }
+    static var kakaoNativeAppKey: String {
+        let key = Self.getSecret(InfoKeys.kakaoNativeAppKey)
+        
+        if key.isEmpty || key.contains("$") {
+            assertionFailure("Info.plist가 가짜 \(key)값을 가지고 있습니다.")
+            return ""
+        }
+        return key
+    }
+    static var googleClientID: String {
+        guard let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+              let plistDict = NSDictionary(contentsOfFile: plistPath) as? [String: Any],
+              let clientID = plistDict[InfoKeys.googleClientID] as? String,
+              !clientID.isEmpty else {
+            assertionFailure("GoogleService-Info.plist 파일을 찾을 수 없거나 'CLIENT_ID'값이 존재하지 않습니다.")
+            return ""
+        }
+        return clientID
+    }
 }

--- a/LeafLog/LeafLog/Configuration/AppSecrets.swift
+++ b/LeafLog/LeafLog/Configuration/AppSecrets.swift
@@ -1,0 +1,26 @@
+//
+//  AppSecrets.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/6/26.
+//
+
+import Foundation
+
+enum AppSecrets {
+    
+    private enum InfoKeys {
+        static let url = "SUPABASE_URL"
+        static let anonKey = "SUPABASE_ANON_KEY"
+    }
+    
+    static func getSecret(_ key: String) -> String {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String else {
+            fatalError("\(key)를 Info.plist에서 찾을 수 없습니다.")
+        }
+        return value
+    }
+
+    static var supabaseURL: String { Self.getSecret(InfoKeys.url) }
+    static var supabaseAnonKey: String { Self.getSecret(InfoKeys.anonKey) }
+}

--- a/LeafLog/LeafLog/Info.plist
+++ b/LeafLog/LeafLog/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>leaflog</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/LeafLog/LeafLog/Info.plist
+++ b/LeafLog/LeafLog/Info.plist
@@ -9,10 +9,38 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
+				<string>kakao$(KAKAO_NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
 				<string>leaflog</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(REVERSED_CLIENT_ID)</string>
+			</array>
+		</dict>
 	</array>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>$(KAKAO_NATIVE_APP_KEY)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaotalk</string>
+	</array>
+	<key>SUPABASE_ANON_KEY</key>
+	<string>$(SUPABASE_ANON_KEY)</string>
+	<key>SUPABASE_URL</key>
+	<string>$(SUPABASE_URL)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/LeafLog/LeafLog/Info.plist
+++ b/LeafLog/LeafLog/Info.plist
@@ -17,7 +17,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>leaflog</string>
+				<string>com.jooslin.leaflog</string>
 			</array>
 		</dict>
 		<dict>

--- a/LeafLog/LeafLog/Network/AuthService.swift
+++ b/LeafLog/LeafLog/Network/AuthService.swift
@@ -1,7 +1,0 @@
-//
-//  AuthService.swift
-//  LeafLog
-//
-//  Created by t2025-m0143 on 4/3/26.
-//
-

--- a/LeafLog/LeafLog/SceneDelegate.swift
+++ b/LeafLog/LeafLog/SceneDelegate.swift
@@ -6,11 +6,29 @@
 //
 
 import UIKit
+import KakaoSDKAuth
+import GoogleSignIn
+import ReactorKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else { return }
 
+        // 카카오 처리
+        if AuthApi.isKakaoTalkLoginUrl(url) {
+            _ = AuthController.handleOpenUrl(url: url)
+            return
+        }
+        
+        // 구글 처리
+        if GIDSignIn.sharedInstance.handle(url) {
+            return
+        }
+    }
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -18,7 +36,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        window?.rootViewController = UINavigationController(rootViewController: ViewController())
+        // 로그인 화면 실행
+        let vc = LoginViewController()
+        vc.reactor = LoginReactor()
+        
+        window?.rootViewController = UINavigationController(rootViewController: vc)
         window?.makeKeyAndVisible()
     }
 

--- a/LeafLog/LeafLog/Util/Extension/Extension.swift
+++ b/LeafLog/LeafLog/Util/Extension/Extension.swift
@@ -5,3 +5,39 @@
 //  Created by t2025-m0143 on 4/3/26.
 //
 
+import UIKit
+
+extension UIViewController {
+    
+    // MARK: 확인 버튼 1개 알림창 (단순 알림)
+    func showAlert(
+        title: String = "오류",
+        message: String,
+        confirmTitle: String = "확인",
+        onConfirm: (() -> Void)? = nil
+    ) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let confirm = UIAlertAction(title: confirmTitle, style: .default) { _ in
+            onConfirm?()
+        }
+        alert.addAction(confirm)
+        present(alert, animated: true)
+    }
+    
+    // MARK: 버튼 2개 알림창 (회원 탈퇴, 글 삭제, 로그아웃 등)
+    func showDestructiveAlert(
+        title: String,
+        message: String,
+        confirmTitle: String,
+        onConfirm: (() -> Void)? = nil
+    ) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        let confirm = UIAlertAction(title: confirmTitle, style: .destructive) { _ in
+            onConfirm?()
+        }
+        alert.addAction(cancel)
+        alert.addAction(confirm)
+        present(alert, animated: true)
+    }
+}

--- a/LeafLog/LeafLog/Util/NonceGenerator.swift
+++ b/LeafLog/LeafLog/Util/NonceGenerator.swift
@@ -1,0 +1,22 @@
+//
+//  NonceGenerator.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/6/26.
+//
+
+import CryptoKit
+import Foundation
+
+enum NonceGenerator {
+    static func randomNonceString(length: Int = 32) -> String {
+        let charset = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        return String((0..<length).compactMap { _ in charset.randomElement() })
+    }
+
+    static func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashed = SHA256.hash(data: inputData)
+        return hashed.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/LeafLog/LeafLog/View/LoginView.swift
+++ b/LeafLog/LeafLog/View/LoginView.swift
@@ -1,0 +1,74 @@
+//
+//  LoginView.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/5/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class LoginView: UIView {
+    
+    // MARK: - UI Components
+    let googleLoginButton = UIButton().then {
+        $0.setTitle("Google로 시작하기", for: .normal)
+        $0.setTitleColor(.black, for: .normal)
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 8
+        $0.titleLabel?.font = .boldSystemFont(ofSize: 16)
+    }
+    
+    let kakaoLoginButton = UIButton().then {
+        $0.setTitle("카카오톡으로 시작하기", for: .normal)
+        $0.setTitleColor(.black, for: .normal)
+        $0.backgroundColor = .systemYellow
+        $0.layer.cornerRadius = 8
+        $0.titleLabel?.font = .boldSystemFont(ofSize: 16)
+
+    }
+    
+    let appleLoginButton = UIButton().then {
+        $0.setTitle("Apple로 시작하기", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = .black
+        $0.layer.cornerRadius = 8
+        $0.titleLabel?.font = .boldSystemFont(ofSize: 16)
+    }
+    
+    
+    // MARK: -  Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    
+    
+    // MARK: - UI Setup
+    private func setupUI() {
+        [kakaoLoginButton, googleLoginButton, appleLoginButton].forEach { addSubview($0) }
+        
+        kakaoLoginButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview().offset(-30)
+            $0.height.equalTo(50)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+        
+        googleLoginButton.snp.makeConstraints {
+            $0.top.equalTo(kakaoLoginButton.snp.bottom).offset(16)
+            $0.centerX.equalToSuperview()
+            $0.height.horizontalEdges.equalTo(kakaoLoginButton)
+        }
+        
+        appleLoginButton.snp.makeConstraints {
+            $0.top.equalTo(googleLoginButton.snp.bottom).offset(16)
+            $0.centerX.equalToSuperview()
+            $0.height.horizontalEdges.equalTo(kakaoLoginButton)
+        }
+    }
+}

--- a/LeafLog/LeafLog/View/LoginViewController.swift
+++ b/LeafLog/LeafLog/View/LoginViewController.swift
@@ -37,7 +37,10 @@ class LoginViewController: UIViewController, View {
     
     private func bindAction(reactor: LoginReactor) {
         loginView.googleLoginButton.rx.tap
-            .map { LoginReactor.Action.googleLoginTapped }
+            .compactMap { [weak self] in
+                guard let self else { return nil }
+                return LoginReactor.Action.googleLoginTapped(self)
+            }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         

--- a/LeafLog/LeafLog/View/LoginViewController.swift
+++ b/LeafLog/LeafLog/View/LoginViewController.swift
@@ -54,10 +54,20 @@ class LoginViewController: UIViewController, View {
     private func bindState(reactor: LoginReactor) {
         let state = reactor.state.asDriver(onErrorJustReturn: LoginReactor.State())
         
+        state
+            .map { !$0.isLoading }
+            .distinctUntilChanged()
+            .drive(onNext: { [weak self] isEnabled in
+                self?.loginView.googleLoginButton.isEnabled = isEnabled
+                self?.loginView.kakaoLoginButton.isEnabled = isEnabled
+            })
+            .disposed(by: disposeBag)
+
+        
         reactor.pulse(\.$loginSuccess)
             .filter { $0 == true }
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] _ in
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(onNext: { [weak self] _ in
                 self?.transitionToMain()
             })
             .disposed(by: disposeBag)
@@ -65,8 +75,8 @@ class LoginViewController: UIViewController, View {
         
         reactor.pulse(\.$errorMessage)
             .compactMap { $0 }
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] message in
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(onNext: { [weak self] message in
                 self?.showAlert(message: message)
             })
             .disposed(by: disposeBag)

--- a/LeafLog/LeafLog/View/LoginViewController.swift
+++ b/LeafLog/LeafLog/View/LoginViewController.swift
@@ -1,0 +1,75 @@
+//
+//  LoginViewController.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/3/26.
+//
+
+import UIKit
+import ReactorKit
+import RxSwift
+import RxCocoa
+
+class LoginViewController: UIViewController, View {
+    
+    var disposeBag = DisposeBag()
+    
+    private let loginView = LoginView()
+    
+    
+    // MARK: - Lifecycle
+    override func loadView() {
+        view = loginView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+    }
+    
+    
+    // MARK: - Bind
+    func bind(reactor: LoginReactor) {
+        bindAction(reactor: reactor)
+        bindState(reactor: reactor)
+    }
+    
+    
+    private func bindAction(reactor: LoginReactor) {
+        loginView.googleLoginButton.rx.tap
+            .map { LoginReactor.Action.googleLoginTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        loginView.kakaoLoginButton.rx.tap
+            .map { LoginReactor.Action.kakaoLoginTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+    }
+    
+    
+    private func bindState(reactor: LoginReactor) {
+        let state = reactor.state.asDriver(onErrorJustReturn: LoginReactor.State())
+        
+        reactor.pulse(\.$loginSuccess)
+            .filter { $0 == true }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] _ in
+                self?.transitionToMain()
+            })
+            .disposed(by: disposeBag)
+
+        
+        reactor.pulse(\.$errorMessage)
+            .compactMap { $0 }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] message in
+                self?.showAlert(message: message)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func transitionToMain() {
+        // TODO: 실제 메인 뷰 컨트롤러로 넘어가는 코드 작성
+    }
+}

--- a/LeafLog/LeafLog/ViewModel/LoginReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/LoginReactor.swift
@@ -1,0 +1,92 @@
+//
+//  LoginReactor.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/5/26.
+//
+
+import Foundation
+import ReactorKit
+import Supabase
+
+final class LoginReactor: Reactor {
+    
+    enum Action {
+        case googleLoginTapped
+        case kakaoLoginTapped
+    }
+    
+    enum Mutation {
+        case setLoading(Bool)
+        case setLoginSuccess
+        case setError(String)
+    }
+    
+    struct State {
+        var isLoading: Bool = false
+        @Pulse var loginSuccess: Bool = false
+        @Pulse var errorMessage: String? = nil
+    }
+    
+    let initialState = State()
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .googleLoginTapped:
+            return loginFlow { try await AuthService.shared.startGoogleNativeLogin() }
+            
+        case .kakaoLoginTapped:
+            return loginFlow { try await AuthService.shared.startKakaoNativeLogin() }
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .setLoading(let isLoading):
+            newState.isLoading = isLoading
+            
+        case .setLoginSuccess:
+            newState.isLoading = false
+            newState.loginSuccess = true
+            
+        case .setError(let message):
+            newState.isLoading = false
+            newState.errorMessage = message
+        }
+        return newState
+    }
+    
+    private func loginFlow(_ login: @escaping () async throws -> Supabase.User) -> Observable<Mutation> {
+        return Observable.create { observer in
+            observer.onNext(.setLoading(true))
+            let task = Task {
+                do {
+                    _ = try await login()
+                    observer.onNext(.setLoginSuccess)
+                    observer.onCompleted()
+                } catch let error as AuthError {
+                    switch error {
+                    case .cancelled:
+                        // 취소는 조용히 로딩만 해제
+                        observer.onNext(.setLoading(false))
+                    case .loginFailed(let message),
+                         .sessionFailed(let message):
+                        observer.onNext(.setError(message))
+                    case .invalidCallbackURL:
+                        observer.onNext(.setError("잘못된 로그인 URL입니다."))
+                    }
+                    observer.onCompleted()
+                } catch {
+                    // AuthError 외의 예상치 못한 에러
+                    observer.onNext(.setError(error.localizedDescription))
+                    observer.onCompleted()
+                }
+            }
+            return Disposables.create() {
+                task.cancel()
+            }
+            
+        }
+    }
+}

--- a/LeafLog/LeafLog/ViewModel/LoginReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/LoginReactor.swift
@@ -6,13 +6,14 @@
 //
 
 import Foundation
+import UIKit
 import ReactorKit
 import Supabase
 
 final class LoginReactor: Reactor {
     
     enum Action {
-        case googleLoginTapped
+        case googleLoginTapped(UIViewController)
         case kakaoLoginTapped
     }
     
@@ -32,8 +33,12 @@ final class LoginReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .googleLoginTapped:
-            return loginFlow { try await AuthService.shared.startGoogleNativeLogin() }
+        case .googleLoginTapped(let presentingViewController):
+            return loginFlow {
+                try await AuthService.shared.startGoogleNativeLogin(
+                    presentingViewController: presentingViewController
+                )
+            }
             
         case .kakaoLoginTapped:
             return loginFlow { try await AuthService.shared.startKakaoNativeLogin() }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #2

## 🛠 작업 내용 (What I did)
- Supabase 초기 세팅
- 카카오톡 및 구글 소셜 로그인 연동
- `ReactorKit`과 `RxSwift`를 활용한 로그인 화면 구현

## 💻 구현 상세 (Implementation Details)
- 보안 관리: `AppSecrets.swift`를 생성하여 `Info.plist`와 `GoogleService-Info.plist`에서 API Key와 Client ID를 안전하고 명확하게 가져오도록 캡슐화

- Supabase 세팅: `SupabaseManager` 싱글톤 객체를 구현하여 앱 전역에서 Supabase 클라이언트에 접근할 수 있도록 구성

- SDK 초기화 및 URL 핸들링: `AppDelegate`에서 카카오/구글 SDK를 초기화하고, `SceneDelegate`에서 각 소셜 로그인의 콜백 URL을 핸들링하도록 로직을 추가

- UI 및 상태 관리:
(현재 Apple 로그인 버튼 UI도 포함되어 있으나 액션은 추후 연동 예정)
 
- `LoginReactor`를 통해 비동기 로그인 로직(`Task`)을 `Observable`로 감싸 상태(`isLoading`, `loginSuccess`, `errorMessage`)를 관리
 
- `@Pulse`를 활용해 성공 시 화면 전환 및 에러 알림과 같은 단발성 이벤트를 효율적으로 처리
 
- 보안 유틸: 인증 과정에서 사용될 `NonceGenerator` (SHA256 해싱 기능 포함)를 추가했습니다.

## 📸 스크린샷 (Screenshots)
<img width="300" height="800" alt="IMG_2331 2" src="https://github.com/user-attachments/assets/03d0e50f-1582-4f01-848d-658a5c512e7c" />
<img width="300" height="800" alt="IMG_2333" src="https://github.com/user-attachments/assets/52803cee-911f-4c3c-9c21-a22634d36b9d" />

## 🧐 리뷰 포인트 (Review Points)
- 가장 중요: 민감한 키값이나 정보가 담긴 파일(`Config.xcconfig`, `GoogleService-Info.plist` 등)이 `.gitignore`에 잘 적용되어 깃허브에 노출되지 않았는지 확인해 주세요! (혹시 보이는 파일이 있다면 알려주세요)
- 새롭게 추가된 `UIViewController` 공통 Alert Extension의 코드 구조와 사용성이 괜찮은지 리뷰 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [✔️] 빌드 및 테스트가 정상적으로 통과되었나요?
- [✔️] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [✔️] 불필요한 주석이나 디버그 코드를 삭제했나요?
