### PR TITLE
[Refactor] Splash~Login~Main 화면 흐름 Flow 리팩토링

### DIFF
--- a/LeafLog/LeafLog/App/Flows/AppFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/AppFlow.swift
@@ -46,15 +46,7 @@ final class AppFlow: Flow {
         
         switch step {
         case .splash:
-            let splashViewController = SplashViewController()
-            window.rootViewController = splashViewController
-            
-            return .one(
-                flowContributor: .contribute(
-                    withNextPresentable: splashViewController,
-                    withNextStepper: splashViewController
-                )
-            )
+            return navigateToSplash()
             
         case .loginRequired:
             return navigateToLogin()
@@ -69,6 +61,18 @@ final class AppFlow: Flow {
 }
 
 extension AppFlow {
+    private func navigateToSplash() -> FlowContributors {
+        let splashViewController = SplashViewController()
+        window.rootViewController = splashViewController
+        
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: splashViewController,
+                withNextStepper: splashViewController
+            )
+        )
+    }
+    
     private func navigateToLogin() -> FlowContributors {
         let loginFlow = LoginFlow(window: window)
         return .one(flowContributor: .contribute(

--- a/LeafLog/LeafLog/App/Flows/AppFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/AppFlow.swift
@@ -35,11 +35,10 @@ final class AppFlow: Flow {
     let tabBarController = UITabBarController()
     let loginNavigationController = UINavigationController()
     
-    var root: any RxFlow.Presentable { loginNavigationController }
+    var root: any RxFlow.Presentable { window }
     
     init(windowScene: UIWindowScene) {
         self.window = UIWindow(windowScene: windowScene)
-        self.window.rootViewController = loginNavigationController
         self.window.makeKeyAndVisible()
     }
     
@@ -51,30 +50,40 @@ final class AppFlow: Flow {
         
         switch step {
         case .splash:
-            let viewController = SplashViewController()
-            
-            loginNavigationController.setViewControllers([viewController], animated: false)
-            window.rootViewController = loginNavigationController
+            let splashViewController = SplashViewController()
+            window.rootViewController = splashViewController
             
             return .one(
                 flowContributor: .contribute(
-                    withNextPresentable: viewController,
-                    withNextStepper: viewController
+                    withNextPresentable: splashViewController,
+                    withNextStepper: splashViewController
                 )
             )
             
-        case .login:
+        case .loginRequired:
+            let loginFlow = LoginFlow(window: self.window)
             let viewController = LoginViewController()
             viewController.reactor = LoginReactor()
 
-            loginNavigationController.setViewControllers([viewController], animated: false)
-            window.rootViewController = loginNavigationController // 다시 로그인 화면으로 돌아왔을때도 화면 교체
+//            loginNavigationController.setViewControllers([viewController], animated: false)
+//            window.rootViewController = loginNavigationController // 다시 로그인 화면으로 돌아왔을때도 화면 교체
 
+//            return .one(
+//                flowContributor: .contribute(
+//                    withNextPresentable: viewController,
+//                    withNextStepper: viewController // 다음 Step 신호는 loginVC가 쏠거다
+//                )
+//            )
+            Flows.use(loginFlow, when: .created) { login in
+                guard let nav = login as? UINavigationController else { return }
+                
+                nav.setViewControllers([viewController], animated: true)
+            }
+            
             return .one(
                 flowContributor: .contribute(
-                    withNextPresentable: viewController,
-                    withNextStepper: viewController // 다음 Step 신호는 loginVC가 쏠거다
-                )
+                    withNextPresentable: loginFlow,
+                    withNextStepper: viewController)
             )
 
         case .main:
@@ -131,6 +140,14 @@ final class AppFlow: Flow {
             
         default:
             return .none
+        }
+    }
+    
+    func navigate(from navigationController: UIViewController, to viewController: UIViewController, animated: Bool) {
+        if let navigationController = navigationController as? UINavigationController {
+            navigationController.pushViewController(viewController, animated: true)
+        } else {
+            
         }
     }
     

--- a/LeafLog/LeafLog/App/Flows/AppFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/AppFlow.swift
@@ -119,42 +119,11 @@ extension AppFlow {
     }
     
     private func navigateToMain() -> FlowContributors {
-        let tabBarController = UITabBarController()
-        
-        let plantTabFlow = PlantTabFlow()
-        let calendarTabFlow = CalendarTabFlow()
-        let myInfoTabFlow = MyInfoTabFlow()
-
-        window.rootViewController = tabBarController
-        
-        // Flow를 준비 - 클로저는 Flow가 배치될 준비가 되었을 때(Flow의 첫 번째 화면이 선택되었을 때) 실행될 동작
-        // Flow.use는 내부에서 Single 이벤트를 drive로 구독을 소비하므로 소비 완료 후 자동으로 구독이 해제되어 메모리 누수가 발생하지 않음
-        Flows.use(plantTabFlow, calendarTabFlow, myInfoTabFlow, when: .created) { plant, calendar, my in
-            plant.tabBarItem = UITabBarItem(
-                title: "식물",
-                image: UIImage(systemName: "leaf"),
-                tag: 0
+        let mainFlow = MainFlow(window: window)
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: mainFlow,
+                withNextStepper: OneStepper(withSingleStep: AppStep.main))
             )
-            
-            calendar.tabBarItem = UITabBarItem(
-                title: "달력",
-                image: UIImage(systemName: "calendar"),
-                tag: 1
-            )
-            
-            my.tabBarItem = UITabBarItem(
-                title: "내 정보",
-                image: UIImage(systemName: "person"),
-                tag: 2
-            )
-            
-            tabBarController.setViewControllers([plant, calendar, my], animated: true)
-        }
-        
-        return .multiple(flowContributors: [
-            .contribute(withNextPresentable: plantTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.plantTab)),
-            .contribute(withNextPresentable: calendarTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.calendarTab)),
-            .contribute(withNextPresentable: myInfoTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.myInfoTab))
-        ])
     }
 }

