### PR TITLE
[feat] Apple 계정 삭제 토큰 revoke 기능 구현

### DIFF
--- a/LeafLog/LeafLog.xcodeproj/project.pbxproj
+++ b/LeafLog/LeafLog.xcodeproj/project.pbxproj
@@ -275,10 +275,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0AE522C32F8600A50075F8D6 /* Secrets.xcconfig */;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+					ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+					CODE_SIGN_ENTITLEMENTS = LeafLog/LeafLog.entitlements;
+					"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+					CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Q7HGK38S83;
@@ -316,10 +317,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0AE522C32F8600A50075F8D6 /* Secrets.xcconfig */;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+					ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+					CODE_SIGN_ENTITLEMENTS = LeafLog/LeafLog.entitlements;
+					"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+					CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Q7HGK38S83;

--- a/LeafLog/LeafLog/App/Flows/LoginFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/LoginFlow.swift
@@ -3,6 +3,7 @@
 //  LeafLog
 //
 //  Created by t2025-m0143 on 4/10/26.
+//  Updated by 김주희 on 4/17/26.
 //
 
 import UIKit
@@ -30,9 +31,18 @@ final class LoginFlow: Flow {
             return navigateToLogin()
         case .main:
             return .end(forwardToParentFlowWithStep: step)
+        case .alert(let title, let message):
+            return presentAlert(title: title, message: message)
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
         }
+    }
+
+    private func presentAlert(title: String, message: String) -> FlowContributors {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        navigationController.present(alert, animated: true)
+        return .none
     }
 }
 

