### PR TITLE
[FEAT] 검색화면 UI 컴포넌트 구현 

### DIFF
--- a/LeafLog/LeafLog/Assets.xcassets/grayScale/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/grayScale/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/grayScale/grayScale100.colorset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/grayScale/grayScale100.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.890",
+          "green" : "0.890",
+          "red" : "0.890"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/grayScale/grayScale50.colorset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/grayScale/grayScale50.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.970",
+          "green" : "0.970",
+          "red" : "0.970"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/grayScale/grayScale500.colorset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/grayScale/grayScale500.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.490",
+          "green" : "0.490",
+          "red" : "0.490"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.490",
+          "green" : "0.490",
+          "red" : "0.490"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/grayScale/grayScale700.colorset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/grayScale/grayScale700.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.290",
+          "green" : "0.290",
+          "red" : "0.290"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.290",
+          "green" : "0.290",
+          "red" : "0.290"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/primaryColor/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/primaryColor/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/primaryColor/primary200.colorset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/primaryColor/primary200.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.745",
+          "green" : "0.955",
+          "red" : "0.908"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.745",
+          "green" : "0.955",
+          "red" : "0.908"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/primaryColor/primary400.colorset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/primaryColor/primary400.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.405",
+          "green" : "0.895",
+          "red" : "0.784"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.405",
+          "green" : "0.895",
+          "red" : "0.784"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/primaryColor/primary800.colorset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/primaryColor/primary800.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.075",
+          "green" : "0.425",
+          "red" : "0.346"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.075",
+          "green" : "0.425",
+          "red" : "0.346"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/sub/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/sub/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/sub/subBlue.colorset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/sub/subBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.498",
+          "red" : "0.169"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.498",
+          "red" : "0.169"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/sub/subRed.colorset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/sub/subRed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.417",
+          "green" : "0.417",
+          "red" : "0.942"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.417",
+          "green" : "0.417",
+          "red" : "0.942"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeafLog/LeafLog/Network/NetworkManager.swift
+++ b/LeafLog/LeafLog/Network/NetworkManager.swift
@@ -26,7 +26,7 @@ final class NetworkManager {
     func fetchPlantList(
         keyword: String,
         searchType: PlantSearchType = .plantName,
-        filterState: PlantFilterState = .init(),
+        filterState: PlantFilterState,
         pageNo: Int = 1,
         numOfRows: Int = 10
     ) async throws -> [PlantSummary] {

--- a/LeafLog/LeafLog/Util/Custom/CornerRadius14Button.swift
+++ b/LeafLog/LeafLog/Util/Custom/CornerRadius14Button.swift
@@ -30,8 +30,8 @@ class CornerRadius14Button: UIButton {
         configuration.title = title
         // TODO: 색 확정시 수정 요망
         configuration.baseForegroundColor = UIColor.darkGray
-        configuration.background.backgroundColor = UIColor(red: 0.89, green: 0.89, blue: 0.89, alpha: 1)
-        configuration.background.cornerRadius = 12
+        configuration.background.backgroundColor = UIColor(red: 0.908, green: 0.955, blue: 0.745, alpha: 1)
+        configuration.background.cornerRadius = 8
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12)
         
         // 다이나믹 폰트 설정

--- a/LeafLog/LeafLog/Util/Custom/CornerRadius14Button.swift
+++ b/LeafLog/LeafLog/Util/Custom/CornerRadius14Button.swift
@@ -1,0 +1,48 @@
+//
+//  CornerRadius14Button.swift
+//  LeafLog
+//
+//  Created by Yeseul Jang on 4/13/26.
+//
+
+import UIKit
+
+/*
+ 생성 시
+ let button = CornerRadius14Button(title: "선택")
+ 
+ 이름 변경시
+ button.apply(title: "완료")
+ */
+
+class CornerRadius14Button: UIButton {
+    init(title: String) {
+        super.init(frame: .zero)
+        apply(title: title)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func apply(title: String) {
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = title
+        // TODO: 색 확정시 수정 요망
+        configuration.baseForegroundColor = UIColor.darkGray
+        configuration.background.backgroundColor = UIColor(red: 0.89, green: 0.89, blue: 0.89, alpha: 1)
+        configuration.background.cornerRadius = 12
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12)
+        
+        // 다이나믹 폰트 설정
+        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            let baseFont = UIFont.systemFont(ofSize: 14, weight: .medium)
+            outgoing.font = UIFontMetrics(forTextStyle: .subheadline).scaledFont(for: baseFont)
+            return outgoing
+        }
+        self.configuration = configuration
+        titleLabel?.adjustsFontForContentSizeCategory = true
+    }
+}
+

--- a/LeafLog/LeafLog/Util/Custom/CornerRadius14Button.swift
+++ b/LeafLog/LeafLog/Util/Custom/CornerRadius14Button.swift
@@ -16,21 +16,34 @@ import UIKit
  */
 
 class CornerRadius14Button: UIButton {
-    init(title: String) {
+    enum BackgroundColor {
+        case gray
+        case lightGreen
+
+        fileprivate var color: UIColor {
+            switch self {
+            case .gray:
+                return UIColor(red: 0.97, green: 0.97, blue: 0.97, alpha: 1)
+            case .lightGreen:
+                return UIColor(red: 0.908, green: 0.955, blue: 0.745, alpha: 1)
+            }
+        }
+    }
+
+    init(title: String, backgroundColor: BackgroundColor = .lightGreen) {
         super.init(frame: .zero)
-        apply(title: title)
+        apply(title: title, backgroundColor: backgroundColor)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func apply(title: String) {
+    func apply(title: String, backgroundColor: BackgroundColor = .lightGreen) {
         var configuration = UIButton.Configuration.plain()
         configuration.title = title
-        // TODO: 색 확정시 수정 요망
         configuration.baseForegroundColor = UIColor.darkGray
-        configuration.background.backgroundColor = UIColor(red: 0.908, green: 0.955, blue: 0.745, alpha: 1)
+        configuration.background.backgroundColor = backgroundColor.color
         configuration.background.cornerRadius = 8
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12)
         
@@ -45,4 +58,3 @@ class CornerRadius14Button: UIButton {
         titleLabel?.adjustsFontForContentSizeCategory = true
     }
 }
-

--- a/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
+++ b/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
@@ -24,9 +24,9 @@ class CornerRadius8Button: UIButton {
         fileprivate var color: UIColor {
             switch self {
             case .gray:
-                return UIColor(red: 0.97, green: 0.97, blue: 0.97, alpha: 1)
+                return .grayScale50
             case .lightGreen:
-                return UIColor(red: 0.908, green: 0.955, blue: 0.745, alpha: 1)
+                return .primary200
             }
         }
     }

--- a/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
+++ b/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
@@ -15,7 +15,7 @@ import UIKit
  button.apply(title: "완료")
  */
 
-class CornerRadius14Button: UIButton {
+class CornerRadius8Button: UIButton {
     enum BackgroundColor {
         case gray
         case lightGreen

--- a/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
+++ b/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
@@ -1,5 +1,5 @@
 //
-//  CornerRadius14Button.swift
+//  CornerRadius8Button.swift
 //  LeafLog
 //
 //  Created by Yeseul Jang on 4/13/26.
@@ -9,8 +9,8 @@ import UIKit
 
 /*
  생성 시 (색 설정 안하면 자동으로 회색 적용됩니다.)
- let button = CornerRadius14Button(title: "선택")
- let button = CornerRadius14Button(title: "선택", backgroundColor: .lightGreen)
+ let button = CornerRadius8Button(title: "선택")
+ let button = CornerRadius8Button(title: "선택", backgroundColor: .lightGreen)
  
  이름 변경시
  button.apply(title: "완료")

--- a/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
+++ b/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
@@ -40,7 +40,7 @@ class CornerRadius8Button: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func apply(title: String, backgroundColor: BackgroundColor = .lightGreen) {
+    func apply(title: String, backgroundColor: BackgroundColor = .gray) {
         var configuration = UIButton.Configuration.plain()
         configuration.title = title
         configuration.baseForegroundColor = UIColor.darkGray

--- a/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
+++ b/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
@@ -56,6 +56,5 @@ class CornerRadius8Button: UIButton {
             return outgoing
         }
         self.configuration = configuration
-        titleLabel?.adjustsFontForContentSizeCategory = true
     }
 }

--- a/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
+++ b/LeafLog/LeafLog/Util/Custom/CornerRadius8Button.swift
@@ -8,8 +8,9 @@
 import UIKit
 
 /*
- 생성 시
+ 생성 시 (색 설정 안하면 자동으로 회색 적용됩니다.)
  let button = CornerRadius14Button(title: "선택")
+ let button = CornerRadius14Button(title: "선택", backgroundColor: .lightGreen)
  
  이름 변경시
  button.apply(title: "완료")
@@ -30,7 +31,7 @@ class CornerRadius8Button: UIButton {
         }
     }
 
-    init(title: String, backgroundColor: BackgroundColor = .lightGreen) {
+    init(title: String, backgroundColor: BackgroundColor = .gray) {
         super.init(frame: .zero)
         apply(title: title, backgroundColor: backgroundColor)
     }

--- a/LeafLog/LeafLog/Util/Custom/DropdownFilterButton.swift
+++ b/LeafLog/LeafLog/Util/Custom/DropdownFilterButton.swift
@@ -48,6 +48,5 @@ final class DropdownFilterButton: UIButton {
         }
 
         self.configuration = configuration
-        titleLabel?.adjustsFontForContentSizeCategory = true
     }
 }

--- a/LeafLog/LeafLog/Util/Custom/DropdownFilterButton.swift
+++ b/LeafLog/LeafLog/Util/Custom/DropdownFilterButton.swift
@@ -33,11 +33,11 @@ final class DropdownFilterButton: UIButton {
             UIImage.SymbolConfiguration(pointSize: 10, weight: .medium)
         configuration.imagePlacement = .trailing
         configuration.imagePadding = 4
-        configuration.baseForegroundColor = UIColor(red: 0.35, green: 0.35, blue: 0.35, alpha: 1)
+        configuration.baseForegroundColor = .grayScale500
         configuration.background.backgroundColor = .white
         configuration.background.cornerRadius = 12
         configuration.background.strokeWidth = 1
-        configuration.background.strokeColor = UIColor(red: 0.89, green: 0.89, blue: 0.89, alpha: 1)
+        configuration.background.strokeColor = .grayScale100
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12)
 
         configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in

--- a/LeafLog/LeafLog/Util/Custom/DropdownFilterButton.swift
+++ b/LeafLog/LeafLog/Util/Custom/DropdownFilterButton.swift
@@ -1,0 +1,53 @@
+//
+//  DropdownFilterButton.swift
+//  LeafLog
+//
+//  Created by Yeseul Jang on 4/13/26.
+//
+
+import UIKit
+
+/*
+ 생성 시
+ let button = DropdownFilterButton(title: "꽃색")
+
+ 이름 변경시
+ button.apply(title: "잎색")
+ */
+
+final class DropdownFilterButton: UIButton {
+    init(title: String) {
+        super.init(frame: .zero)
+        apply(title: title)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func apply(title: String) {
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = title
+        configuration.image = UIImage(systemName: "chevron.down")
+        configuration.preferredSymbolConfigurationForImage =
+            UIImage.SymbolConfiguration(pointSize: 10, weight: .medium)
+        configuration.imagePlacement = .trailing
+        configuration.imagePadding = 4
+        configuration.baseForegroundColor = UIColor(red: 0.35, green: 0.35, blue: 0.35, alpha: 1)
+        configuration.background.backgroundColor = .white
+        configuration.background.cornerRadius = 12
+        configuration.background.strokeWidth = 1
+        configuration.background.strokeColor = UIColor(red: 0.89, green: 0.89, blue: 0.89, alpha: 1)
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12)
+
+        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            let baseFont = UIFont.systemFont(ofSize: 14, weight: .medium)
+            outgoing.font = UIFontMetrics(forTextStyle: .body).scaledFont(for: baseFont)
+            return outgoing
+        }
+
+        self.configuration = configuration
+        titleLabel?.adjustsFontForContentSizeCategory = true
+    }
+}

--- a/LeafLog/LeafLog/Util/Custom/MatchStatusBadgeLabel.swift
+++ b/LeafLog/LeafLog/Util/Custom/MatchStatusBadgeLabel.swift
@@ -39,7 +39,7 @@ final class MatchStatusBadgeLabel: UILabel {
             case .high:
                 return UIColor(red: 0.169, green: 0.498, blue: 1, alpha: 0.1)
             case .medium:
-                return UIColor(red: 0.97, green: 0.97, blue: 0.97, alpha: 1)
+                return .grayScale50
             case .low:
                 return UIColor(red: 0.941, green: 0.416, blue: 0.416, alpha: 0.1)
             }

--- a/LeafLog/LeafLog/Util/Custom/MatchStatusBadgeLabel.swift
+++ b/LeafLog/LeafLog/Util/Custom/MatchStatusBadgeLabel.swift
@@ -68,7 +68,7 @@ final class MatchStatusBadgeLabel: UILabel {
         backgroundColor = style.backgroundColor
     }
     
-    // 내부 패딩을 위한 override 메서드 - 안쪽으로 인셋이 나오고 가운데에 글자가 나올 수 있도록 해줌
+    // 내부 패딩을 위한 override 메서드 - 안쪽으로 인셋을 확보하고 가운데에 글자가 들어갈 수 있도록 해줌
     override func drawText(in rect: CGRect) {
         let insets = UIEdgeInsets(
             top: verticalPadding,

--- a/LeafLog/LeafLog/Util/Custom/MatchStatusBadgeLabel.swift
+++ b/LeafLog/LeafLog/Util/Custom/MatchStatusBadgeLabel.swift
@@ -26,22 +26,22 @@ final class MatchStatusBadgeLabel: UILabel {
         fileprivate var textColor: UIColor {
             switch self {
             case .high:
-                return UIColor(red: 0.169, green: 0.498, blue: 1, alpha: 1)
+                return .subBlue
             case .medium:
-                return UIColor(red: 0.29, green: 0.29, blue: 0.29, alpha: 1)
+                return .grayScale700
             case .low:
-                return UIColor(red: 0.942, green: 0.417, blue: 0.417, alpha: 1)
+                return .subRed
             }
         }
 
         fileprivate var backgroundColor: UIColor {
             switch self {
             case .high:
-                return UIColor(red: 0.169, green: 0.498, blue: 1, alpha: 0.1)
+                return .subBlue.withAlphaComponent(0.1)
             case .medium:
                 return .grayScale50
             case .low:
-                return UIColor(red: 0.941, green: 0.416, blue: 0.416, alpha: 0.1)
+                return .subRed.withAlphaComponent(0.1)
             }
         }
 
@@ -62,7 +62,9 @@ final class MatchStatusBadgeLabel: UILabel {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        font = .systemFont(ofSize: 12, weight: .medium)
+        let baseFont = UIFont.systemFont(ofSize: 12, weight: .medium)
+        font = UIFontMetrics(forTextStyle: .footnote).scaledFont(for: baseFont)
+        adjustsFontForContentSizeCategory = true
         layer.cornerRadius = 8
         layer.masksToBounds = true
         numberOfLines = 1

--- a/LeafLog/LeafLog/Util/Custom/MatchStatusBadgeLabel.swift
+++ b/LeafLog/LeafLog/Util/Custom/MatchStatusBadgeLabel.swift
@@ -6,6 +6,17 @@
 //
 import UIKit
 
+/*
+ 검색 결과의 일치율/상태 값을 배지 형태로 보여줄 때 사용하는 라벨입니다.
+
+ 생성 시
+ let badgeLabel = MatchStatusBadgeLabel()
+
+ 다른 스타일 적용 시 - 아무것도 안적으면 "일치율" 자동 적용
+ badgeLabel.apply(style: .high)
+ badgeLabel.apply(style: .medium, prefix: "온도") // 온도: 보통
+ */
+
 final class MatchStatusBadgeLabel: UILabel {
     enum Style {
         case high

--- a/LeafLog/LeafLog/Util/Custom/MatchStatusBadgeLabel.swift
+++ b/LeafLog/LeafLog/Util/Custom/MatchStatusBadgeLabel.swift
@@ -1,0 +1,90 @@
+//
+//  MatchStatusBadgeLabel.swift
+//  LeafLog
+//
+//  Created by Yeseul Jang on 4/13/26.
+//
+import UIKit
+
+final class MatchStatusBadgeLabel: UILabel {
+    enum Style {
+        case high
+        case medium
+        case low
+
+        fileprivate var textColor: UIColor {
+            switch self {
+            case .high:
+                return UIColor(red: 0.169, green: 0.498, blue: 1, alpha: 1)
+            case .medium:
+                return UIColor(red: 0.29, green: 0.29, blue: 0.29, alpha: 1)
+            case .low:
+                return UIColor(red: 0.942, green: 0.417, blue: 0.417, alpha: 1)
+            }
+        }
+
+        fileprivate var backgroundColor: UIColor {
+            switch self {
+            case .high:
+                return UIColor(red: 0.169, green: 0.498, blue: 1, alpha: 0.1)
+            case .medium:
+                return UIColor(red: 0.97, green: 0.97, blue: 0.97, alpha: 1)
+            case .low:
+                return UIColor(red: 0.941, green: 0.416, blue: 0.416, alpha: 0.1)
+            }
+        }
+
+        fileprivate var descriptionText: String {
+            switch self {
+            case .high:
+                return "높음"
+            case .medium:
+                return "보통"
+            case .low:
+                return "낮음"
+            }
+        }
+    }
+
+    private let horizontalPadding: CGFloat = 4
+    private let verticalPadding: CGFloat = 2
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        font = .systemFont(ofSize: 12, weight: .medium)
+        layer.cornerRadius = 8
+        layer.masksToBounds = true
+        numberOfLines = 1
+        apply(style: .high)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func apply(style: Style, prefix: String = "일치율") {
+        text = "\(prefix) : \(style.descriptionText)"
+        textColor = style.textColor
+        backgroundColor = style.backgroundColor
+    }
+    
+    // 내부 패딩을 위한 override 메서드 - 안쪽으로 인셋이 나오고 가운데에 글자가 나올 수 있도록 해줌
+    override func drawText(in rect: CGRect) {
+        let insets = UIEdgeInsets(
+            top: verticalPadding,
+            left: horizontalPadding,
+            bottom: verticalPadding,
+            right: horizontalPadding
+        )
+        super.drawText(in: rect.inset(by: insets))
+    }
+    
+    // 패딩까지 포함한 레이아웃으로 컨텐트 크기를 잡도록 해주는 override 메서드
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(
+            width: size.width + horizontalPadding * 2,
+            height: size.height + verticalPadding * 2
+        )
+    }
+}

--- a/LeafLog/LeafLog/Util/Extension/UILabel+.swift
+++ b/LeafLog/LeafLog/Util/Extension/UILabel+.swift
@@ -12,7 +12,8 @@ extension UILabel {
         color: UIColor? = nil,
         lines: Int? = nil
     ) {
-        self.font = config.font
+        self.font = UIFontMetrics(forTextStyle: config.textStyle).scaledFont(for: config.font)
+        self.adjustsFontForContentSizeCategory = true
         self.textColor = color ?? config.color
         self.numberOfLines = lines ?? config.lines
     }

--- a/LeafLog/LeafLog/Util/LabelConfiguration.swift
+++ b/LeafLog/LeafLog/Util/LabelConfiguration.swift
@@ -8,6 +8,7 @@ import UIKit
 
 struct LabelConfiguration {
     let font: UIFont
+    let textStyle: UIFont.TextStyle
     let color: UIColor
     let lines: Int
 }
@@ -30,32 +31,34 @@ extension LabelConfiguration {
     private static func make(
         size: CGFloat,
         weight: UIFont.Weight,
+        textStyle: UIFont.TextStyle,
         color: UIColor = .label,
         lines: Int = 0
     ) -> LabelConfiguration {
         LabelConfiguration(
             font: .systemFont(ofSize: size, weight: weight),
+            textStyle: textStyle,
             color: color,
             lines: lines
         )
     }
 
-    static let headline24 = make(size: 24, weight: .bold)
-    static let headline20 = make(size: 20, weight: .bold)
-    static let headline18 = make(size: 18, weight: .bold)
-    static let headline16 = make(size: 16, weight: .bold)
+    static let headline24 = make(size: 24, weight: .bold, textStyle: .largeTitle)
+    static let headline20 = make(size: 20, weight: .bold, textStyle: .title1)
+    static let headline18 = make(size: 18, weight: .bold, textStyle: .title2)
+    static let headline16 = make(size: 16, weight: .bold, textStyle: .title3)
 
-    static let body18 = make(size: 18, weight: .regular)
-    static let body16 = make(size: 16, weight: .regular)
-    static let body14 = make(size: 14, weight: .regular)
-    static let body12 = make(size: 12, weight: .regular)
+    static let body18 = make(size: 18, weight: .regular, textStyle: .body)
+    static let body16 = make(size: 16, weight: .regular, textStyle: .body)
+    static let body14 = make(size: 14, weight: .regular, textStyle: .body)
+    static let body12 = make(size: 12, weight: .regular, textStyle: .footnote)
 
-    static let title20 = make(size: 20, weight: .semibold)
-    static let title18 = make(size: 18, weight: .semibold)
-    static let title16 = make(size: 16, weight: .semibold)
-    static let title14 = make(size: 14, weight: .semibold)
+    static let title20 = make(size: 20, weight: .semibold, textStyle: .title2)
+    static let title18 = make(size: 18, weight: .semibold, textStyle: .title3)
+    static let title16 = make(size: 16, weight: .semibold, textStyle: .headline)
+    static let title14 = make(size: 14, weight: .semibold, textStyle: .subheadline)
 
-    static let label16 = make(size: 16, weight: .medium)
-    static let label14 = make(size: 14, weight: .medium)
-    static let label12 = make(size: 12, weight: .medium)
+    static let label16 = make(size: 16, weight: .medium, textStyle: .headline)
+    static let label14 = make(size: 14, weight: .medium, textStyle: .subheadline)
+    static let label12 = make(size: 12, weight: .medium, textStyle: .footnote)
 }

--- a/LeafLog/LeafLog/View/SearchView/SearchBarView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchBarView.swift
@@ -1,0 +1,85 @@
+//
+//  SearchBarView.swift
+//  LeafLog
+//
+//  Created by Yeseul Jang on 4/13/26.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class SearchBarView: UIView {
+    let textField = UITextField().then {
+        $0.placeholder = "place holder"
+        $0.borderStyle = .none
+        $0.autocapitalizationType = .none
+        $0.returnKeyType = .search
+        $0.font = .systemFont(ofSize: 16, weight: .regular)
+        $0.textColor = .label
+    }
+
+    let cameraButton = UIButton(type: .system).then {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: "camera")
+        configuration.baseForegroundColor = UIColor(red: 0.39, green: 0.39, blue: 0.39, alpha: 1)
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+        $0.configuration = configuration
+    }
+
+    private let searchIconImageView = UIImageView().then {
+        $0.image = UIImage(systemName: "magnifyingglass")
+        $0.tintColor = UIColor(red: 0.79, green: 0.79, blue: 0.79, alpha: 1)
+        $0.contentMode = .scaleAspectFit
+    }
+
+    private let dividerView = UIView().then {
+        $0.backgroundColor = UIColor(red: 0.79, green: 0.79, blue: 0.79, alpha: 1)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        backgroundColor = .white
+        layer.cornerRadius = 12
+        layer.borderWidth = 1
+        layer.borderColor = UIColor(red: 0.89, green: 0.89, blue: 0.89, alpha: 1).cgColor
+
+        addSubview(searchIconImageView)
+        addSubview(textField)
+        addSubview(dividerView)
+        addSubview(cameraButton)
+
+        searchIconImageView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(20)
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(24)
+        }
+
+        cameraButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(12)
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(24)
+        }
+
+        dividerView.snp.makeConstraints {
+            $0.trailing.equalTo(cameraButton.snp.leading).offset(-12)
+            $0.centerY.equalToSuperview()
+            $0.width.equalTo(1 / UIScreen.main.scale)
+            $0.height.equalTo(30)
+        }
+
+        textField.snp.makeConstraints {
+            $0.leading.equalTo(searchIconImageView.snp.trailing).offset(12)
+            $0.trailing.equalTo(dividerView.snp.leading).offset(-12)
+            $0.centerY.equalToSuperview()
+        }
+    }
+}

--- a/LeafLog/LeafLog/View/SearchView/SearchBarView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchBarView.swift
@@ -66,7 +66,7 @@ final class SearchBarView: UIView {
         cameraButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(12)
             $0.centerY.equalToSuperview()
-            $0.size.equalTo(24)
+            $0.size.equalTo(30)
         }
 
         dividerView.snp.makeConstraints {

--- a/LeafLog/LeafLog/View/SearchView/SearchBarView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchBarView.swift
@@ -50,7 +50,7 @@ final class SearchBarView: UIView {
         backgroundColor = .white
         layer.cornerRadius = 12
         layer.borderWidth = 1
-        layer.borderColor = UIColor(red: 0.89, green: 0.89, blue: 0.89, alpha: 1).cgColor
+        layer.borderColor = UIColor.grayScale100.cgColor
 
         addSubview(searchIconImageView)
         addSubview(textField)

--- a/LeafLog/LeafLog/View/SearchView/SearchBottomGuideView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchBottomGuideView.swift
@@ -1,0 +1,43 @@
+//
+//  SearchBottomGuideView.swift
+//  LeafLog
+//
+//  Created by Yeseul Jang on 4/13/26.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class SearchBottomGuideView: UICollectionReusableView {
+    static let reuseIdentifier = "SearchBottomGuideView"
+
+    private let titleLabel = UILabel(text: "찾으시는 결과가 없으신가요?", config: .title16)
+
+    let actionButton = CornerRadius14Button(title: "기타로 등록하기", backgroundColor: .gray)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        addSubview(titleLabel)
+        addSubview(actionButton)
+
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(24)
+            $0.centerX.equalToSuperview()
+        }
+
+        actionButton.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(36)
+        }
+    }
+}

--- a/LeafLog/LeafLog/View/SearchView/SearchBottomGuideView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchBottomGuideView.swift
@@ -14,7 +14,7 @@ final class SearchBottomGuideView: UICollectionReusableView {
 
     private let titleLabel = UILabel(text: "찾으시는 결과가 없으신가요?", config: .title16)
 
-    let actionButton = CornerRadius14Button(title: "기타로 등록하기", backgroundColor: .gray)
+    let actionButton = CornerRadius8Button(title: "기타로 등록하기", backgroundColor: .gray)
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/LeafLog/LeafLog/View/SearchView/SearchResultCell.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchResultCell.swift
@@ -1,0 +1,131 @@
+//
+//  SearchResultCell.swift
+//  LeafLog
+//
+//  Created by Yeseul Jang on 4/13/26.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class SearchResultCell: UICollectionViewCell {
+    static let reuseIdentifier = "SearchResultCell"
+    private static let lineWidth = 1 / UIScreen.main.scale
+
+    private let cardView = UIView().then {
+        $0.backgroundColor = .systemBackground
+        $0.layer.cornerRadius = 16
+        $0.layer.masksToBounds = true
+    }
+    
+    // 이미지가 없을 경우, 로딩 시 사용
+    private let thumbnailContainerView = UIView().then {
+        $0.backgroundColor = UIColor(red: 0.97, green: 0.97, blue: 0.97, alpha: 1)
+        $0.layer.cornerRadius = 8
+        $0.layer.masksToBounds = true
+    }
+
+    private let thumbnailImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.clipsToBounds = true
+        $0.tintColor = .systemGray3
+    }
+
+    private let infoStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .leading
+        $0.spacing = 4
+    }
+
+    private let statusLabel = MatchStatusBadgeLabel().then {
+        $0.apply(style: .high)
+    }
+    
+    private let plantNameLabel = UILabel(text: "식물 이름", config: .title16)
+
+    private let selectButton = CornerRadius14Button(title: "선택")
+
+    private let dividerView = UIView().then {
+        $0.backgroundColor = UIColor.separator.withAlphaComponent(0.1)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    } 
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        thumbnailImageView.image = nil
+        statusLabel.isHidden = false
+        statusLabel.apply(style: .high)
+        plantNameLabel.text = nil
+    }
+
+    func configure(
+        plantName: String,
+        statusStyle: MatchStatusBadgeLabel.Style,
+        statusPrefix: String = "일치율",
+        showsStatusBadge: Bool = true,
+        image: UIImage? = nil
+    ) {
+        plantNameLabel.text = plantName
+        statusLabel.isHidden = !showsStatusBadge
+        statusLabel.apply(style: statusStyle, prefix: statusPrefix)
+        thumbnailImageView.image = image
+    }
+
+    private func setupUI() {
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+
+        contentView.addSubview(cardView)
+        cardView.addSubview(thumbnailContainerView)
+        thumbnailContainerView.addSubview(thumbnailImageView)
+        cardView.addSubview(infoStackView)
+        cardView.addSubview(selectButton)
+        contentView.addSubview(dividerView)
+
+        infoStackView.addArrangedSubview(statusLabel)
+        infoStackView.addArrangedSubview(plantNameLabel)
+
+        cardView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(dividerView.snp.top)
+        }
+
+        thumbnailContainerView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(16)
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(72)
+        }
+
+        thumbnailImageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        infoStackView.snp.makeConstraints {
+            $0.leading.equalTo(thumbnailContainerView.snp.trailing).offset(12)
+            $0.centerY.equalToSuperview()
+            $0.trailing.lessThanOrEqualTo(selectButton.snp.leading).offset(-12)
+        }
+
+        selectButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+            $0.height.equalTo(36)
+        }
+
+        dividerView.snp.makeConstraints {
+            $0.leading.equalTo(thumbnailContainerView)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(Self.lineWidth)
+        }
+    }
+}