--- a/LeafLog/LeafLog/App/Flows/AppFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/AppFlow.swift
@@ -30,11 +30,7 @@ import ReactorKit
  */
 
 final class AppFlow: Flow {
-    
     let window: UIWindow
-    let tabBarController = UITabBarController()
-    let loginNavigationController = UINavigationController()
-    
     var root: any RxFlow.Presentable { window }
     
     init(windowScene: UIWindowScene) {
@@ -66,36 +62,9 @@ final class AppFlow: Flow {
         case .main:
             return navigateToMain()
             
-        case .alert(let title, let message):
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "확인", style: .default))
-
-            let presenter: UIViewController?
-            if let selected = tabBarController.selectedViewController {
-                presenter = selected
-            } else {
-                presenter = window.rootViewController
-            }
-
-            presenter?.present(alert, animated: true)
-            return .none
-
-            
         default:
             return .none
         }
-    }
-    
-    func navigate(to viewController: UIViewController, animated: Bool) {
-        if let navigationController = tabBarController.selectedViewController as? UINavigationController {
-            navigationController.pushViewController(viewController, animated: animated)
-        } else {
-            tabBarController.selectedViewController?.present(viewController, animated: animated, completion: nil)
-        }
-    }
-    
-    private func present(_ viewController: UIViewController, animated: Bool) {
-        tabBarController.selectedViewController?.present(viewController, animated: animated, completion: nil)
     }
 }
 

