### PR TITLE
[Feat] Reactive UIViewController 확장 및 gemini 코드 리뷰 조건 수정

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -48,3 +48,4 @@ Minor coordination logic or common MVC-style controller behavior should not auto
 
 ## Exceptions
 - You should not review about below codes:
+    1) Do not review about 'Fatal Error'. most of them are written on purpose

--- a/LeafLog/LeafLog.xcodeproj/project.pbxproj
+++ b/LeafLog/LeafLog.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		16AD0E702F7FB17000C98732 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 16AD0E6F2F7FB17000C98732 /* Then */; };
 		16AD0E732F7FB17D00C98732 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 16AD0E722F7FB17D00C98732 /* SnapKit */; };
 		16AD0E782F7FB1E600C98732 /* RxFlow in Frameworks */ = {isa = PBXBuildFile; productRef = 16AD0E772F7FB1E600C98732 /* RxFlow */; };
+		16BE7CC22F853B3A00F6C98B /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 16BE7CC12F853B3A00F6C98B /* DependenciesMacros */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -70,6 +71,7 @@
 				16AD0E612F7FB0FF00C98732 /* RxCocoa in Frameworks */,
 				16AD0E472F7FB0BB00C98732 /* Auth in Frameworks */,
 				16AD0E632F7FB0FF00C98732 /* RxRelay in Frameworks */,
+				16BE7CC22F853B3A00F6C98B /* DependenciesMacros in Frameworks */,
 				16AD0E5E2F7FB0E000C98732 /* Kingfisher in Frameworks */,
 				16AD0E4F2F7FB0BB00C98732 /* Storage in Frameworks */,
 				16AD0E4D2F7FB0BB00C98732 /* Realtime in Frameworks */,
@@ -83,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				16AD0E2F2F7FAFE200C98732 /* LeafLog */,
+				16BE7CC02F853B3A00F6C98B /* Frameworks */,
 				16AD0E2E2F7FAFE200C98732 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -93,6 +96,13 @@
 				16AD0E2D2F7FAFE200C98732 /* LeafLog.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		16BE7CC02F853B3A00F6C98B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -133,6 +143,7 @@
 				16AD0E6F2F7FB17000C98732 /* Then */,
 				16AD0E722F7FB17D00C98732 /* SnapKit */,
 				16AD0E772F7FB1E600C98732 /* RxFlow */,
+				16BE7CC12F853B3A00F6C98B /* DependenciesMacros */,
 			);
 			productName = LeafLog;
 			productReference = 16AD0E2D2F7FAFE200C98732 /* LeafLog.app */;
@@ -234,7 +245,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Q7HGK38S83;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LeafLog/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -247,7 +257,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jooslin.leaflog.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jooslin.leaflog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -270,7 +280,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Q7HGK38S83;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LeafLog/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -283,7 +292,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jooslin.leaflog.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jooslin.leaflog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -609,6 +618,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 16AD0E762F7FB1E600C98732 /* XCRemoteSwiftPackageReference "RxFlow" */;
 			productName = RxFlow;
+		};
+		16BE7CC12F853B3A00F6C98B /* DependenciesMacros */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 16AD0E552F7FB0D500C98732 /* XCRemoteSwiftPackageReference "swift-dependencies" */;
+			productName = DependenciesMacros;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/LeafLog/LeafLog/Util/Extension/Extension.swift
+++ b/LeafLog/LeafLog/Util/Extension/Extension.swift
@@ -1,7 +1,0 @@
-//
-//  Extension.swift
-//  LeafLog
-//
-//  Created by t2025-m0143 on 4/3/26.
-//
-

--- a/LeafLog/LeafLog/Util/Extension/UIViewController+.swift
+++ b/LeafLog/LeafLog/Util/Extension/UIViewController+.swift
@@ -11,7 +11,7 @@ import RxCocoa
 
 // ViewController의 메서드를 Observable 객체로 사용할 수 있도록 확장
 extension Reactive where Base: UIViewController {
-    var viewWilAppear: Observable<Void> {
+    var viewWillAppear: Observable<Void> {
         methodInvoked(#selector(Base.viewWillAppear(_:))).map { _ in }
     }
     

--- a/LeafLog/LeafLog/Util/Extension/UIViewController+.swift
+++ b/LeafLog/LeafLog/Util/Extension/UIViewController+.swift
@@ -16,7 +16,7 @@ extension Reactive where Base: UIViewController {
     }
     
     var viewDidLoad: Observable<Void> {
-        methodInvoked(#selector(Base.viewDidAppear(_:))).map { _ in }
+        methodInvoked(#selector(Base.viewDidLoad)).map { _ in }
     }
     
     var viewWillDisappear: Observable<Void> {

--- a/LeafLog/LeafLog/Util/Extension/UIViewController+.swift
+++ b/LeafLog/LeafLog/Util/Extension/UIViewController+.swift
@@ -1,0 +1,25 @@
+//
+//  Extension.swift
+//  LeafLog
+//
+//  Created by t2025-m0143 on 4/3/26.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+// ViewController의 메서드를 Observable 객체로 사용할 수 있도록 확장
+extension Reactive where Base: UIViewController {
+    var viewWilAppear: Observable<Void> {
+        methodInvoked(#selector(Base.viewWillAppear(_:))).map { _ in }
+    }
+    
+    var viewDidLoad: Observable<Void> {
+        methodInvoked(#selector(Base.viewDidAppear(_:))).map { _ in }
+    }
+    
+    var viewWillDisappear: Observable<Void> {
+        methodInvoked(#selector(Base.viewWillDisappear(_:))).map { _ in }
+    }
+}

--- a/LeafLog/LeafLog/View/ViewController.swift
+++ b/LeafLog/LeafLog/View/ViewController.swift
@@ -16,4 +16,3 @@ class ViewController: UIViewController {
 
 
 }
-


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #12 

## 🛠 작업 내용 (What I did)
- ViewController의 라이프사이클에 따른 메서드를 RxSwift에 확장
- AI 코드 리뷰어 gemini의 설정을 변경

## 💻 구현 상세 (Implementation Details)
- ViewController의 라이프사이클에 따른 메서드를 RxSwift에 확장했습니다.
  : viewWillAppear, viewDidLoad, viewWillDisappear
- AI 코드 리뷰어 gemini의 설정을 변경
  : fatalError는 리뷰하지 않기

## 🧐 리뷰 포인트 (Review Points)
-  추후 viewController의 다른 메서드가 필요하시다면 추가로 확장하셔서 사용하시면 될 것 같습니다.
- 코드 리뷰어 설정 추가 변경 필요하다면 말씀 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