--- a/LeafLog/LeafLog/View/SearchView/SearchResultCell.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchResultCell.swift
@@ -44,7 +44,7 @@ final class SearchResultCell: UICollectionViewCell {
     
     private let plantNameLabel = UILabel(text: "식물 이름", config: .title16)
 
-    private let selectButton = CornerRadius14Button(title: "선택")
+    private let selectButton = CornerRadius8Button(title: "선택")
 
     private let dividerView = UIView().then {
         $0.backgroundColor = UIColor.separator.withAlphaComponent(0.1)

--- a/LeafLog/LeafLog/View/SearchView/SearchTestView.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchTestView.swift
@@ -14,7 +14,7 @@ import Then
 
 
 // TODO: 오류 처리
-final class SearchView: BaseViewController, View {
+final class SearchTestView: BaseViewController, View {
     private let filterScrollView = UIScrollView().then {
         $0.showsHorizontalScrollIndicator = false
     }

--- a/LeafLog/LeafLog/View/SearchView/SearchViewController.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchViewController.swift
@@ -1,0 +1,7 @@
+//
+//  SearchViewController.swift
+//  LeafLog
+//
+//  Created by Yeseul Jang on 4/13/26.
+//
+


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #35 

## 🛠 작업 내용 (What I did)
- CornerRadius8Button: 연두색/회색 컬러 에셋 반영해서 선택가능하도록 구현
- DropdownFilterButton: 회색 버튼 컬러 에셋 반영해서 구현
- MatchStatusBadgeLabel: 일치율 뱃지 구현

## 📸 스크린샷 (Screenshots)
|기능 실행 전|
|:---:|
|<img width="300" height="630" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-14 at 10 39 52" src="https://github.com/user-attachments/assets/d505d75e-8060-4e95-b909-1d6c1272ac66" />|

## 🧐 리뷰 포인트 (Review Points)
- 일단 공용 컴포넌트에만 컬러에셋을 적용했습니다. 추후에 코드 전체에 컬러 에셋 적용예정입니다.
- 컴포넌트 파일내의 사용안내 주석 읽고 사용하시는거 추천드립니다!

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?