--- a/LeafLog/LeafLog/App/Flows/AppFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/AppFlow.swift
@@ -101,20 +101,10 @@ final class AppFlow: Flow {
 
 extension AppFlow {
     private func navigateToLogin() -> FlowContributors {
-        let loginFlow = LoginFlow(window: self.window)
-        let viewController = LoginViewController()
-        viewController.reactor = LoginReactor()
-
-        Flows.use(loginFlow, when: .created) { login in
-            guard let nav = login as? UINavigationController else { return }
-            
-            nav.setViewControllers([viewController], animated: true)
-        }
-        
-        return .one(
-            flowContributor: .contribute(
-                withNextPresentable: loginFlow,
-                withNextStepper: viewController)
+        let loginFlow = LoginFlow(window: window)
+        return .one(flowContributor: .contribute(
+            withNextPresentable: loginFlow,
+            withNextStepper: OneStepper(withSingleStep: AppStep.loginRequired))
         )
     }
     

--- a/LeafLog/LeafLog/App/Flows/AppFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/AppFlow.swift
@@ -61,67 +61,10 @@ final class AppFlow: Flow {
             )
             
         case .loginRequired:
-            let loginFlow = LoginFlow(window: self.window)
-            let viewController = LoginViewController()
-            viewController.reactor = LoginReactor()
-
-//            loginNavigationController.setViewControllers([viewController], animated: false)
-//            window.rootViewController = loginNavigationController // 다시 로그인 화면으로 돌아왔을때도 화면 교체
-
-//            return .one(
-//                flowContributor: .contribute(
-//                    withNextPresentable: viewController,
-//                    withNextStepper: viewController // 다음 Step 신호는 loginVC가 쏠거다
-//                )
-//            )
-            Flows.use(loginFlow, when: .created) { login in
-                guard let nav = login as? UINavigationController else { return }
-                
-                nav.setViewControllers([viewController], animated: true)
-            }
-            
-            return .one(
-                flowContributor: .contribute(
-                    withNextPresentable: loginFlow,
-                    withNextStepper: viewController)
-            )
+            return navigateToLogin()
 
         case .main:
-            let plantTabFlow = PlantTabFlow()
-            let calendarTabFlow = CalendarTabFlow()
-            let myInfoTabFlow = MyInfoTabFlow()
-
-            window.rootViewController = tabBarController
-            
-            // Flow를 준비 - 클로저는 Flow가 배치될 준비가 되었을 때(Flow의 첫 번째 화면이 선택되었을 때) 실행될 동작
-            // Flow.use는 내부에서 Single 이벤트를 drive로 구독을 소비하므로 소비 완료 후 자동으로 구독이 해제되어 메모리 누수가 발생하지 않음
-            Flows.use(plantTabFlow, calendarTabFlow, myInfoTabFlow, when: .created) { plant, calendar, my in
-                plant.tabBarItem = UITabBarItem(
-                    title: "식물",
-                    image: UIImage(systemName: "leaf"),
-                    tag: 0
-                )
-                
-                calendar.tabBarItem = UITabBarItem(
-                    title: "달력",
-                    image: UIImage(systemName: "calendar"),
-                    tag: 1
-                )
-                
-                my.tabBarItem = UITabBarItem(
-                    title: "내 정보",
-                    image: UIImage(systemName: "person"),
-                    tag: 2
-                )
-                
-                self.tabBarController.setViewControllers([plant, calendar, my], animated: true)
-            }
-            
-            return .multiple(flowContributors: [
-                .contribute(withNextPresentable: plantTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.plantTab)),
-                .contribute(withNextPresentable: calendarTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.calendarTab)),
-                .contribute(withNextPresentable: myInfoTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.myInfoTab))
-            ])
+            return navigateToMain()
             
         case .alert(let title, let message):
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
@@ -143,14 +86,6 @@ final class AppFlow: Flow {
         }
     }
     
-    func navigate(from navigationController: UIViewController, to viewController: UIViewController, animated: Bool) {
-        if let navigationController = navigationController as? UINavigationController {
-            navigationController.pushViewController(viewController, animated: true)
-        } else {
-            
-        }
-    }
-    
     func navigate(to viewController: UIViewController, animated: Bool) {
         if let navigationController = tabBarController.selectedViewController as? UINavigationController {
             navigationController.pushViewController(viewController, animated: animated)
@@ -161,5 +96,65 @@ final class AppFlow: Flow {
     
     private func present(_ viewController: UIViewController, animated: Bool) {
         tabBarController.selectedViewController?.present(viewController, animated: animated, completion: nil)
+    }
+}
+
+extension AppFlow {
+    private func navigateToLogin() -> FlowContributors {
+        let loginFlow = LoginFlow(window: self.window)
+        let viewController = LoginViewController()
+        viewController.reactor = LoginReactor()
+
+        Flows.use(loginFlow, when: .created) { login in
+            guard let nav = login as? UINavigationController else { return }
+            
+            nav.setViewControllers([viewController], animated: true)
+        }
+        
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: loginFlow,
+                withNextStepper: viewController)
+        )
+    }
+    
+    private func navigateToMain() -> FlowContributors {
+        let tabBarController = UITabBarController()
+        
+        let plantTabFlow = PlantTabFlow()
+        let calendarTabFlow = CalendarTabFlow()
+        let myInfoTabFlow = MyInfoTabFlow()
+
+        window.rootViewController = tabBarController
+        
+        // Flow를 준비 - 클로저는 Flow가 배치될 준비가 되었을 때(Flow의 첫 번째 화면이 선택되었을 때) 실행될 동작
+        // Flow.use는 내부에서 Single 이벤트를 drive로 구독을 소비하므로 소비 완료 후 자동으로 구독이 해제되어 메모리 누수가 발생하지 않음
+        Flows.use(plantTabFlow, calendarTabFlow, myInfoTabFlow, when: .created) { plant, calendar, my in
+            plant.tabBarItem = UITabBarItem(
+                title: "식물",
+                image: UIImage(systemName: "leaf"),
+                tag: 0
+            )
+            
+            calendar.tabBarItem = UITabBarItem(
+                title: "달력",
+                image: UIImage(systemName: "calendar"),
+                tag: 1
+            )
+            
+            my.tabBarItem = UITabBarItem(
+                title: "내 정보",
+                image: UIImage(systemName: "person"),
+                tag: 2
+            )
+            
+            tabBarController.setViewControllers([plant, calendar, my], animated: true)
+        }
+        
+        return .multiple(flowContributors: [
+            .contribute(withNextPresentable: plantTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.plantTab)),
+            .contribute(withNextPresentable: calendarTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.calendarTab)),
+            .contribute(withNextPresentable: myInfoTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.myInfoTab))
+        ])
     }
 }