--- a/LeafLog/LeafLog/Auth/AppleAuthProvider.swift
+++ b/LeafLog/LeafLog/Auth/AppleAuthProvider.swift
@@ -15,6 +15,8 @@ final class AppleAuthProvider {
     // 서버에 넘겨줄 데이터 바구니
     struct AppleCredential {
         let idToken: String
+        let authorizationCode: String
+        let userIdentifier: String
         let rawNonce: String
         let email: String? // 이메일, 이름은 최초 로그인 시에만 제공
         let fullName: PersonNameComponents?
@@ -111,14 +113,21 @@ extension AppleSignInCoordinator: ASAuthorizationControllerDelegate {
         }
 
         guard let identityToken = appleIDCredential.identityToken,
-              let idToken = String(data: identityToken, encoding: .utf8) else {
-            finish(with: .failure(AuthError.loginFailed("Apple ID Token을 가져올 수 없습니다.")))
+              let idToken = String(data: identityToken, encoding: .utf8),
+              let authorizationCodeData = appleIDCredential.authorizationCode,
+              let authorizationCode = String(data: authorizationCodeData, encoding: .utf8)
+        else {
+            finish(with: .failure(AuthError.loginFailed("Apple 인증 정보를 가져올 수 없습니다.")))
             return
         }
+        
+        let userIdentifier = appleIDCredential.user
 
         finish(with: .success(
             AppleAuthProvider.AppleCredential(
                 idToken: idToken,
+                authorizationCode: authorizationCode,
+                userIdentifier: userIdentifier,
                 rawNonce: rawNonce,
                 email: appleIDCredential.email,
                 fullName: appleIDCredential.fullName

--- a/LeafLog/LeafLog/Auth/AuthService.swift
+++ b/LeafLog/LeafLog/Auth/AuthService.swift
@@ -59,6 +59,24 @@ final class AuthService {
         try await supabase.auth.signInWithIdToken(
             credentials: .init(provider: .apple, idToken: credential.idToken, nonce: credential.rawNonce)
         )
+        
+        
+        let session = try await supabase.auth.session
+
+        try await supabase.functions.invoke(
+            "store-apple-token",
+            options: .init(
+                method: .post,
+                headers: [
+                    "Authorization": "Bearer \(session.accessToken)"
+                ],
+                body: [
+                    "authorizationCode": credential.authorizationCode,
+                    "userIdentifier": credential.userIdentifier
+                ]
+            )
+        )
+
         return try await supabase.auth.user()
     }
 

--- a/LeafLog/LeafLog/Auth/AuthService.swift
+++ b/LeafLog/LeafLog/Auth/AuthService.swift
@@ -109,7 +109,7 @@ final class AuthService {
             userIdentifier: credential.userIdentifier
         )
 
-        let _: StoreAppleTokenResponse = try await supabase.functions.invoke(
+        let response: StoreAppleTokenResponse = try await supabase.functions.invoke(
             "store-apple-token",
             options: .init(
                 method: .post,
@@ -117,6 +117,10 @@ final class AuthService {
                 body: request
             )
         )
+
+        guard response.success else {
+            throw AuthError.sessionFailed(Message.appleTokenStoreFailed)
+        }
     }
 
     

--- a/LeafLog/LeafLog/Auth/AuthService.swift
+++ b/LeafLog/LeafLog/Auth/AuthService.swift
@@ -3,6 +3,7 @@
 //  LeafLog
 //
 //  Created by t2025-m0143 on 4/3/26.
+//  Updated by 김주희 on 4/16/26.
 //
 
 import UIKit
@@ -12,6 +13,17 @@ import Dependencies
 final class AuthService {
 
     private struct WithdrawResponse: Decodable {
+        let success: Bool
+    }
+
+    // 서버로 Apple authorizationCode를 보내기 위한 요청 모델
+    private struct StoreAppleTokenRequest: Encodable {
+        let authorizationCode: String
+        let userIdentifier: String
+    }
+
+    // Edgefunction의 응답
+    private struct StoreAppleTokenResponse: Decodable {
         let success: Bool
     }
     
@@ -56,37 +68,55 @@ final class AuthService {
     // MARK: - Apple Login
     func startAppleNativeLogin(presentingViewController: UIViewController) async throws -> Supabase.User {
         let credential = try await appleProvider.fetchCredential(presentingViewController: presentingViewController)
+
         try await supabase.auth.signInWithIdToken(
             credentials: .init(provider: .apple, idToken: credential.idToken, nonce: credential.rawNonce)
         )
-        
-        
-        let session = try await supabase.auth.session
 
-        try await supabase.functions.invoke(
-            "store-apple-token",
+        let session = try await supabase.auth.session // 슈파베이스 로그인 세션
+        
+        do {
+            // Edge function으로 authorizationCode 보냄
+            try await storeAppleToken(credential: credential, accessToken: session.accessToken)
+        } catch {
+            try? await supabase.auth.signOut(scope: .local) // 로그인 성공했지만 refresh_token 저장 실패했으므로 로컬 세션 지워줌
+            throw AuthError.sessionFailed("Apple 인증 정보를 저장하지 못했어요. 잠시 후 다시 시도해주세요.")
+        }
+
+        return try await supabase.auth.user()
+    }
+
+    // Edge Function 호출
+    private func storeAppleToken(
+        credential: AppleAuthProvider.AppleCredential, // authorizationCode, userIdentifier
+        accessToken: String // Edge function 인증용
+    ) async throws {
+        let request = StoreAppleTokenRequest(
+            authorizationCode: credential.authorizationCode,
+            userIdentifier: credential.userIdentifier
+        )
+
+        let _: StoreAppleTokenResponse = try await supabase.functions.invoke(
+            "store-apple-token", // 호출할 edge function 이름
             options: .init(
                 method: .post,
                 headers: [
-                    "Authorization": "Bearer \(session.accessToken)"
+                    "Authorization": "Bearer \(accessToken)"
                 ],
-                body: [
-                    "authorizationCode": credential.authorizationCode,
-                    "userIdentifier": credential.userIdentifier
-                ]
+                body: request
             )
         )
-
-        return try await supabase.auth.user()
     }
 
     
     // MARK: - Google Login
     func startGoogleNativeLogin(presentingViewController: UIViewController) async throws -> Supabase.User {
         let credential = try await googleProvider.fetchCredential(presentingViewController: presentingViewController)
+
         try await supabase.auth.signInWithIdToken(
             credentials: .init(provider: .google, idToken: credential.idToken, nonce: credential.rawNonce)
         )
+
         let user = try await supabase.auth.user()
         try await ensureProfileExists(for: user)
         return user

--- a/LeafLog/LeafLog/Auth/AuthService.swift
+++ b/LeafLog/LeafLog/Auth/AuthService.swift
@@ -12,17 +12,23 @@ import Dependencies
 
 final class AuthService {
 
+    private enum Message {
+        static let appleLoginFailed = "Apple 로그인에 실패했어요. 잠시 후 다시 시도해주세요."
+        static let appleTokenStoreFailed = "Apple 로그인 정보를 저장하지 못했어요. 잠시 후 다시 시도해주세요."
+        static let withdrawalFailed = "회원탈퇴를 처리하지 못했어요. 잠시 후 다시 시도해주세요."
+    }
+
     private struct WithdrawResponse: Decodable {
         let success: Bool
     }
 
-    // 서버로 Apple authorizationCode를 보내기 위한 요청 모델
+    // Apple 토큰 저장 함수에 전달할 요청 모델
     private struct StoreAppleTokenRequest: Encodable {
         let authorizationCode: String
         let userIdentifier: String
     }
 
-    // Edgefunction의 응답
+    // Edge Function의 응답
     private struct StoreAppleTokenResponse: Decodable {
         let success: Bool
     }
@@ -69,27 +75,34 @@ final class AuthService {
     func startAppleNativeLogin(presentingViewController: UIViewController) async throws -> Supabase.User {
         let credential = try await appleProvider.fetchCredential(presentingViewController: presentingViewController)
 
-        try await supabase.auth.signInWithIdToken(
-            credentials: .init(provider: .apple, idToken: credential.idToken, nonce: credential.rawNonce)
-        )
-
-        let session = try await supabase.auth.session // 슈파베이스 로그인 세션
-        
         do {
-            // Edge function으로 authorizationCode 보냄
-            try await storeAppleToken(credential: credential, accessToken: session.accessToken)
+            try await supabase.auth.signInWithIdToken(
+                credentials: .init(provider: .apple, idToken: credential.idToken, nonce: credential.rawNonce)
+            )
         } catch {
-            try? await supabase.auth.signOut(scope: .local) // 로그인 성공했지만 refresh_token 저장 실패했으므로 로컬 세션 지워줌
-            throw AuthError.sessionFailed("Apple 인증 정보를 저장하지 못했어요. 잠시 후 다시 시도해주세요.")
+            throw AuthError.sessionFailed(Message.appleLoginFailed)
         }
 
-        return try await supabase.auth.user()
+        let session = try await supabase.auth.session
+        
+        do {
+            try await storeAppleToken(credential: credential, accessToken: session.accessToken)
+        } catch FunctionsError.httpError {
+            await signOutLocalSession()
+            throw AuthError.sessionFailed(Message.appleTokenStoreFailed)
+        } catch {
+            await signOutLocalSession()
+            throw AuthError.sessionFailed(Message.appleTokenStoreFailed)
+        }
+
+        let user = try await supabase.auth.user()
+        try await ensureProfileExists(for: user)
+        return user
     }
 
-    // Edge Function 호출
     private func storeAppleToken(
-        credential: AppleAuthProvider.AppleCredential, // authorizationCode, userIdentifier
-        accessToken: String // Edge function 인증용
+        credential: AppleAuthProvider.AppleCredential,
+        accessToken: String
     ) async throws {
         let request = StoreAppleTokenRequest(
             authorizationCode: credential.authorizationCode,
@@ -97,12 +110,10 @@ final class AuthService {
         )
 
         let _: StoreAppleTokenResponse = try await supabase.functions.invoke(
-            "store-apple-token", // 호출할 edge function 이름
+            "store-apple-token",
             options: .init(
                 method: .post,
-                headers: [
-                    "Authorization": "Bearer \(accessToken)"
-                ],
+                headers: authorizationHeaders(accessToken: accessToken),
                 body: request
             )
         )
@@ -176,21 +187,26 @@ final class AuthService {
                 "delete-user", // DB에서 유저 데이터 삭제
                 options: .init(
                     method: .post,
-                    headers: [
-                        "Authorization": "Bearer \(session.accessToken)"
-                    ]
+                    headers: authorizationHeaders(accessToken: session.accessToken)
                 )
             )
-        } catch FunctionsError.httpError(_, let data) {
-            let body = String(data: data, encoding: .utf8) ?? "응답 본문을 읽을 수 없어요."
-            throw AuthError.withdrawalFailed("회원탈퇴를 처리하지 못했어요. \(body)")
+        } catch FunctionsError.httpError {
+            throw AuthError.withdrawalFailed(Message.withdrawalFailed)
         } catch {
-            throw AuthError.withdrawalFailed("회원탈퇴를 처리하지 못했어요. \(error.localizedDescription)")
+            throw AuthError.withdrawalFailed(Message.withdrawalFailed)
         }
 
         // 로그아웃
         try? await supabase.auth.signOut(scope: .local)
         await signOutProvider(for: user)
+    }
+
+    private func authorizationHeaders(accessToken: String) -> [String: String] {
+        ["Authorization": "Bearer \(accessToken)"]
+    }
+
+    private func signOutLocalSession() async {
+        try? await supabase.auth.signOut(scope: .local)
     }
 
     


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #72

## 🛠 작업 내용 (What I did)
- Sign in with Apple 계정 삭제 정책 대응을 위해 Apple 로그인 토큰 저장 및 회원탈퇴 시 Apple token revoke 플로우를 구현했습니다.


## 💻 구현 상세 (Implementation Details)

### Apple 로그인 토큰 저장

- Apple 로그인 성공 시 `authorizationCode`, `userIdentifier`를 함께 수집하도록 수정했습니다.
- Supabase 로그인 성공 직후 `store-apple-token` Edge Function을 호출하도록 구현했습니다.
- Edge Function에서 Apple `authorizationCode`를 Apple token API로 교환하고, 반환받은 `refresh_token`을 `apple_auth_tokens` 테이블에 저장합니다.
- 저장 시 클라이언트에서 전달한 user id를 신뢰하지 않고, Supabase access token을 직접 검증한 뒤 검증된 `user.id`를 사용합니다.

### Apple token revoke 처리

- 회원탈퇴 시 `delete-user` Edge Function에서 `apple_auth_tokens`에 저장된 Apple `refresh_token`을 조회합니다.
- Apple revoke API를 호출해 Sign in with Apple 연결을 해제합니다.
- 이후 `profiles` row와 Supabase Auth user를 삭제합니다.
- `apple_auth_tokens.user_id`는 `auth.users(id) on delete cascade`로 연결되어 유저 삭제 시 함께 정리됩니다.

### Supabase Edge Function 인증 처리

- Supabase Edge Function의 `Verify JWT` 설정에서 ES256 토큰 검증 오류가 발생해 `verify_jwt = false`로 설정했습니다.
- 대신 함수 내부에서 `Authorization: Bearer <Supabase access token>` 헤더를 직접 읽고 `supabase.auth.getUser(accessToken)`으로 인증을 검증하도록 처리했습니다.

### DB / Edge Function 추가

- `apple_auth_tokens` 테이블 생성 마이그레이션 추가
- Apple token 교환/revoke 공통 로직 `_shared/apple.ts` 추가
- `store-apple-token` Edge Function 추가
- `delete-user` Edge Function에 Apple revoke 로직 추가
- `supabase/config.toml`에 `store-apple-token` 함수 설정 추가


## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?

- [x] Apple 로그인 성공 확인
- [x] `apple_auth_tokens` 테이블에 Apple refresh token 저장 확인
- [x] 회원탈퇴 시 Supabase Auth user 삭제 확인
- [x] `profiles` row 삭제 확인
- [x] `apple_auth_tokens` row 삭제 확인
- [x] 회원탈퇴 후 Apple 재로그인 시 동의 화면 재노출 확인
- [x] Xcode build 성공 확인