### PR TITLE
[Feat] 공통 Component (구분선, 기본 카드뷰, 타이틀 헤더뷰) 구현

### DIFF
--- a/LeafLog/LeafLog/Assets.xcassets/icon/arrowLeft.imageset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/icon/arrowLeft.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/LeafLog/LeafLog/Util/Custom/BaseCardView.swift
+++ b/LeafLog/LeafLog/Util/Custom/BaseCardView.swift
@@ -1,5 +1,5 @@
 //
-//  SeparateBar.swift
+//  BaseCardView.swift
 //  LeafLog
 //
 //  Created by t2025-m0143 on 4/12/26.
@@ -8,15 +8,14 @@
 import UIKit
 import SnapKit
 
-class SeparateBar: UIView {
+class BaseCardView: UIView {
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        backgroundColor = UIColor(red: 0.89, green: 0.89, blue: 0.89, alpha: 1.00) // HEX #E3E3E3
-        
-        self.snp.makeConstraints {
-            $0.height.equalTo(1)
-        }
+        backgroundColor = UIColor(red: 0.97, green: 0.97, blue: 0.97, alpha: 1.00) // HEX #F7F7F7
+        layer.cornerRadius = 8
+        clipsToBounds = true
     }
     
     required init?(coder: NSCoder) {

--- a/LeafLog/LeafLog/Util/Custom/SeparateBar.swift
+++ b/LeafLog/LeafLog/Util/Custom/SeparateBar.swift
@@ -6,20 +6,19 @@
 //
 
 import UIKit
-import SnapKit
 
 class SeparateBar: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         backgroundColor = UIColor(red: 0.89, green: 0.89, blue: 0.89, alpha: 1.00) // HEX #E3E3E3
-        
-        self.snp.makeConstraints {
-            $0.height.equalTo(1)
-        }
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var intrinsicContentSize: CGSize {
+            return CGSize(width: UIView.noIntrinsicMetric, height: 1)
     }
 }

--- a/LeafLog/LeafLog/Util/Custom/SeparateBar.swift
+++ b/LeafLog/LeafLog/Util/Custom/SeparateBar.swift
@@ -1,0 +1,25 @@
+//
+//  SeparateBar.swift
+//  LeafLog
+//
+//  Created by t2025-m0143 on 4/12/26.
+//
+
+import UIKit
+import SnapKit
+
+class SeparateBar: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.backgroundColor = UIColor(red: 0.89, green: 0.89, blue: 0.89, alpha: 1.00) // HEX #E3E3E3
+        
+        self.snp.makeConstraints {
+            $0.height.equalTo(1)
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
+++ b/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
@@ -25,7 +25,7 @@ class TitleHeaderView: UIView {
     
     let rightButton = UIButton(configuration: .plain())
     
-    init(text: String, hasBackButton: Bool, rightButton: String? = nil) {
+    init(text: String, hasBackButton: Bool, rightButtonImage: String? = nil) {
         super.init(frame: .zero)
     }
     
@@ -35,6 +35,18 @@ class TitleHeaderView: UIView {
 }
 
 extension TitleHeaderView {
+    private func configure(text: String, hasBackButton: Bool, rightButtonImage: String? = nil) {
+        titleLabel.text = text
+        backButton.isHidden = !hasBackButton
+        
+        guard let imageName = rightButtonImage else {
+            rightButton.isHidden = true
+            return
+        }
+        
+        rightButton.setImage(UIImage(named: imageName), for: .normal)
+    }
+    
     private func setLayout() {
         addSubview(backButton)
         addSubview(titleLabel)

--- a/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
+++ b/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
@@ -45,8 +45,10 @@ extension TitleHeaderView {
             rightButton.isHidden = true
             return
         }
-        
         rightButton.setImage(UIImage(named: imageName), for: .normal)
+        
+        backButton.configuration?.baseForegroundColor = .black
+        rightButton.configuration?.baseForegroundColor = .black
     }
     
     private func setLayout() {
@@ -68,5 +70,14 @@ extension TitleHeaderView {
             $0.verticalEdges.equalToSuperview().inset(12)
             $0.trailing.equalToSuperview().inset(16)
         }
+    }
+}
+
+extension TitleHeaderView {
+    // 색상 반전 메서드(white)
+    func invertColors() {
+        titleLabel.textColor = .white
+        backButton.configuration?.baseForegroundColor = .white
+        rightButton.configuration?.baseForegroundColor = .white
     }
 }

--- a/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
+++ b/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
@@ -27,6 +27,8 @@ class TitleHeaderView: UIView {
     
     init(text: String, hasBackButton: Bool, rightButtonImage: String? = nil) {
         super.init(frame: .zero)
+        configure(text: text, hasBackButton: hasBackButton, rightButtonImage: rightButtonImage)
+        setLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -48,8 +50,8 @@ extension TitleHeaderView {
     }
     
     private func setLayout() {
-        addSubview(backButton)
         addSubview(titleLabel)
+        addSubview(backButton)
         addSubview(rightButton)
         
         backButton.snp.makeConstraints {

--- a/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
+++ b/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
@@ -10,12 +10,7 @@ import SnapKit
 import Then
 
 class TitleHeaderView: UIView {
-    //TODO: LabelConfiguration 적용 시 주석 해제
-//    private let titleLabel = UILabel(text: "", config: .title18)
-    
-    private let titleLabel = UILabel().then {
-        $0.text = ""
-        $0.font = .systemFont(ofSize: 18, weight: .bold)
+    private let titleLabel = UILabel(text: "", config: .title18).then {
         $0.textAlignment = .center
     }
     

--- a/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
+++ b/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
@@ -16,6 +16,7 @@ class TitleHeaderView: UIView {
     private let titleLabel = UILabel().then {
         $0.text = ""
         $0.font = .systemFont(ofSize: 18, weight: .bold)
+        $0.textAlignment = .center
     }
     
     let backButton = UIButton(configuration: .plain()).then {
@@ -35,6 +36,23 @@ class TitleHeaderView: UIView {
 
 extension TitleHeaderView {
     private func setLayout() {
+        addSubview(backButton)
+        addSubview(titleLabel)
+        addSubview(rightButton)
         
+        backButton.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(12)
+            $0.leading.equalToSuperview().inset(16)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(11)
+            $0.horizontalEdges.equalToSuperview().inset(40)
+        }
+        
+        rightButton.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(12)
+            $0.trailing.equalToSuperview().inset(16)
+        }
     }
 }

--- a/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
+++ b/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
@@ -9,6 +9,12 @@ import UIKit
 import SnapKit
 import Then
 
+/// 공통으로 사용될 TitleHeaderView입니다.
+///
+/// - Parameters:
+///     - text: 타이틀 레이블에 사용될 텍스트입니다.
+///     - hasBackButton: 뒤로가기 버튼 표시 유무입니다. true로 설정할 시 뒤로가기 버튼을 표시합니다.
+///     - rightButtonImage: 오른쪽 버튼의 이미지 이름입니다. nil일 경우 버튼을 표시하지 않습니다. 기본값은 nil입니다.
 class TitleHeaderView: UIView {
     private let titleLabel = UILabel(text: "", config: .title18).then {
         $0.textAlignment = .center

--- a/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
+++ b/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
@@ -1,0 +1,40 @@
+//
+//  TitleHeaderView.swift
+//  LeafLog
+//
+//  Created by t2025-m0143 on 4/13/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class TitleHeaderView: UIView {
+    //TODO: LabelConfiguration 적용 시 주석 해제
+//    private let titleLabel = UILabel(text: "", config: .title18)
+    
+    private let titleLabel = UILabel().then {
+        $0.text = ""
+        $0.font = .systemFont(ofSize: 18, weight: .bold)
+    }
+    
+    let backButton = UIButton(configuration: .plain()).then {
+        $0.setImage(.arrowLeft, for: .normal)
+    }
+    
+    let rightButton = UIButton(configuration: .plain())
+    
+    init(text: String, hasBackButton: Bool, rightButton: String? = nil) {
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension TitleHeaderView {
+    private func setLayout() {
+        
+    }
+}

--- a/LeafLog/LeafLog/View/ViewController.swift
+++ b/LeafLog/LeafLog/View/ViewController.swift
@@ -24,19 +24,51 @@ final class ViewController: BaseViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
         
-        let pushButton = UIButton(configuration: .plain())
-        pushButton.setTitle("push", for: .normal)
+//        let pushButton = UIButton(configuration: .plain())
+//        pushButton.setTitle("push", for: .normal)
+//        
+//        view.addSubview(pushButton)
+//        
+//        pushButton.snp.makeConstraints {
+//            $0.center.equalToSuperview()
+//        }
+//        
+//        pushButton.rx.tap
+//            .map { _ in AppStep.pushButtonTapped } // push Step으로 변환
+//            .bind(to: steps) // VC의 steps와 바인딩 -> 버튼을 누를 때마다 'push' 스텝이 방출
+//            .disposed(by: disposeBag)
         
-        view.addSubview(pushButton)
+        let title1 = TitleHeaderView(text: "", hasBackButton: true) // 백버튼만
+        let title2 = TitleHeaderView(text: "", hasBackButton: false, rightButtonImage: "bell") // 오른쪽 버튼만
+        let title3 = TitleHeaderView(text: "타이틀", hasBackButton: false) // 타이틀만
+        let title4 = TitleHeaderView(text: "타이틀", hasBackButton: true) // 타이틀, 백버튼
+        let title5 = TitleHeaderView(text: "타이틀", hasBackButton: true, rightButtonImage: "bell") // 다
         
-        pushButton.snp.makeConstraints {
-            $0.center.equalToSuperview()
+        [title1, title2, title3, title4, title5].forEach {
+            view.addSubview($0)
         }
         
-        pushButton.rx.tap
-            .map { _ in AppStep.pushButtonTapped } // push Step으로 변환
-            .bind(to: steps) // VC의 steps와 바인딩 -> 버튼을 누를 때마다 'push' 스텝이 방출
-            .disposed(by: disposeBag)
+        title1.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        title2.snp.makeConstraints {
+            $0.top.equalTo(title1.snp.bottom).offset(5)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        title3.snp.makeConstraints {
+            $0.top.equalTo(title2.snp.bottom).offset(5)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        title4.snp.makeConstraints {
+            $0.top.equalTo(title3.snp.bottom).offset(5)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        title5.snp.makeConstraints {
+            $0.top.equalTo(title4.snp.bottom).offset(5)
+            $0.horizontalEdges.equalToSuperview()
+        }
     }
 }
 

--- a/LeafLog/LeafLog/View/ViewController.swift
+++ b/LeafLog/LeafLog/View/ViewController.swift
@@ -24,53 +24,19 @@ final class ViewController: BaseViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
         
-//        let pushButton = UIButton(configuration: .plain())
-//        pushButton.setTitle("push", for: .normal)
-//        
-//        view.addSubview(pushButton)
-//        
-//        pushButton.snp.makeConstraints {
-//            $0.center.equalToSuperview()
-//        }
-//        
-//        pushButton.rx.tap
-//            .map { _ in AppStep.pushButtonTapped } // push Step으로 변환
-//            .bind(to: steps) // VC의 steps와 바인딩 -> 버튼을 누를 때마다 'push' 스텝이 방출
-//            .disposed(by: disposeBag)
+        let pushButton = UIButton(configuration: .plain())
+        pushButton.setTitle("push", for: .normal)
         
-        let title1 = TitleHeaderView(text: "", hasBackButton: true) // 백버튼만
-        let title2 = TitleHeaderView(text: "", hasBackButton: false, rightButtonImage: "bell") // 오른쪽 버튼만
-        let title3 = TitleHeaderView(text: "타이틀", hasBackButton: false) // 타이틀만
-        let title4 = TitleHeaderView(text: "타이틀", hasBackButton: true) // 타이틀, 백버튼
-        let title5 = TitleHeaderView(text: "타이틀", hasBackButton: true, rightButtonImage: "bell") // 다
+        view.addSubview(pushButton)
         
-        title4.invertColors()
-        
-        [title1, title2, title3, title4, title5].forEach {
-            view.addSubview($0)
+        pushButton.snp.makeConstraints {
+            $0.center.equalToSuperview()
         }
         
-        title1.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.horizontalEdges.equalToSuperview()
-        }
-        
-        title2.snp.makeConstraints {
-            $0.top.equalTo(title1.snp.bottom).offset(5)
-            $0.horizontalEdges.equalToSuperview()
-        }
-        title3.snp.makeConstraints {
-            $0.top.equalTo(title2.snp.bottom).offset(5)
-            $0.horizontalEdges.equalToSuperview()
-        }
-        title4.snp.makeConstraints {
-            $0.top.equalTo(title3.snp.bottom).offset(5)
-            $0.horizontalEdges.equalToSuperview()
-        }
-        title5.snp.makeConstraints {
-            $0.top.equalTo(title4.snp.bottom).offset(5)
-            $0.horizontalEdges.equalToSuperview()
-        }
+        pushButton.rx.tap
+            .map { _ in AppStep.pushButtonTapped } // push Step으로 변환
+            .bind(to: steps) // VC의 steps와 바인딩 -> 버튼을 누를 때마다 'push' 스텝이 방출
+            .disposed(by: disposeBag)
     }
 }
 

--- a/LeafLog/LeafLog/View/ViewController.swift
+++ b/LeafLog/LeafLog/View/ViewController.swift
@@ -44,6 +44,8 @@ final class ViewController: BaseViewController {
         let title4 = TitleHeaderView(text: "타이틀", hasBackButton: true) // 타이틀, 백버튼
         let title5 = TitleHeaderView(text: "타이틀", hasBackButton: true, rightButtonImage: "bell") // 다
         
+        title4.invertColors()
+        
         [title1, title2, title3, title4, title5].forEach {
             view.addSubview($0)
         }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #32 

## 🛠 작업 내용 (What I did)
- 공통으로 사용할 UI Component 구현

## 💻 구현 상세 (Implementation Details)
- 공통으로 사용할 구분선 Component 구현
- 공통으로 사용할 기본 카드뷰 Component 구현
- 공통으로 사용할 TitleHeaderView Component 구현

## 📸 스크린샷 (Screenshots)
<p align=center><img width=40% src="https://github.com/user-attachments/assets/d346228d-f698-497b-bce8-11751c13c59b" />
<img width=40% src="https://github.com/user-attachments/assets/a5abf223-6f4a-4118-9be4-6fb71cf470b1" /></p>

## 🧐 리뷰 포인트 (Review Points)
- 카드뷰의 cornerRadius 및 색상은 디자인 확정 시 변동 가능성 있습니다.
- 경우에 따른 타이틀 헤더뷰의 모습은 스크린샷 참고 부탁드립니다. (영역 구분을 위해 background를 red로 설정)

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