--- a/LeafLog/LeafLog/App/Flows/AppStep.swift
+++ b/LeafLog/LeafLog/App/Flows/AppStep.swift
@@ -18,7 +18,6 @@ import RxFlow
 
 enum AppStep: Step {
     // Main
-    case root
     case splash
     case loginRequired
     case main

--- a/LeafLog/LeafLog/App/Flows/AppStep.swift
+++ b/LeafLog/LeafLog/App/Flows/AppStep.swift
@@ -20,7 +20,7 @@ enum AppStep: Step {
     // Main
     case root
     case splash
-    case login
+    case loginRequired
     case main
     
     // Tab

--- a/LeafLog/LeafLog/App/Flows/CalendarTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/CalendarTabFlow.swift
@@ -9,7 +9,7 @@ import UIKit
 import RxFlow
 
 final class CalendarTabFlow: Flow {
-    let navigationController = UINavigationController()
+    private let navigationController = UINavigationController()
     
     var root: any RxFlow.Presentable { navigationController }
     

--- a/LeafLog/LeafLog/App/Flows/LoginFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/LoginFlow.swift
@@ -29,7 +29,7 @@ final class LoginFlow: Flow {
         case .loginRequired:
             return navigateToLogin()
         case .main:
-            return navigateToMain()
+            return .end(forwardToParentFlowWithStep: step)
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
         }
@@ -41,21 +41,11 @@ extension LoginFlow {
         let viewController = LoginViewController()
         viewController.reactor = LoginReactor()
 
-        navigationController.pushViewController(viewController, animated: true)
-        
+        navigationController.setViewControllers([viewController], animated: false)
         return .one(
             flowContributor: .contribute(
                 withNextPresentable: viewController,
                 withNextStepper: viewController)
         )
-    }
-    
-    private func navigateToMain() -> FlowContributors {
-        let mainFlow = MainFlow(window: window)
-        return .one(
-            flowContributor: .contribute(
-                withNextPresentable: mainFlow,
-                withNextStepper: OneStepper(withSingleStep: AppStep.main))
-            )
     }
 }

--- a/LeafLog/LeafLog/App/Flows/LoginFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/LoginFlow.swift
@@ -10,23 +10,68 @@ import RxFlow
 import ReactorKit
 
 final class LoginFlow: Flow {
+    let window: UIWindow
     let navigationController = UINavigationController()
-//    let viewController: LoginViewController
     
-    var root: RxFlow.Presentable { self.navigationController }
+    var root: any Presentable { navigationController }
     
     init(window: UIWindow) {
         window.rootViewController = navigationController
+        self.window = window
     }
     
-    func navigate(to step: any RxFlow.Step) -> RxFlow.FlowContributors {
+    func navigate(to step: any RxFlow.Step) -> FlowContributors {
         guard let step = step as? AppStep else {
             return .none
         }
         
         switch step {
+        case .main:
+            return navigateToMain()
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
         }
+    }
+}
+
+extension LoginFlow {
+    private func navigateToMain() -> FlowContributors {
+        let tabBarController = UITabBarController()
+        
+        let plantTabFlow = PlantTabFlow()
+        let calendarTabFlow = CalendarTabFlow()
+        let myInfoTabFlow = MyInfoTabFlow()
+
+        window.rootViewController = tabBarController
+        
+        // Flow를 준비 - 클로저는 Flow가 배치될 준비가 되었을 때(Flow의 첫 번째 화면이 선택되었을 때) 실행될 동작
+        // Flow.use는 내부에서 Single 이벤트를 drive로 구독을 소비하므로 소비 완료 후 자동으로 구독이 해제되어 메모리 누수가 발생하지 않음
+        Flows.use(plantTabFlow, calendarTabFlow, myInfoTabFlow, when: .created) { plant, calendar, my in
+            plant.tabBarItem = UITabBarItem(
+                title: "식물",
+                image: UIImage(systemName: "leaf"),
+                tag: 0
+            )
+            
+            calendar.tabBarItem = UITabBarItem(
+                title: "달력",
+                image: UIImage(systemName: "calendar"),
+                tag: 1
+            )
+            
+            my.tabBarItem = UITabBarItem(
+                title: "내 정보",
+                image: UIImage(systemName: "person"),
+                tag: 2
+            )
+            
+            tabBarController.setViewControllers([plant, calendar, my], animated: true)
+        }
+        
+        return .multiple(flowContributors: [
+            .contribute(withNextPresentable: plantTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.plantTab)),
+            .contribute(withNextPresentable: calendarTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.calendarTab)),
+            .contribute(withNextPresentable: myInfoTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.myInfoTab))
+        ])
     }
 }

