### PR TITLE
[Feat] 식물 관리 기록을 Supabase와 연동하기 위한 모델과 DBManager 구현

### DIFF
--- a/LeafLog/LeafLog/Auth/AuthError.swift
+++ b/LeafLog/LeafLog/Auth/AuthError.swift
@@ -10,13 +10,13 @@ import Foundation
 enum AuthError: Error {
     /// 로그인 과정 자체에서 실패했을 때 (카카오/구글 SDK 에러 등)
     case loginFailed(String)
-    
+
     /// 사용자가 로그인 취소하였을때
     case cancelled
-    
+
     /// 로그인 후 앱으로 돌아오는 URL Scheme이 잘못되었을 때
     case invalidCallbackURL
-    
+
     /// 로그인은 성공했지만 Supabase 서버에 세션을 만들거나 유저 정보를 가져오는데 실패했을 때
     case sessionFailed(String)
 
@@ -25,6 +25,9 @@ enum AuthError: Error {
 
     /// 식물 관련 저장/조회 작업이 실패했을 때
     case plantFailed(String)
+
+    /// 식물 관리 기록 저장/조회 작업이 실패했을 때
+    case careFailed(String)
 
     /// 회원탈퇴 처리 중 실패했을 때
     case withdrawalFailed(String)
@@ -37,6 +40,7 @@ extension AuthError {
              .sessionFailed(let message),
              .profileFailed(let message),
              .plantFailed(let message),
+             .careFailed(let message),
              .withdrawalFailed(let message):
             return message
         case .cancelled:

--- a/LeafLog/LeafLog/Model/CareRecord.swift
+++ b/LeafLog/LeafLog/Model/CareRecord.swift
@@ -1,0 +1,71 @@
+//
+//  CareRecord.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/16/26.
+//
+
+import Foundation
+
+// MARK: - LocalDate
+struct LocalDate: RawRepresentable, Codable, Hashable {
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    init(date: Date) {
+        self.rawValue = Self.formatter.string(from: date)
+    }
+
+    var date: Date? {
+        Self.formatter.date(from: rawValue)
+    }
+
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+}
+
+// MARK: - Models
+//  DB에서 가져온 데이터 저장
+struct CareRecord: Codable {
+    let id: UUID
+    let plantID: UUID
+    let recordedAt: Date
+    let status: String?
+    let watered, repotted, fertilized, treated: Bool
+    let createdAt, updatedAt: Date
+    let recordDate: LocalDate
+    let wateredNote, repottedNote, fertilizedNote, treatedNote, diaryText, diaryPhotoPath: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, status, watered, repotted, fertilized, treated
+        case plantID = "plant_id"
+        case recordedAt = "recorded_at"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case recordDate = "record_date"
+        case wateredNote = "watered_note"
+        case repottedNote = "repotted_note"
+        case fertilizedNote = "fertilized_note"
+        case treatedNote = "treated_note"
+        case diaryText = "diary_text"
+        case diaryPhotoPath = "diary_photo_path"
+    }
+}
+
+// 앱 -> DB에 보낼 데이터
+struct CareRecordUpsertInput {
+    let plantID: UUID
+    let recordDate: LocalDate
+    var recordedAt: Date?
+    var status: String?
+    var watered, repotted, fertilized, treated: Bool?
+    var wateredNote, repottedNote, fertilizedNote, treatedNote: String?
+    var diaryText, diaryPhotoPath: String?
+}

--- a/LeafLog/LeafLog/Network/CareRecordDBManager.swift
+++ b/LeafLog/LeafLog/Network/CareRecordDBManager.swift
@@ -16,41 +16,45 @@ final class CareRecordDBManager {
     
     // MARK: - 특정 식물의 특정 날짜에 해당하는 관리 기록 DB에서 불러 옴 (없으면 nil)
     func fetchCareRecord(plantID: UUID, recordDate: LocalDate) async throws -> CareRecord? {
-        let records: [CareRecord] = try await supabaseManager.client
-            .from("care_records")
-            .select()
-            .eq("plant_id", value: plantID)
-            .eq("record_date", value: recordDate.rawValue)
-            .limit(1)
-            .execute()
-            .value
-        
-        return records.first
+        do {
+            let records: [CareRecord] = try await supabaseManager.client
+                .from("care_records")
+                .select()
+                .eq("plant_id", value: plantID)
+                .eq("record_date", value: recordDate.rawValue)
+                .limit(1)
+                .execute()
+                .value
+
+            return records.first
+        } catch {
+            throw AuthError.careFailed("식물 상태 기록을 불러오지 못했어요: \(error.localizedDescription)")
+        }
     }
     
     
     // MARK: - 식물 관리 기록 upsert
     func upsertCareRecord(input: CareRecordUpsertInput) async throws -> CareRecord {
-        let existing = try await fetchCareRecord(plantID: input.plantID, recordDate: input.recordDate)
-        
-        let payload = CareRecordPayload(
-            plantID: input.plantID,
-            recordDate: input.recordDate,
-            recordedAt: input.recordedAt ?? existing?.recordedAt ?? Date(),
-            status: input.status ?? existing?.status,
-            watered: input.watered ?? existing?.watered ?? false,
-            repotted: input.repotted ?? existing?.repotted ?? false,
-            fertilized: input.fertilized ?? existing?.fertilized ?? false,
-            treated: input.treated ?? existing?.treated ?? false,
-            wateredNote: input.wateredNote ?? existing?.wateredNote,
-            repottedNote: input.repottedNote ?? existing?.repottedNote,
-            fertilizedNote: input.fertilizedNote ?? existing?.fertilizedNote,
-            treatedNote: input.treatedNote ?? existing?.treatedNote,
-            diaryText: input.diaryText ?? existing?.diaryText,
-            diaryPhotoPath: input.diaryPhotoPath ?? existing?.diaryPhotoPath
-        )
-        
         do {
+            let existing = try await fetchCareRecord(plantID: input.plantID, recordDate: input.recordDate)
+
+            let payload = CareRecordPayload(
+                plantID: input.plantID,
+                recordDate: input.recordDate,
+                recordedAt: input.recordedAt ?? existing?.recordedAt ?? Date(),
+                status: input.status ?? existing?.status,
+                watered: input.watered ?? existing?.watered ?? false,
+                repotted: input.repotted ?? existing?.repotted ?? false,
+                fertilized: input.fertilized ?? existing?.fertilized ?? false,
+                treated: input.treated ?? existing?.treated ?? false,
+                wateredNote: input.wateredNote ?? existing?.wateredNote,
+                repottedNote: input.repottedNote ?? existing?.repottedNote,
+                fertilizedNote: input.fertilizedNote ?? existing?.fertilizedNote,
+                treatedNote: input.treatedNote ?? existing?.treatedNote,
+                diaryText: input.diaryText ?? existing?.diaryText,
+                diaryPhotoPath: input.diaryPhotoPath ?? existing?.diaryPhotoPath
+            )
+
             return try await supabaseManager.client
                 .from("care_records")
                 .upsert(payload, onConflict: "plant_id,record_date") // 같은 날짜, 식물이면 
@@ -58,8 +62,10 @@ final class CareRecordDBManager {
                 .single()
                 .execute()
                 .value
+        } catch let error as AuthError {
+            throw error
         } catch {
-            throw AuthError.careFailed("식물 상태 기록을 저장하지 못했어요. 잠시 후 다시 시도해주세요.")
+            throw AuthError.careFailed("식물 상태 기록을 저장하지 못했어요: \(error.localizedDescription)")
         }
     }
     

--- a/LeafLog/LeafLog/Network/CareRecordDBManager.swift
+++ b/LeafLog/LeafLog/Network/CareRecordDBManager.swift
@@ -36,7 +36,7 @@ final class CareRecordDBManager {
         let payload = CareRecordPayload(
             plantID: input.plantID,
             recordDate: input.recordDate,
-            recordedAt: input.recordedAt ?? existing?.recordedAt,
+            recordedAt: input.recordedAt ?? existing?.recordedAt ?? Date(),
             status: input.status ?? existing?.status,
             watered: input.watered ?? existing?.watered ?? false,
             repotted: input.repotted ?? existing?.repotted ?? false,

--- a/LeafLog/LeafLog/Network/CareRecordDBManager.swift
+++ b/LeafLog/LeafLog/Network/CareRecordDBManager.swift
@@ -1,0 +1,100 @@
+//
+//  CareRecordDBManager.swift
+//  LeafLog
+//
+//  Created by 김주희 on 4/16/26.
+//
+import Foundation
+import Supabase
+import Dependencies
+
+final class CareRecordDBManager {
+    @Dependency(\.supabaseManager) private var supabaseManager
+    
+    private init() {}
+    
+    
+    // MARK: - 특정 식물의 특정 날짜에 해당하는 관리 기록 DB에서 불러 옴 (없으면 nil)
+    func fetchCareRecord(plantID: UUID, recordDate: LocalDate) async throws -> CareRecord? {
+        let records: [CareRecord] = try await supabaseManager.client
+            .from("care_records")
+            .select()
+            .eq("plant_id", value: plantID)
+            .eq("record_date", value: recordDate.rawValue)
+            .limit(1)
+            .execute()
+            .value
+        
+        return records.first
+    }
+    
+    
+    // MARK: - 식물 관리 기록 upsert
+    func upsertCareRecord(input: CareRecordUpsertInput) async throws -> CareRecord {
+        let existing = try await fetchCareRecord(plantID: input.plantID, recordDate: input.recordDate)
+        
+        let payload = CareRecordPayload(
+            plantID: input.plantID,
+            recordDate: input.recordDate,
+            recordedAt: input.recordedAt ?? existing?.recordedAt,
+            status: input.status ?? existing?.status,
+            watered: input.watered ?? existing?.watered ?? false,
+            repotted: input.repotted ?? existing?.repotted ?? false,
+            fertilized: input.fertilized ?? existing?.fertilized ?? false,
+            treated: input.treated ?? existing?.treated ?? false,
+            wateredNote: input.wateredNote ?? existing?.wateredNote,
+            repottedNote: input.repottedNote ?? existing?.repottedNote,
+            fertilizedNote: input.fertilizedNote ?? existing?.fertilizedNote,
+            treatedNote: input.treatedNote ?? existing?.treatedNote,
+            diaryText: input.diaryText ?? existing?.diaryText,
+            diaryPhotoPath: input.diaryPhotoPath ?? existing?.diaryPhotoPath
+        )
+        
+        do {
+            return try await supabaseManager.client
+                .from("care_records")
+                .upsert(payload, onConflict: "plant_id,record_date") // 같은 날짜, 식물이면 
+                .select()
+                .single()
+                .execute()
+                .value
+        } catch {
+            throw AuthError.careFailed("식물 상태 기록을 저장하지 못했어요. 잠시 후 다시 시도해주세요.")
+        }
+    }
+    
+    private struct CareRecordPayload: Encodable {
+        let plantID: UUID
+        let recordDate: LocalDate
+        let recordedAt: Date?
+        let status: String?
+        let watered, repotted, fertilized, treated: Bool
+        let wateredNote, repottedNote, fertilizedNote, treatedNote, diaryText, diaryPhotoPath: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case status, watered, repotted, fertilized, treated
+            case plantID = "plant_id"
+            case recordDate = "record_date"
+            case recordedAt = "recorded_at"
+            case wateredNote = "watered_note"
+            case repottedNote = "repotted_note"
+            case fertilizedNote = "fertilized_note"
+            case treatedNote = "treated_note"
+            case diaryText = "diary_text"
+            case diaryPhotoPath = "diary_photo_path"
+        }
+    }
+}
+
+
+// MARK: - Dependencies
+extension CareRecordDBManager: DependencyKey {
+    static var liveValue: CareRecordDBManager { CareRecordDBManager() }
+}
+
+extension DependencyValues {
+    var careRecordDBManager: CareRecordDBManager {
+        get { self[CareRecordDBManager.self] }
+        set { self[CareRecordDBManager.self] = newValue }
+    }
+}

--- a/LeafLog/LeafLog/Network/PlantDBManager.swift
+++ b/LeafLog/LeafLog/Network/PlantDBManager.swift
@@ -14,6 +14,23 @@ final class PlantDBManager {
     
     
     private init() {}
+
+    // MARK: 현재 로그인한 사용자가 등록한 식물 목록 조회
+    func fetchMyPlants() async throws -> [MyPlant] {
+        let user = try await supabaseManager.client.auth.user()
+
+        do {
+            return try await supabaseManager.client
+                .from("plants")
+                .select()
+                .eq("user_id", value: user.id)
+                .order("created_at", ascending: false)
+                .execute()
+                .value
+        } catch {
+            throw AuthError.plantFailed("등록한 식물 목록을 불러오지 못했어요. 잠시 후 다시 시도해주세요.")
+        }
+    }
     
     /// DB의 plants 테이블에 새 레코드를 Insert
     func createPlant(plantID: UUID, userID: UUID, imagePath: String?, input: PlantCreateInput) async throws -> MyPlant {


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #24 

## 🛠 작업 내용 (What I did)
- careFailed 에러 타입 추가
- 현재 로그인한 사용자의 식물 목록을 조회하는 `PlantDBManager.fetchMyPlants()` 추가
- `care_records` 테이블과 매핑되는 `CareRecord`, `LocalDate`, `CareRecordUpsertInput` 모델 추가
- 특정 날짜의 식물 관리 기록 조회 및 upsert를 담당하는 `CareRecordDBManager` 추가
- `plant_id + record_date` 기준으로 기존 기록은 업데이트하고, 없는 기록은 새로 생성하도록 구현
- `CareRecordDBManager`를 `swift-dependencies`로 주입 가능하도록 등록

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
