### PR TITLE
[FEAT] SearchFiltering 기능 구현

### DIFF
--- a/LeafLog/LeafLog/Info.plist
+++ b/LeafLog/LeafLog/Info.plist
@@ -31,6 +31,10 @@
 	</array>
 	<key>KAKAO_NATIVE_APP_KEY</key>
 	<string>$(KAKAO_NATIVE_APP_KEY)</string>
+	<key>NongsaroAPIKey</key>
+	<string>$(NONGSARO_API_KEY)</string>
+	<key>NongsaroBaseURL</key>
+	<string>$(NONGSARO_BASE_URL)</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/LeafLog/LeafLog/Model/PlantResponse.swift
+++ b/LeafLog/LeafLog/Model/PlantResponse.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 enum PlantSearchType: String, CaseIterable {
-    case name = "sCntntsSj"
+    case plantName = "sCntntsSj"
     case botanicalName = "sPlntbneNm"
     case englishName = "sPlntzrNm"
 
     var title: String {
         switch self {
-        case .name:
+        case .plantName:
             return "식물명"
         case .botanicalName:
             return "학명"

--- a/LeafLog/LeafLog/Model/PlantResponse.swift
+++ b/LeafLog/LeafLog/Model/PlantResponse.swift
@@ -182,12 +182,19 @@ struct PlantListItems: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        if let items = try? container.decode([PlantSummary].self, forKey: .item) {
-            item = items
-        } else if let singleItem = try? container.decode(PlantSummary.self, forKey: .item) {
+        do {
+            item = try container.decode([PlantSummary].self, forKey: .item)
+        } catch DecodingError.typeMismatch {
+            // 배열 디코딩 실패 시 단일 객체로 시도
+            let singleItem = try container.decode(PlantSummary.self, forKey: .item)
             item = [singleItem]
-        } else {
-            item = []
+        } catch let error as DecodingError {
+            switch error {
+            case .keyNotFound, .valueNotFound:
+                item = []
+            default:
+                throw error
+            }
         }
         
         numOfRows = try container.decodeIfPresent(String.self, forKey: .numOfRows)
@@ -227,12 +234,18 @@ struct PlantFilterItems: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        if let items = try? container.decode([PlantFilterOption].self, forKey: .item) {
-            item = items
-        } else if let singleItem = try? container.decode(PlantFilterOption.self, forKey: .item) {
+        do {
+            item = try container.decode([PlantFilterOption].self, forKey: .item)
+        } catch DecodingError.typeMismatch {
+            let singleItem = try container.decode(PlantFilterOption.self, forKey: .item)
             item = [singleItem]
-        } else {
-            item = []
+        } catch let error as DecodingError {
+            switch error {
+            case .keyNotFound, .valueNotFound:
+                item = []
+            default:
+                throw error
+            }
         }
     }
 }

--- a/LeafLog/LeafLog/Model/PlantResponse.swift
+++ b/LeafLog/LeafLog/Model/PlantResponse.swift
@@ -26,6 +26,7 @@ enum PlantSearchType: String, CaseIterable {
 
 // 필터링 검색을 위한 이넘 정의
 enum PlantFilterKind: CaseIterable, Hashable {
+    case searchType
     case light
     case growthStyle
     case leafColor
@@ -39,6 +40,8 @@ enum PlantFilterKind: CaseIterable, Hashable {
     // UI 표시형
     var title: String {
         switch self {
+        case .searchType:
+            return "검색기준"
         case .light:
             return "광도요구"
         case .growthStyle:
@@ -63,6 +66,8 @@ enum PlantFilterKind: CaseIterable, Hashable {
     // API 요청path
     var listPath: String {
         switch self {
+        case .searchType: // 검색 타입 제외
+            return ""
         case .light:
             return "lightList"
         case .growthStyle:
@@ -87,6 +92,8 @@ enum PlantFilterKind: CaseIterable, Hashable {
     // 파라미터
     var requestParameterName: String {
         switch self {
+        case .searchType: // 검색 타입 제외
+            return ""
         case .light:
             return "lightChkVal"
         case .growthStyle:
@@ -106,6 +113,11 @@ enum PlantFilterKind: CaseIterable, Hashable {
         case .waterCycle:
             return "waterCycleSel"
         }
+    }
+    
+    //
+    var usesServerProvidedOptions: Bool {
+        self != .searchType
     }
 }
 

--- a/LeafLog/LeafLog/Model/PlantResponse.swift
+++ b/LeafLog/LeafLog/Model/PlantResponse.swift
@@ -24,6 +24,102 @@ enum PlantSearchType: String, CaseIterable {
     }
 }
 
+// 필터링 검색을 위한 이넘 정의
+enum PlantFilterKind: CaseIterable, Hashable {
+    case light
+    case growthStyle
+    case leafColor
+    case leafPattern
+    case flowerColor
+    case fruitColor
+    case bloomingSeason
+    case winterMinTemperature
+    case waterCycle
+    
+    // UI 표시형
+    var title: String {
+        switch self {
+        case .light:
+            return "광도요구"
+        case .growthStyle:
+            return "생육형태"
+        case .leafColor:
+            return "잎색"
+        case .leafPattern:
+            return "잎무늬"
+        case .flowerColor:
+            return "꽃색"
+        case .fruitColor:
+            return "열매색"
+        case .bloomingSeason:
+            return "꽃피는 계절"
+        case .winterMinTemperature:
+            return "겨울최저온도"
+        case .waterCycle:
+            return "물주기"
+        }
+    }
+    
+    // API 요청path
+    var listPath: String {
+        switch self {
+        case .light:
+            return "lightList"
+        case .growthStyle:
+            return "grwhstleList"
+        case .leafColor:
+            return "lefcolrList"
+        case .leafPattern:
+            return "lefmrkList"
+        case .flowerColor:
+            return "flclrList"
+        case .fruitColor:
+            return "fmldecolrList"
+        case .bloomingSeason:
+            return "ignSeasonList"
+        case .winterMinTemperature:
+            return "winterLwetList"
+        case .waterCycle:
+            return "waterCycleList"
+        }
+    }
+    
+    // 파라미터
+    var requestParameterName: String {
+        switch self {
+        case .light:
+            return "lightChkVal"
+        case .growthStyle:
+            return "grwhstleChkVal"
+        case .leafColor:
+            return "lefcolrChkVal"
+        case .leafPattern:
+            return "lefmrkChkVal"
+        case .flowerColor:
+            return "flclrChkVal"
+        case .fruitColor:
+            return "fmldecolrChkVal"
+        case .bloomingSeason:
+            return "ignSeasonChkVal"
+        case .winterMinTemperature:
+            return "winterLwetChkVal"
+        case .waterCycle:
+            return "waterCycleSel"
+        }
+    }
+}
+
+// 코드는 숫자, name은 사용자 표시용
+struct PlantFilterOption: Decodable, Equatable {
+    let code: String
+    let name: String
+
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case name = "codeNm"
+    }
+}
+
 // 검색용 API 모델
 struct PlantListResponse: Decodable {
     let header: PlantResponseHeader
@@ -74,6 +170,37 @@ struct PlantDetailResponse: Decodable {
 
 struct PlantDetailBody: Decodable {
     let item: PlantDetail?
+}
+
+// 필터용 요청
+struct PlantFilterListResponse: Decodable {
+    let header: PlantResponseHeader
+    let body: PlantFilterListBody?
+}
+
+struct PlantFilterListBody: Decodable {
+    let items: PlantFilterItems?
+}
+
+// 실제 필터용 옵션 담는 곳
+struct PlantFilterItems: Decodable {
+    let item: [PlantFilterOption]
+
+    private enum CodingKeys: String, CodingKey {
+        case item
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let items = try? container.decode([PlantFilterOption].self, forKey: .item) {
+            item = items
+        } else if let singleItem = try? container.decode(PlantFilterOption.self, forKey: .item) {
+            item = [singleItem]
+        } else {
+            item = []
+        }
+    }
 }
 
 struct PlantResponseHeader: Decodable {

--- a/LeafLog/LeafLog/Model/PlantResponse.swift
+++ b/LeafLog/LeafLog/Model/PlantResponse.swift
@@ -7,6 +7,23 @@
 
 import Foundation
 
+enum PlantSearchType: String, CaseIterable {
+    case name = "sCntntsSj"
+    case botanicalName = "sPlntbneNm"
+    case englishName = "sPlntzrNm"
+
+    var title: String {
+        switch self {
+        case .name:
+            return "식물명"
+        case .botanicalName:
+            return "학명"
+        case .englishName:
+            return "영명"
+        }
+    }
+}
+
 // 검색용 API 모델
 struct PlantListResponse: Decodable {
     let header: PlantResponseHeader

--- a/LeafLog/LeafLog/Model/PlantResponse.swift
+++ b/LeafLog/LeafLog/Model/PlantResponse.swift
@@ -120,6 +120,28 @@ struct PlantFilterOption: Decodable, Equatable {
     }
 }
 
+// 고른 필터로 상태
+struct PlantFilterState {
+    var selectedOptions: [PlantFilterKind: PlantFilterOption] = [:]
+
+    var isEmpty: Bool {
+        selectedOptions.isEmpty
+    }
+
+    func option(for kind: PlantFilterKind) -> PlantFilterOption? {
+        selectedOptions[kind]
+    }
+
+    func applyOption(_ option: PlantFilterOption?, for kind: PlantFilterKind) -> PlantFilterState {
+        var next = self
+        next.selectedOptions[kind] = option
+        if option == nil {
+            next.selectedOptions.removeValue(forKey: kind)
+        }
+        return next
+    }
+}
+
 // 검색용 API 모델
 struct PlantListResponse: Decodable {
     let header: PlantResponseHeader

--- a/LeafLog/LeafLog/Network/NetworkManager.swift
+++ b/LeafLog/LeafLog/Network/NetworkManager.swift
@@ -26,18 +26,25 @@ final class NetworkManager {
     func fetchPlantList(
         keyword: String,
         searchType: PlantSearchType = .name,
+        filterState: PlantFilterState = .init(),
         pageNo: Int = 1,
         numOfRows: Int = 10
     ) async throws -> [PlantSummary] {
+        var parameters: Parameters = [
+            "apiKey": AppConfig.apiKey,
+            "sType": searchType.rawValue,
+            "sText": keyword,
+            "pageNo": String(pageNo),
+            "numOfRows": String(numOfRows)
+        ]
+
+        for (kind, option) in filterState.selectedOptions {
+            parameters[kind.requestParameterName] = option.code
+        }
+
         let response: PlantListResponse = try await request(
             path: "gardenList",
-            parameters: [
-                "apiKey": AppConfig.apiKey,
-                "sType": searchType.rawValue,
-                "sText": keyword,
-                "pageNo": String(pageNo),
-                "numOfRows": String(numOfRows)
-            ]
+            parameters: parameters
         )
         // HTTP 요청이 아닌 농사로 자체 API 확인(내부 resultCode 확인)
         try validate(header: response.header)

--- a/LeafLog/LeafLog/Network/NetworkManager.swift
+++ b/LeafLog/LeafLog/Network/NetworkManager.swift
@@ -88,7 +88,7 @@ final class NetworkManager {
         // withThrowingTaskGroup 이용해서 병렬 호출
         try await withThrowingTaskGroup(of: (PlantFilterKind, [PlantFilterOption]).self) { group in
             // 케이스 돌면서 작업 등록
-            for kind in PlantFilterKind.allCases {
+            for kind in PlantFilterKind.allCases where kind.usesServerProvidedOptions {
                 group.addTask { [self] in
                     (kind, try await fetchFilterOptions(kind: kind))
                 }

--- a/LeafLog/LeafLog/Network/NetworkManager.swift
+++ b/LeafLog/LeafLog/Network/NetworkManager.swift
@@ -25,7 +25,7 @@ final class NetworkManager {
 
     func fetchPlantList(
         keyword: String,
-        searchType: PlantSearchType = .name,
+        searchType: PlantSearchType = .plantName,
         filterState: PlantFilterState = .init(),
         pageNo: Int = 1,
         numOfRows: Int = 10

--- a/LeafLog/LeafLog/Network/NetworkManager.swift
+++ b/LeafLog/LeafLog/Network/NetworkManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Alamofire
+import Dependencies
 import Foundation
 import XMLCoder
 
@@ -102,5 +103,18 @@ extension NetworkManager {
                 return "네트워크 요청에 실패했습니다. \(error.localizedDescription)"
             }
         }
+    }
+}
+
+extension NetworkManager: DependencyKey {
+    static var liveValue: NetworkManager {
+        .shared
+    }
+}
+
+extension DependencyValues {
+    var networkManager: NetworkManager {
+        get { self[NetworkManager.self] }
+        set { self[NetworkManager.self] = newValue }
     }
 }

--- a/LeafLog/LeafLog/Network/NetworkManager.swift
+++ b/LeafLog/LeafLog/Network/NetworkManager.swift
@@ -63,6 +63,40 @@ final class NetworkManager {
         return detail
     }
     
+    // 필터 코드 목록 하나 보내는 거 분리
+    func fetchFilterOptions(kind: PlantFilterKind) async throws -> [PlantFilterOption] {
+        let response: PlantFilterListResponse = try await request(
+            path: kind.listPath,
+            parameters: [
+                "apiKey": AppConfig.apiKey
+            ]
+        )
+
+        try validate(header: response.header)
+        return response.body?.items?.item ?? []
+    }
+    
+    //필터 오래걸리니까 병렬로 보내기
+    func fetchAllFilterOptions() async throws -> [PlantFilterKind: [PlantFilterOption]] {
+        // withThrowingTaskGroup 이용해서 병렬 호출
+        try await withThrowingTaskGroup(of: (PlantFilterKind, [PlantFilterOption]).self) { group in
+            // 케이스 돌면서 작업 등록
+            for kind in PlantFilterKind.allCases {
+                group.addTask { [self] in
+                    (kind, try await fetchFilterOptions(kind: kind))
+                }
+            }
+
+            var results: [PlantFilterKind: [PlantFilterOption]] = [:]
+            
+            // 모이면 여기에 딕셔너리에 모음(어떤 버튼에 어떤 옵션인지 붙이기 쉽게)
+            for try await (kind, options) in group {
+                results[kind] = options
+            }
+            return results
+        }
+    }
+    
     // 공통 메서드
     private func request<T: Decodable>(path: String, parameters: Parameters) async throws -> T {
         let url = "\(baseURL)/\(path)"

--- a/LeafLog/LeafLog/Network/NetworkManager.swift
+++ b/LeafLog/LeafLog/Network/NetworkManager.swift
@@ -23,12 +23,17 @@ final class NetworkManager {
         self.decoder.shouldProcessNamespaces = false
     }
 
-    func fetchPlantList(keyword: String, pageNo: Int = 1, numOfRows: Int = 10) async throws -> [PlantSummary] {
+    func fetchPlantList(
+        keyword: String,
+        searchType: PlantSearchType = .name,
+        pageNo: Int = 1,
+        numOfRows: Int = 10
+    ) async throws -> [PlantSummary] {
         let response: PlantListResponse = try await request(
             path: "gardenList",
             parameters: [
                 "apiKey": AppConfig.apiKey,
-                "sType": "sCntntsSj",
+                "sType": searchType.rawValue,
                 "sText": keyword,
                 "pageNo": String(pageNo),
                 "numOfRows": String(numOfRows)

--- a/LeafLog/LeafLog/View/SearchView/SearchView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchView.swift
@@ -12,17 +12,22 @@ import SnapKit
 import UIKit
 import Then
 
+
+// TODO: 오류 처리
 final class SearchView: BaseViewController, View {
     private let searchTypeControl = UISegmentedControl(items: PlantSearchType.allCases.map(\.title)).then {
         $0.selectedSegmentIndex = 0
     }
 
-    private let lightFilterButton = UIButton(configuration: .filled()).then {
-        $0.configuration?.cornerStyle = .capsule
-        $0.configuration?.baseBackgroundColor = .secondarySystemBackground
-        $0.configuration?.baseForegroundColor = .label
-        $0.configuration?.title = "광도요구"
-        $0.showsMenuAsPrimaryAction = true
+    private let filterScrollView = UIScrollView().then {
+        $0.showsHorizontalScrollIndicator = false
+    }
+
+    private let filterStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 8
+        $0.alignment = .fill
+        $0.distribution = .fillProportionally
     }
 
     private let searchTextField = UITextField().then {
@@ -45,6 +50,8 @@ final class SearchView: BaseViewController, View {
         $0.text = "검색 중"
         $0.isHidden = true
     }
+
+    private var filterButtons: [PlantFilterKind: UIButton] = [:]
     
     // 테스트 용으로 생성될 떄 SearchReactor()해서 그냥 생성 가능하게
     // self.reactor = reactor 하는 순간 bind 메서드 호출
@@ -60,6 +67,7 @@ final class SearchView: BaseViewController, View {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
+        configureFilterButtons()
         configureLayout()
     }
     
@@ -105,14 +113,15 @@ final class SearchView: BaseViewController, View {
         reactor.state
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] state in
-                self?.updateLightFilterMenu(state: state, reactor: reactor)
+                self?.updateFilterMenus(state: state, reactor: reactor)
             })
             .disposed(by: disposeBag)
     }
 
     private func configureLayout() {
         view.addSubview(searchTypeControl)
-        view.addSubview(lightFilterButton)
+        view.addSubview(filterScrollView)
+        filterScrollView.addSubview(filterStackView)
         view.addSubview(searchTextField)
         view.addSubview(loadingLabel)
         view.addSubview(resultLabel)
@@ -122,13 +131,19 @@ final class SearchView: BaseViewController, View {
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
 
-        lightFilterButton.snp.makeConstraints {
+        filterScrollView.snp.makeConstraints {
             $0.top.equalTo(searchTypeControl.snp.bottom).offset(16)
-            $0.leading.equalTo(searchTypeControl)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(40)
+        }
+
+        filterStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20))
+            $0.height.equalToSuperview()
         }
 
         searchTextField.snp.makeConstraints {
-            $0.top.equalTo(lightFilterButton.snp.bottom).offset(16)
+            $0.top.equalTo(filterScrollView.snp.bottom).offset(16)
             $0.horizontalEdges.equalTo(searchTypeControl)
             $0.height.equalTo(50)
         }
@@ -144,29 +159,50 @@ final class SearchView: BaseViewController, View {
         }
     }
 
-    private func updateLightFilterMenu(state: SearchReactor.State, reactor: SearchReactor) {
-        let options = state.filterOptions[.light] ?? []
-        let selectedOption = state.filterState.option(for: .light)
+    private func configureFilterButtons() {
+        PlantFilterKind.allCases.forEach { kind in
+            var configuration = UIButton.Configuration.filled()
+            configuration.cornerStyle = .capsule
+            configuration.baseBackgroundColor = .secondarySystemBackground
+            configuration.baseForegroundColor = .label
+            configuration.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)
+            configuration.title = kind.title
 
-        var configuration = lightFilterButton.configuration ?? .filled()
-        configuration.title = selectedOption?.name ?? "광도요구"
-        configuration.baseBackgroundColor = selectedOption == nil ? .secondarySystemBackground : .systemGreen
-        configuration.baseForegroundColor = selectedOption == nil ? .label : .white
-        lightFilterButton.configuration = configuration
-        
-        // 옵션 하나 선택시 액션을 보냄(선택됨을 알림)
-        let actions = options.map { option in
-            UIAction(title: option.name) { _ in
-                reactor.action.onNext(.updateFilter(.light, option))
+            let button = UIButton(configuration: configuration)
+            button.showsMenuAsPrimaryAction = true
+            filterButtons[kind] = button
+            filterStackView.addArrangedSubview(button)
+        }
+    }
+    
+    // 버튼 상태 업데이트
+    private func updateFilterMenus(state: SearchReactor.State, reactor: SearchReactor) {
+        for kind in PlantFilterKind.allCases {
+            guard let button = filterButtons[kind] else { continue }
+
+            let options = state.filterOptions[kind] ?? []
+            let selectedOption = state.filterState.option(for: kind)
+
+            var configuration = button.configuration ?? .filled()
+            configuration.title = selectedOption?.name ?? kind.title
+            configuration.baseBackgroundColor = selectedOption == nil ? .secondarySystemBackground : .systemGreen
+            configuration.baseForegroundColor = selectedOption == nil ? .label : .white
+            button.configuration = configuration
+            
+            // 옵션 하나 선택시 액션을 보냄(선택됨을 알림)
+            let actions = options.map { option in
+                UIAction(title: option.name) { _ in
+                    reactor.action.onNext(.updateFilter(kind, option))
+                }
             }
-        }
-        
-        // 전체를 누르면 다 nil
-        let clearAction = UIAction(title: "전체") { _ in
-            reactor.action.onNext(.updateFilter(.light, nil))
-        }
+            
+            // 전체를 누르면 다 nil
+            let clearAction = UIAction(title: "전체") { _ in
+                reactor.action.onNext(.updateFilter(kind, nil))
+            }
 
-        lightFilterButton.menu = UIMenu(children: [clearAction] + actions)
+            button.menu = UIMenu(children: [clearAction] + actions)
+        }
     }
 }
 

--- a/LeafLog/LeafLog/View/SearchView/SearchView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchView.swift
@@ -17,6 +17,14 @@ final class SearchView: BaseViewController, View {
         $0.selectedSegmentIndex = 0
     }
 
+    private let lightFilterButton = UIButton(configuration: .filled()).then {
+        $0.configuration?.cornerStyle = .capsule
+        $0.configuration?.baseBackgroundColor = .secondarySystemBackground
+        $0.configuration?.baseForegroundColor = .label
+        $0.configuration?.title = "광도요구"
+        $0.showsMenuAsPrimaryAction = true
+    }
+
     private let searchTextField = UITextField().then {
         $0.borderStyle = .roundedRect
         $0.placeholder = "검색어를 입력해 주세요"
@@ -57,6 +65,10 @@ final class SearchView: BaseViewController, View {
     
     // 입출력 연결
     func bind(reactor: SearchReactor) {
+        Observable.just(SearchReactor.Action.viewDidLoad)
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
         searchTypeControl.rx.selectedSegmentIndex
             .compactMap { PlantSearchType.allCases[safe: $0] }
             .map(SearchReactor.Action.updateSearchType)
@@ -88,10 +100,19 @@ final class SearchView: BaseViewController, View {
             .map { !$0 }
             .bind(to: loadingLabel.rx.isHidden)
             .disposed(by: disposeBag)
+        
+        // 필터 메뉴 선택 바꿔줌
+        reactor.state
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] state in
+                self?.updateLightFilterMenu(state: state, reactor: reactor)
+            })
+            .disposed(by: disposeBag)
     }
 
     private func configureLayout() {
         view.addSubview(searchTypeControl)
+        view.addSubview(lightFilterButton)
         view.addSubview(searchTextField)
         view.addSubview(loadingLabel)
         view.addSubview(resultLabel)
@@ -101,8 +122,13 @@ final class SearchView: BaseViewController, View {
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
 
-        searchTextField.snp.makeConstraints {
+        lightFilterButton.snp.makeConstraints {
             $0.top.equalTo(searchTypeControl.snp.bottom).offset(16)
+            $0.leading.equalTo(searchTypeControl)
+        }
+
+        searchTextField.snp.makeConstraints {
+            $0.top.equalTo(lightFilterButton.snp.bottom).offset(16)
             $0.horizontalEdges.equalTo(searchTypeControl)
             $0.height.equalTo(50)
         }
@@ -116,6 +142,31 @@ final class SearchView: BaseViewController, View {
             $0.top.equalTo(loadingLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalTo(searchTextField)
         }
+    }
+
+    private func updateLightFilterMenu(state: SearchReactor.State, reactor: SearchReactor) {
+        let options = state.filterOptions[.light] ?? []
+        let selectedOption = state.filterState.option(for: .light)
+
+        var configuration = lightFilterButton.configuration ?? .filled()
+        configuration.title = selectedOption?.name ?? "광도요구"
+        configuration.baseBackgroundColor = selectedOption == nil ? .secondarySystemBackground : .systemGreen
+        configuration.baseForegroundColor = selectedOption == nil ? .label : .white
+        lightFilterButton.configuration = configuration
+        
+        // 옵션 하나 선택시 액션을 보냄(선택됨을 알림)
+        let actions = options.map { option in
+            UIAction(title: option.name) { _ in
+                reactor.action.onNext(.updateFilter(.light, option))
+            }
+        }
+        
+        // 전체를 누르면 다 nil
+        let clearAction = UIAction(title: "전체") { _ in
+            reactor.action.onNext(.updateFilter(.light, nil))
+        }
+
+        lightFilterButton.menu = UIMenu(children: [clearAction] + actions)
     }
 }
 

--- a/LeafLog/LeafLog/View/SearchView/SearchView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchView.swift
@@ -13,6 +13,10 @@ import UIKit
 import Then
 
 final class SearchView: BaseViewController, View {
+    private let searchTypeControl = UISegmentedControl(items: PlantSearchType.allCases.map(\.title)).then {
+        $0.selectedSegmentIndex = 0
+    }
+
     private let searchTextField = UITextField().then {
         $0.borderStyle = .roundedRect
         $0.placeholder = "검색어를 입력해 주세요"
@@ -53,6 +57,12 @@ final class SearchView: BaseViewController, View {
     
     // 입출력 연결
     func bind(reactor: SearchReactor) {
+        searchTypeControl.rx.selectedSegmentIndex
+            .compactMap { PlantSearchType.allCases[safe: $0] }
+            .map(SearchReactor.Action.updateSearchType)
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
         // 텍스트 필드에서 흐르는거 계속 받음
         searchTextField.rx.text.orEmpty
             .debounce(.milliseconds(400), scheduler: MainScheduler.instance)
@@ -81,14 +91,20 @@ final class SearchView: BaseViewController, View {
     }
 
     private func configureLayout() {
+        view.addSubview(searchTypeControl)
         view.addSubview(searchTextField)
         view.addSubview(loadingLabel)
         view.addSubview(resultLabel)
 
-        searchTextField.snp.makeConstraints {
+        searchTypeControl.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(24)
             $0.horizontalEdges.equalToSuperview().inset(20)
-            $0.height.equalTo(44)
+        }
+
+        searchTextField.snp.makeConstraints {
+            $0.top.equalTo(searchTypeControl.snp.bottom).offset(16)
+            $0.horizontalEdges.equalTo(searchTypeControl)
+            $0.height.equalTo(50)
         }
 
         loadingLabel.snp.makeConstraints {
@@ -100,5 +116,15 @@ final class SearchView: BaseViewController, View {
             $0.top.equalTo(loadingLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalTo(searchTextField)
         }
+    }
+}
+
+// 안전하게 배열 접근할 수 있도록 확장(인덱스 벗어나서 접근해도 크래시 나지 않도록)
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        // 범위 벗어나면 nil
+        guard indices.contains(index) else { return nil }
+        // 해당인덱스가 있을떄만 접근
+        return self[index]
     }
 }

--- a/LeafLog/LeafLog/View/SearchView/SearchView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchView.swift
@@ -1,0 +1,104 @@
+//
+//  SearchView.swift
+//  LeafLog
+//
+//  Created by Yeseul Jang on 4/8/26.
+//
+
+import ReactorKit
+import RxCocoa
+import RxSwift
+import SnapKit
+import UIKit
+import Then
+
+final class SearchView: BaseViewController, View {
+    private let searchTextField = UITextField().then {
+        $0.borderStyle = .roundedRect
+        $0.placeholder = "검색어를 입력해 주세요"
+        $0.clearButtonMode = .whileEditing
+        $0.autocapitalizationType = .none
+    }
+
+    private let resultLabel = UILabel().then {
+        $0.numberOfLines = 0
+        $0.font = .systemFont(ofSize: 16)
+        $0.textColor = .label
+        $0.text = "검색어입력"
+    }
+
+    private let loadingLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 16)
+        $0.textColor = .secondaryLabel
+        $0.text = "검색 중"
+        $0.isHidden = true
+    }
+    
+    // 테스트 용으로 생성될 떄 SearchReactor()해서 그냥 생성 가능하게
+    // self.reactor = reactor 하는 순간 bind 메서드 호출
+    init(reactor: SearchReactor = SearchReactor()) {
+        super.init(nibName: nil, bundle: nil)
+        self.reactor = reactor
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        configureLayout()
+    }
+    
+    // 입출력 연결
+    func bind(reactor: SearchReactor) {
+        // 텍스트 필드에서 흐르는거 계속 받음
+        searchTextField.rx.text.orEmpty
+            .debounce(.milliseconds(400), scheduler: MainScheduler.instance)
+        // 이전값이랑 같으면 무시
+            .distinctUntilChanged()
+        // 입력 문자열을 Reactor의 액션으로 변환
+            .map(SearchReactor.Action.updateQuery)
+        // Reactor로 전달
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        // 상태를 보고 결과 라벨을 바인딩
+        reactor.state
+            .map(\.resultText)
+            .distinctUntilChanged()
+            .bind(to: resultLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        // 로딩중도 바꿔줌
+        reactor.state
+            .map(\.isLoading)
+            .distinctUntilChanged()
+            .map { !$0 }
+            .bind(to: loadingLabel.rx.isHidden)
+            .disposed(by: disposeBag)
+    }
+
+    private func configureLayout() {
+        view.addSubview(searchTextField)
+        view.addSubview(loadingLabel)
+        view.addSubview(resultLabel)
+
+        searchTextField.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(24)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(44)
+        }
+
+        loadingLabel.snp.makeConstraints {
+            $0.top.equalTo(searchTextField.snp.bottom).offset(12)
+            $0.horizontalEdges.equalTo(searchTextField)
+        }
+
+        resultLabel.snp.makeConstraints {
+            $0.top.equalTo(loadingLabel.snp.bottom).offset(16)
+            $0.horizontalEdges.equalTo(searchTextField)
+        }
+    }
+}

--- a/LeafLog/LeafLog/View/SearchView/SearchView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchView.swift
@@ -15,10 +15,6 @@ import Then
 
 // TODO: 오류 처리
 final class SearchView: BaseViewController, View {
-    private let searchTypeControl = UISegmentedControl(items: PlantSearchType.allCases.map(\.title)).then {
-        $0.selectedSegmentIndex = 0
-    }
-
     private let filterScrollView = UIScrollView().then {
         $0.showsHorizontalScrollIndicator = false
     }
@@ -77,12 +73,6 @@ final class SearchView: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
-        searchTypeControl.rx.selectedSegmentIndex
-            .compactMap { PlantSearchType.allCases[safe: $0] }
-            .map(SearchReactor.Action.updateSearchType)
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-
         // 텍스트 필드에서 흐르는거 계속 받음
         searchTextField.rx.text.orEmpty
             .debounce(.milliseconds(400), scheduler: MainScheduler.instance)
@@ -119,20 +109,14 @@ final class SearchView: BaseViewController, View {
     }
 
     private func configureLayout() {
-        view.addSubview(searchTypeControl)
         view.addSubview(filterScrollView)
         filterScrollView.addSubview(filterStackView)
         view.addSubview(searchTextField)
         view.addSubview(loadingLabel)
         view.addSubview(resultLabel)
 
-        searchTypeControl.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(24)
-            $0.horizontalEdges.equalToSuperview().inset(20)
-        }
-
         filterScrollView.snp.makeConstraints {
-            $0.top.equalTo(searchTypeControl.snp.bottom).offset(16)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(24)
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(40)
         }
@@ -144,7 +128,7 @@ final class SearchView: BaseViewController, View {
 
         searchTextField.snp.makeConstraints {
             $0.top.equalTo(filterScrollView.snp.bottom).offset(16)
-            $0.horizontalEdges.equalTo(searchTypeControl)
+            $0.horizontalEdges.equalToSuperview().inset(20)
             $0.height.equalTo(50)
         }
 
@@ -160,7 +144,7 @@ final class SearchView: BaseViewController, View {
     }
 
     private func configureFilterButtons() {
-        PlantFilterKind.allCases.forEach { kind in
+        PlantFilterKind.allCases.filter { $0 != .searchType }.forEach { kind in // 검색 타입 제외 
             var configuration = UIButton.Configuration.filled()
             configuration.cornerStyle = .capsule
             configuration.baseBackgroundColor = .secondarySystemBackground
@@ -177,13 +161,13 @@ final class SearchView: BaseViewController, View {
     
     // 버튼 상태 업데이트
     private func updateFilterMenus(state: SearchReactor.State, reactor: SearchReactor) {
-        for kind in PlantFilterKind.allCases {
+        for kind in PlantFilterKind.allCases where kind != .searchType { // 검색 타입 제외
             guard let button = filterButtons[kind] else { continue }
 
             let options = state.filterOptions[kind] ?? []
             let selectedOption = state.filterState.option(for: kind)
-
             var configuration = button.configuration ?? .filled()
+
             configuration.title = selectedOption?.name ?? kind.title
             configuration.baseBackgroundColor = selectedOption == nil ? .secondarySystemBackground : .systemGreen
             configuration.baseForegroundColor = selectedOption == nil ? .label : .white
@@ -203,15 +187,5 @@ final class SearchView: BaseViewController, View {
 
             button.menu = UIMenu(children: [clearAction] + actions)
         }
-    }
-}
-
-// 안전하게 배열 접근할 수 있도록 확장(인덱스 벗어나서 접근해도 크래시 나지 않도록)
-private extension Array {
-    subscript(safe index: Int) -> Element? {
-        // 범위 벗어나면 nil
-        guard indices.contains(index) else { return nil }
-        // 해당인덱스가 있을떄만 접근
-        return self[index]
     }
 }

--- a/LeafLog/LeafLog/ViewModel/SearchReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/SearchReactor.swift
@@ -15,16 +15,19 @@ final class SearchReactor: Reactor {
     // 사용자가 한 행동
     enum Action {
         case updateQuery(String) // 검색어 생김
+        case updateSearchType(PlantSearchType) // 식물 이름 어떤식으로 검색하는지
     }
     
     // 상태를 어떻게 바꿀지에 대한 변화
     enum Mutation {
         case setLoading(Bool) // 검색 전후
+        case setSearchType(PlantSearchType) // (영명, 학명, 식물명)
         case setResultText(String) // 결과가 나올때
     }
     
     // 화면이 어떤 상태인지 표현(처음 상태)
     struct State {
+        var searchType: PlantSearchType = .name
         var isLoading: Bool = false
         var resultText: String = "검색어를 입력해 주세요."
     }
@@ -53,9 +56,12 @@ final class SearchReactor: Reactor {
             // 로딩 시작 - 네트워크 검색 - 로딩 종료
             return .concat([
                 .just(.setLoading(true)),
-                search(query: query),
+                search(query: query, searchType: currentState.searchType),
                 .just(.setLoading(false))
             ])
+
+        case .updateSearchType(let searchType):
+            return .just(.setSearchType(searchType))
         }
     }
     
@@ -67,6 +73,8 @@ final class SearchReactor: Reactor {
         switch mutation {
         case .setLoading(let isLoading):
             newState.isLoading = isLoading
+        case .setSearchType(let searchType):
+            newState.searchType = searchType
         case .setResultText(let resultText):
             newState.resultText = resultText
         }
@@ -75,12 +83,13 @@ final class SearchReactor: Reactor {
     }
     
     
-    private func search(query: String) -> Observable<Mutation> {
+    private func search(query: String, searchType: PlantSearchType) -> Observable<Mutation> {
         Observable.create { [networkManager] observer in
             let task = Task {
                 do {
                     let plants = try await networkManager.fetchPlantList(
                         keyword: query,
+                        searchType: searchType,
                         pageNo: 1,
                         numOfRows: 10
                     )
@@ -93,6 +102,7 @@ final class SearchReactor: Reactor {
                         // 검색 결과가 있으면 앞의 세개만 보여줌
                         let names = plants.prefix(10).map { $0.name }.joined(separator: "\n")
                         message = """
+                        검색 기준: \(searchType.title)
                         검색어: \(query)
                         결과 수: \(plants.count)
 

--- a/LeafLog/LeafLog/ViewModel/SearchReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/SearchReactor.swift
@@ -14,20 +14,28 @@ final class SearchReactor: Reactor {
     
     // 사용자가 한 행동
     enum Action {
+        case viewDidLoad
         case updateQuery(String) // 검색어 생김
         case updateSearchType(PlantSearchType) // 식물 이름 어떤식으로 검색하는지
+        case updateFilter(PlantFilterKind, PlantFilterOption?) // 필터 바꿈
     }
     
     // 상태를 어떻게 바꿀지에 대한 변화
     enum Mutation {
         case setLoading(Bool) // 검색 전후
+        case setQuery(String) // 검색어 저장
         case setSearchType(PlantSearchType) // (영명, 학명, 식물명)
+        case setFilterOptions([PlantFilterKind: [PlantFilterOption]]) // 옵션 전체
+        case setFilter(PlantFilterKind, PlantFilterOption?) // 선택한 옵션
         case setResultText(String) // 결과가 나올때
     }
     
     // 화면이 어떤 상태인지 표현(처음 상태)
     struct State {
-        var searchType: PlantSearchType = .name
+        var query: String = ""
+        var searchType: PlantSearchType = .plantName // 어떤걸 기준으로 검색할지
+        var filterOptions: [PlantFilterKind: [PlantFilterOption]] = [:]
+        var filterState = PlantFilterState()
         var isLoading: Bool = false
         var resultText: String = "검색어를 입력해 주세요."
     }
@@ -41,6 +49,13 @@ final class SearchReactor: Reactor {
     // Action을 받아서 어떤 Mutation을 만들지 결정
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .viewDidLoad:
+            return .concat([
+                .just(.setLoading(true)),
+                loadFilterOptions(), // 서버에서 필터 목록가져오기
+                .just(.setLoading(false))
+            ])
+
             // 사용자가 텍스트 입력시 실행
         case .updateQuery(let rawQuery):
             let query = cleanQuery(rawQuery)
@@ -55,13 +70,60 @@ final class SearchReactor: Reactor {
             
             // 로딩 시작 - 네트워크 검색 - 로딩 종료
             return .concat([
+                .just(.setQuery(query)),
                 .just(.setLoading(true)),
-                search(query: query, searchType: currentState.searchType),
+                search(
+                    query: query,
+                    searchType: currentState.searchType,
+                    filterState: currentState.filterState
+                ),
                 .just(.setLoading(false))
             ])
-
+            
+            
+            // 검색타입 바꿀때
         case .updateSearchType(let searchType):
-            return .just(.setSearchType(searchType))
+            let currentQuery = currentState.query
+            
+            // 검색어 없으면 그냥 바꾸기만
+            guard !currentQuery.isEmpty else {
+                return .just(.setSearchType(searchType))
+            }
+            
+            // 검색어 있으면 검색해줌
+            return .concat([
+                .just(.setSearchType(searchType)),
+                .just(.setLoading(true)),
+                search(
+                    query: currentQuery,
+                    searchType: searchType,
+                    filterState: currentState.filterState
+                ),
+                .just(.setLoading(false))
+            ])
+            
+            
+            // 필터 업데이트 할 때
+        case let .updateFilter(kind, option):
+            let nextFilterState = currentState.filterState.applyOption(option, for: kind)
+            let currentQuery = currentState.query
+            
+            // 검색어 없으면 그냥 필터 바꿈
+            guard !currentQuery.isEmpty else {
+                return .just(.setFilter(kind, option))
+            }
+            
+            // 필터 적용해서 다시 검색
+            return .concat([
+                .just(.setFilter(kind, option)),
+                .just(.setLoading(true)),
+                search(
+                    query: currentQuery,
+                    searchType: currentState.searchType,
+                    filterState: nextFilterState
+                ),
+                .just(.setLoading(false))
+            ])
         }
     }
     
@@ -73,8 +135,14 @@ final class SearchReactor: Reactor {
         switch mutation {
         case .setLoading(let isLoading):
             newState.isLoading = isLoading
-        case .setSearchType(let searchType):
+        case .setQuery(let query): // 검색어
+            newState.query = query
+        case .setSearchType(let searchType): // 검색 타입(결과)
             newState.searchType = searchType
+        case .setFilterOptions(let filterOptions):
+            newState.filterOptions = filterOptions
+        case let .setFilter(kind, option):
+            newState.filterState = newState.filterState.applyOption(option, for: kind)
         case .setResultText(let resultText):
             newState.resultText = resultText
         }
@@ -82,14 +150,39 @@ final class SearchReactor: Reactor {
         return newState
     }
     
+    // 서버에서 필터 목록을 가져와서 Mutation으로 바꿔주는 역할
+    private func loadFilterOptions() -> Observable<Mutation> {
+        Observable.create { [networkManager] observer in
+            let task = Task {
+                do {
+                    let options = try await networkManager.fetchAllFilterOptions()
+                    observer.onNext(.setFilterOptions(options))
+                    observer.onCompleted()
+                } catch {
+                    observer.onNext(.setResultText("필터 옵션 로드 실패: \(error.localizedDescription)"))
+                    observer.onCompleted()
+                }
+            }
+
+            return Disposables.create {
+                task.cancel()
+            }
+        }
+    }
     
-    private func search(query: String, searchType: PlantSearchType) -> Observable<Mutation> {
+    
+    private func search(
+        query: String,
+        searchType: PlantSearchType,
+        filterState: PlantFilterState
+    ) -> Observable<Mutation> {
         Observable.create { [networkManager] observer in
             let task = Task {
                 do {
                     let plants = try await networkManager.fetchPlantList(
                         keyword: query,
                         searchType: searchType,
+                        filterState: filterState,
                         pageNo: 1,
                         numOfRows: 10
                     )
@@ -101,9 +194,11 @@ final class SearchReactor: Reactor {
                     } else {
                         // 검색 결과가 있으면 앞의 세개만 보여줌
                         let names = plants.prefix(10).map { $0.name }.joined(separator: "\n")
+                        let lightFilterText = filterState.option(for: .light)?.name ?? "없음"
                         message = """
                         검색 기준: \(searchType.title)
                         검색어: \(query)
+                        광도요구: \(lightFilterText)
                         결과 수: \(plants.count)
 
                         \(names)

--- a/LeafLog/LeafLog/ViewModel/SearchReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/SearchReactor.swift
@@ -1,0 +1,125 @@
+//
+//  SearchReactor.swift
+//  LeafLog
+//
+//  Created by Yeseul Jang on 4/8/26.
+//
+
+import Dependencies
+import Foundation
+import ReactorKit
+import RxSwift
+
+final class SearchReactor: Reactor {
+    
+    // 사용자가 한 행동
+    enum Action {
+        case updateQuery(String) // 검색어 생김
+    }
+    
+    // 상태를 어떻게 바꿀지에 대한 변화
+    enum Mutation {
+        case setLoading(Bool) // 검색 전후
+        case setResultText(String) // 결과가 나올때
+    }
+    
+    // 화면이 어떤 상태인지 표현(처음 상태)
+    struct State {
+        var isLoading: Bool = false
+        var resultText: String = "검색어를 입력해 주세요."
+    }
+
+    @Dependency(\.networkManager) private var networkManager
+    
+    // 최초 상태
+    let initialState = State()
+    
+    // Action -> Mutation -> State
+    // Action을 받아서 어떤 Mutation을 만들지 결정
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+            // 사용자가 텍스트 입력시 실행
+        case .updateQuery(let rawQuery):
+            let query = cleanQuery(rawQuery)
+            
+            // 비었을 때
+            guard !query.isEmpty else {
+                return .concat([
+                    .just(.setLoading(false)),
+                    .just(.setResultText("검색어를 입력해 주세요."))
+                ])
+            }
+            
+            // 로딩 시작 - 네트워크 검색 - 로딩 종료
+            return .concat([
+                .just(.setLoading(true)),
+                search(query: query),
+                .just(.setLoading(false))
+            ])
+        }
+    }
+    
+    // Mutation을 받아서 새로운 State를 생성(상태 변경 함수)
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        
+        // 검색 시작 전엔 로딩 켜기, 검색 작업이 끝나면 로딩 끄기
+        switch mutation {
+        case .setLoading(let isLoading):
+            newState.isLoading = isLoading
+        case .setResultText(let resultText):
+            newState.resultText = resultText
+        }
+
+        return newState
+    }
+    
+    
+    private func search(query: String) -> Observable<Mutation> {
+        Observable.create { [networkManager] observer in
+            let task = Task {
+                do {
+                    let plants = try await networkManager.fetchPlantList(
+                        keyword: query,
+                        pageNo: 1,
+                        numOfRows: 10
+                    )
+                    
+                    // 결과 처리
+                    let message: String
+                    if plants.isEmpty {
+                        message = "'\(query)' 검색 결과가 없습니다."
+                    } else {
+                        // 검색 결과가 있으면 앞의 세개만 보여줌
+                        let names = plants.prefix(10).map { $0.name }.joined(separator: "\n")
+                        message = """
+                        검색어: \(query)
+                        결과 수: \(plants.count)
+
+                        \(names)
+                        """
+                    }
+                    
+                    // 검색이 끝나면 결과 텍스트를 바꾸는 Mutation을 보냄
+                    observer.onNext(.setResultText(message))
+                    observer.onCompleted()
+                    // 에러 처리
+                } catch {
+                    observer.onNext(.setResultText("검색 실패: \(error.localizedDescription)"))
+                    observer.onCompleted()
+                }
+            }
+            
+            // 구독이 해제되면 실행중인 Task 취소
+            return Disposables.create {
+                task.cancel()
+            }
+        }
+    }
+
+    private func cleanQuery(_ query: String) -> String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+}

--- a/LeafLog/LeafLog/ViewModel/SearchReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/SearchReactor.swift
@@ -194,11 +194,15 @@ final class SearchReactor: Reactor {
                     } else {
                         // 검색 결과가 있으면 앞의 세개만 보여줌
                         let names = plants.prefix(10).map { $0.name }.joined(separator: "\n")
-                        let lightFilterText = filterState.option(for: .light)?.name ?? "없음"
+                        let selectedFilters = filterState.selectedOptions
+                            .sorted { $0.key.title < $1.key.title }
+                            .map { "\($0.key.title): \($0.value.name)" }
+                            .joined(separator: ", ")
+                        let filterDescription = selectedFilters.isEmpty ? "없음" : selectedFilters
                         message = """
                         검색 기준: \(searchType.title)
                         검색어: \(query)
-                        광도요구: \(lightFilterText)
+                        적용 필터: \(filterDescription)
                         결과 수: \(plants.count)
 
                         \(names)


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #16

## 🛠 작업 내용 (What I did)
- 실내정원 검색 화면에 검색어 기반 조회 로직을 붙이고, 식물명/학명/영명 검색 타입을 PlantSearchType으로 분리
- 필터 코드 목록 API를 연동해 광도요구, 물주기, 꽃색, 잎색 등 필터 항목을 서버 옵션 기반으로 조회/선택할 수 있게 구성

## 💻 구현 상세 (Implementation Details)
- NetworkManager에 필터 코드 목록 조회와 gardenList 필터 파라미터 조합 로직을 추가
- SearchReactor는 PlantFilterState로 선택된 필터들을 공통 관리
- SearchView는 상단 가로 스크롤 필터 버튼 UI를 추가해 각 필터의 서버 옵션을 메뉴로 노출하고, 선택 시 즉시 재검색

## 📸 스크린샷 (Screenshots)
|기능 실행 전|
|:---:|
|![11111](https://github.com/user-attachments/assets/0c06ef17-d61d-4dfd-bfef-4ec297a633fc)|


## 🧐 리뷰 포인트 (Review Points)
- 검색 화면에서는 현재 검색 기준을 plantName으로 고정했습니다.
- 추후 다른 화면에서 searchType 기능을 재사용할 수 있도록 내부 로직은 유지해서 나중에 기능연결이 가능하도록 했습니다.
- UI는 검색 기능 확인을 위해 구성한 것으로 나중에 수정 예정입니다. 

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