--- a/LeafLog/LeafLog/App/Flows/LoginFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/LoginFlow.swift
@@ -26,6 +26,8 @@ final class LoginFlow: Flow {
         }
         
         switch step {
+        case .loginRequired:
+            return navigateToLogin()
         case .main:
             return navigateToMain()
         default:
@@ -35,6 +37,19 @@ final class LoginFlow: Flow {
 }
 
 extension LoginFlow {
+    private func navigateToLogin() -> FlowContributors {
+        let viewController = LoginViewController()
+        viewController.reactor = LoginReactor()
+
+        navigationController.pushViewController(viewController, animated: true)
+        
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: viewController,
+                withNextStepper: viewController)
+        )
+    }
+    
     private func navigateToMain() -> FlowContributors {
         let mainFlow = MainFlow(window: window)
         return .one(

--- a/LeafLog/LeafLog/App/Flows/LoginFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/LoginFlow.swift
@@ -1,0 +1,32 @@
+//
+//  LoginFlow.swift
+//  LeafLog
+//
+//  Created by t2025-m0143 on 4/10/26.
+//
+
+import UIKit
+import RxFlow
+import ReactorKit
+
+final class LoginFlow: Flow {
+    let navigationController = UINavigationController()
+//    let viewController: LoginViewController
+    
+    var root: RxFlow.Presentable { self.navigationController }
+    
+    init(window: UIWindow) {
+        window.rootViewController = navigationController
+    }
+    
+    func navigate(to step: any RxFlow.Step) -> RxFlow.FlowContributors {
+        guard let step = step as? AppStep else {
+            return .none
+        }
+        
+        switch step {
+        default:
+            return .one(flowContributor: .forwardToParentFlow(withStep: step))
+        }
+    }
+}

--- a/LeafLog/LeafLog/App/Flows/LoginFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/LoginFlow.swift
@@ -10,8 +10,8 @@ import RxFlow
 import ReactorKit
 
 final class LoginFlow: Flow {
-    let window: UIWindow
-    let navigationController = UINavigationController()
+    private let window: UIWindow
+    private let navigationController = UINavigationController()
     
     var root: any Presentable { navigationController }
     

--- a/LeafLog/LeafLog/App/Flows/LoginFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/LoginFlow.swift
@@ -36,42 +36,11 @@ final class LoginFlow: Flow {
 
 extension LoginFlow {
     private func navigateToMain() -> FlowContributors {
-        let tabBarController = UITabBarController()
-        
-        let plantTabFlow = PlantTabFlow()
-        let calendarTabFlow = CalendarTabFlow()
-        let myInfoTabFlow = MyInfoTabFlow()
-
-        window.rootViewController = tabBarController
-        
-        // Flow를 준비 - 클로저는 Flow가 배치될 준비가 되었을 때(Flow의 첫 번째 화면이 선택되었을 때) 실행될 동작
-        // Flow.use는 내부에서 Single 이벤트를 drive로 구독을 소비하므로 소비 완료 후 자동으로 구독이 해제되어 메모리 누수가 발생하지 않음
-        Flows.use(plantTabFlow, calendarTabFlow, myInfoTabFlow, when: .created) { plant, calendar, my in
-            plant.tabBarItem = UITabBarItem(
-                title: "식물",
-                image: UIImage(systemName: "leaf"),
-                tag: 0
+        let mainFlow = MainFlow(window: window)
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: mainFlow,
+                withNextStepper: OneStepper(withSingleStep: AppStep.main))
             )
-            
-            calendar.tabBarItem = UITabBarItem(
-                title: "달력",
-                image: UIImage(systemName: "calendar"),
-                tag: 1
-            )
-            
-            my.tabBarItem = UITabBarItem(
-                title: "내 정보",
-                image: UIImage(systemName: "person"),
-                tag: 2
-            )
-            
-            tabBarController.setViewControllers([plant, calendar, my], animated: true)
-        }
-        
-        return .multiple(flowContributors: [
-            .contribute(withNextPresentable: plantTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.plantTab)),
-            .contribute(withNextPresentable: calendarTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.calendarTab)),
-            .contribute(withNextPresentable: myInfoTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.myInfoTab))
-        ])
     }
 }

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -1,0 +1,7 @@
+//
+//  MainFlow.swift
+//  LeafLog
+//
+//  Created by t2025-m0143 on 4/10/26.
+//
+

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -11,7 +11,7 @@ import ReactorKit
 
 final class MainFlow: Flow {
     let window: UIWindow
-    let tabBarController = UITabBarController()
+    let tabBarController = MainViewController()
     
     var root: any Presentable { tabBarController }
     

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -10,8 +10,8 @@ import RxFlow
 import ReactorKit
 
 final class MainFlow: Flow {
-    let window: UIWindow
-    let tabBarController = MainViewController()
+    private let window: UIWindow
+    private let tabBarController = MainViewController()
     
     var root: any Presentable { tabBarController }
     

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -5,3 +5,73 @@
 //  Created by t2025-m0143 on 4/10/26.
 //
 
+import UIKit
+import RxFlow
+import ReactorKit
+
+final class MainFlow: Flow {
+    let window: UIWindow
+    let tabBarController = UITabBarController()
+    
+    var root: any Presentable { tabBarController }
+    
+    init(window: UIWindow) {
+        window.rootViewController = tabBarController
+        self.window = window
+    }
+    
+    func navigate(to step: any RxFlow.Step) -> FlowContributors {
+        guard let step = step as? AppStep else {
+            return .none
+        }
+        
+        switch step {
+        case .main:
+            return navigateToMain()
+        default:
+            return .one(flowContributor: .forwardToParentFlow(withStep: step))
+        }
+    }
+}
+
+extension MainFlow {
+    private func navigateToMain() -> FlowContributors {
+        let tabBarController = UITabBarController()
+        
+        let plantTabFlow = PlantTabFlow()
+        let calendarTabFlow = CalendarTabFlow()
+        let myInfoTabFlow = MyInfoTabFlow()
+
+        window.rootViewController = tabBarController
+        
+        // Flow를 준비 - 클로저는 Flow가 배치될 준비가 되었을 때(Flow의 첫 번째 화면이 선택되었을 때) 실행될 동작
+        // Flow.use는 내부에서 Single 이벤트를 drive로 구독을 소비하므로 소비 완료 후 자동으로 구독이 해제되어 메모리 누수가 발생하지 않음
+        Flows.use(plantTabFlow, calendarTabFlow, myInfoTabFlow, when: .created) { plant, calendar, my in
+            plant.tabBarItem = UITabBarItem(
+                title: "식물",
+                image: UIImage(systemName: "leaf"),
+                tag: 0
+            )
+            
+            calendar.tabBarItem = UITabBarItem(
+                title: "달력",
+                image: UIImage(systemName: "calendar"),
+                tag: 1
+            )
+            
+            my.tabBarItem = UITabBarItem(
+                title: "내 정보",
+                image: UIImage(systemName: "person"),
+                tag: 2
+            )
+            
+            tabBarController.setViewControllers([plant, calendar, my], animated: true)
+        }
+        
+        return .multiple(flowContributors: [
+            .contribute(withNextPresentable: plantTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.plantTab)),
+            .contribute(withNextPresentable: calendarTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.calendarTab)),
+            .contribute(withNextPresentable: myInfoTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.myInfoTab))
+        ])
+    }
+}

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -56,8 +56,6 @@ extension MainFlow {
         let plantTabFlow = PlantTabFlow()
         let calendarTabFlow = CalendarTabFlow()
         let myInfoTabFlow = MyInfoTabFlow()
-
-        window.rootViewController = tabBarController
         
         // Flow를 준비 - 클로저는 Flow가 배치될 준비가 되었을 때(Flow의 첫 번째 화면이 선택되었을 때) 실행될 동작
         // Flow.use는 내부에서 Single 이벤트를 drive로 구독을 소비하므로 소비 완료 후 자동으로 구독이 해제되어 메모리 누수가 발생하지 않음

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -30,11 +30,7 @@ final class MainFlow: Flow {
             return navigateToMain()
             
         case .alert(let title, let message):
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "확인", style: .default))
-            
-            present(alert, animated: true)
-            return .none
+            return presentAlert(title: title, message: message)
             
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
@@ -92,5 +88,13 @@ extension MainFlow {
             .contribute(withNextPresentable: calendarTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.calendarTab)),
             .contribute(withNextPresentable: myInfoTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.myInfoTab))
         ])
+    }
+    
+    private func presentAlert(title: String, message: String) -> FlowContributors {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        
+        present(alert, animated: true)
+        return .none
     }
 }

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -28,15 +28,34 @@ final class MainFlow: Flow {
         switch step {
         case .main:
             return navigateToMain()
+            
+        case .alert(let title, let message):
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "확인", style: .default))
+            
+            present(alert, animated: true)
+            return .none
+            
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
         }
+    }
+    
+    private func navigate(to viewController: UIViewController, animated: Bool) {
+        if let navigationController = tabBarController.selectedViewController as? UINavigationController {
+            navigationController.pushViewController(viewController, animated: animated)
+        } else {
+            tabBarController.selectedViewController?.present(viewController, animated: animated, completion: nil)
+        }
+    }
+    
+    private func present(_ viewController: UIViewController, animated: Bool) {
+        tabBarController.selectedViewController?.present(viewController, animated: animated, completion: nil)
     }
 }
 
 extension MainFlow {
     private func navigateToMain() -> FlowContributors {
-        let tabBarController = UITabBarController()
         
         let plantTabFlow = PlantTabFlow()
         let calendarTabFlow = CalendarTabFlow()
@@ -65,7 +84,7 @@ extension MainFlow {
                 tag: 2
             )
             
-            tabBarController.setViewControllers([plant, calendar, my], animated: true)
+            self.tabBarController.setViewControllers([plant, calendar, my], animated: true)
         }
         
         return .multiple(flowContributors: [

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -29,6 +29,9 @@ final class MainFlow: Flow {
         case .main:
             return navigateToMain()
             
+        case .loginRequired:
+            return .end(forwardToParentFlowWithStep: step)
+            
         case .alert(let title, let message):
             return presentAlert(title: title, message: message)
             

--- a/LeafLog/LeafLog/App/Flows/MyInfoTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MyInfoTabFlow.swift
@@ -9,7 +9,7 @@ import UIKit
 import RxFlow
 
 final class MyInfoTabFlow: Flow {
-    let navigationController = UINavigationController()
+    private let navigationController = UINavigationController()
     
     var root: any RxFlow.Presentable { navigationController }
     

--- a/LeafLog/LeafLog/App/Flows/MyInfoTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MyInfoTabFlow.swift
@@ -24,6 +24,9 @@ final class MyInfoTabFlow: Flow {
             navigationController.pushViewController(viewController, animated: true)
             return .one(flowContributor: .contribute(withNextPresentable: viewController, withNextStepper: viewController))
             
+        case .loginRequired:
+            return .end(forwardToParentFlowWithStep: step)
+            
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
         }

--- a/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
@@ -15,7 +15,7 @@ import RxFlow
  */
 
 final class PlantTabFlow: Flow {
-    let navigationController = UINavigationController()
+    private let navigationController = UINavigationController()
     
     var root: any RxFlow.Presentable { navigationController }
     

--- a/LeafLog/LeafLog/App/Notification/FCMManager.swift
+++ b/LeafLog/LeafLog/App/Notification/FCMManager.swift
@@ -17,7 +17,6 @@ final class FCMManager: NSObject {
     @Dependency(\.supabaseManager) private var supabaseManager
     
     func setConfigs() {
-        notificationManager.requestNotificationAuthorization() //TODO: 로그인 성공 시 실행하도록 위치 변경 필요
         notificationManager.center.delegate = self
         Messaging.messaging().delegate = self
     }
@@ -30,13 +29,11 @@ extension FCMManager: UNUserNotificationCenterDelegate {
     }
 }
 
-//TODO: 로그인 성공 시 토큰 업데이트 함수 실행 필요 - Messaging.messaging().token()
 extension FCMManager: MessagingDelegate {
     // 파이어베이스 MessagingDelegate 설정 - 앱 시작 시, 혹은 토큰이 갱신되었을 때 호출되는 함수
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         // 전달받은 토큰이 정상적으로 있는지 확인
         guard let validToken = fcmToken else { return }
-        
         supabaseManager.updateFCMToken(validToken)
     }
 }

--- a/LeafLog/LeafLog/App/Notification/NotificationManager.swift
+++ b/LeafLog/LeafLog/App/Notification/NotificationManager.swift
@@ -14,6 +14,7 @@ final class NotificationManager {
     
     // 앱 알림 권한 요청 함수
     func requestNotificationAuthorization() {
+        
         // 앱 실행 시 사용자에게 알림 허용 권한 받기
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
         
@@ -21,7 +22,7 @@ final class NotificationManager {
             //TODO: 에러 처리 함수 필요
             
             // 앱 알림 권한 요청 결과에 따라 supabase에 알림 허용 여부 업데이트
-            self?.supabaseManager.updateIsNotificationEnabled(granted)
+            self?.updateIsNotificationEnabled()
         }
     }
     

--- a/LeafLog/LeafLog/App/SupabaseManager.swift
+++ b/LeafLog/LeafLog/App/SupabaseManager.swift
@@ -30,6 +30,7 @@ final class SupabaseManager {
 }
 
 extension SupabaseManager {
+    //TODO: ProfileDBManager 병합 시 이관 필요
     // 유저 fcm 토큰 업데이트
     func updateFCMToken(_ validToken: String) {
         // Supabase 서버로 토큰 쏴주기

--- a/LeafLog/LeafLog/AppDelegate.swift
+++ b/LeafLog/LeafLog/AppDelegate.swift
@@ -10,6 +10,7 @@ import KakaoSDKCommon
 import GoogleSignIn
 import Firebase
 import Dependencies
+import FirebaseMessaging
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/LeafLog/LeafLog/Auth/AuthService.swift
+++ b/LeafLog/LeafLog/Auth/AuthService.swift
@@ -27,7 +27,7 @@ final class AuthService {
             _ = try await supabase.auth.session
             return .main
         } catch {
-            return .login
+            return .loginRequired
         }
     }
 

--- a/LeafLog/LeafLog/Service/PlantClassificationService/PlantClassificationService.swift
+++ b/LeafLog/LeafLog/Service/PlantClassificationService/PlantClassificationService.swift
@@ -17,6 +17,7 @@ class PlantClassificationService {
         var modelPath: String? {
             switch self {
             case .aiyPlantsV1:
+                // NSDataAsset
                 Bundle.main.path(forResource: "3", ofType: "tflite")
             }
         }

--- a/LeafLog/LeafLog/View/MainViewController.swift
+++ b/LeafLog/LeafLog/View/MainViewController.swift
@@ -1,0 +1,23 @@
+//
+//  MainViewController.swift
+//  LeafLog
+//
+//  Created by t2025-m0143 on 4/10/26.
+//
+
+import UIKit
+import Dependencies
+import FirebaseMessaging
+
+final class MainViewController: UITabBarController {
+    @Dependency(\.notificationManager) private var notificationManager
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        notificationManager.requestNotificationAuthorization()
+        
+        Task {
+            try await Messaging.messaging().token()
+        }
+    }
+}

--- a/LeafLog/LeafLog/View/MainViewController.swift
+++ b/LeafLog/LeafLog/View/MainViewController.swift
@@ -17,7 +17,11 @@ final class MainViewController: UITabBarController {
         notificationManager.requestNotificationAuthorization()
         
         Task {
-            try await Messaging.messaging().token()
+            do {
+                try await Messaging.messaging().token()
+            } catch {
+                print("FCM 토큰 가져오기 실패: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/LeafLog/LeafLog/View/MyPageViewController.swift
+++ b/LeafLog/LeafLog/View/MyPageViewController.swift
@@ -48,7 +48,7 @@ class MyPageViewController: BaseViewController {
             do {
                 try await authService.signOut()
                 await MainActor.run {
-                    self.steps.accept(AppStep.login)
+                    self.steps.accept(AppStep.loginRequired)
                 }
             } catch {
                 await MainActor.run {

--- a/LeafLog/LeafLog/View/SplashViewController.swift
+++ b/LeafLog/LeafLog/View/SplashViewController.swift
@@ -36,9 +36,7 @@ final class SplashViewController: BaseViewController {
         Task {
             let nextStep = await authService.resolveInitialStep()
 
-            await MainActor.run {
-                self.steps.accept(nextStep)
-            }
+            self.steps.accept(nextStep)
         }
     }
 }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #28 

## 🛠 작업 내용 (What I did)
- Flow 분리
- 로그인 성공 시 실행 필요 동작 실행 위치 조정

## 💻 구현 상세 (Implementation Details)
- AppFlow와 MainFlow, LoginFlow를 분리하였습니다.
- UITabBarController인 MainViewController를 생성하였습니다.
- AppFlow에 존재하던 공통 동작 (alert present)을 MainFlow로 이관하였습니다.
- 로그인 성공 시 알람 권한을 요청하도록 함수 호출 시점을 변경하였습니다.
- 로그인 성공 시 fcm 토큰을 업데이트하는 함수를 호출합니다.

## 🧐 리뷰 포인트 (Review Points)
- alert step은 MainFlow에서 동작하도록 변경되었습니다. 참고 부탁드립니다.
- 기존 login step을 loginRequired step으로 명칭을 변경하였습니다. 참고 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?
