### PR TITLE
✨feat: 캘린더 화면 기록 조회 및 필터링 기능 구현

### DIFF
--- a/LeafLog/LeafLog/App/Flows/AppStep.swift
+++ b/LeafLog/LeafLog/App/Flows/AppStep.swift
@@ -28,6 +28,7 @@ enum AppStep: Step {
     case calendarTab
     case myInfoTab
     case profileEdit // 프로필 수정 화면
+    case record(plantID: UUID)
     
     // Global
     case alert(String, String) // (타이틀, 메세지)
@@ -41,7 +42,6 @@ enum AppStep: Step {
     )
     
     case profileImageSourceSheet
-    case record(UUID)
     // 예시용
     case pushButtonTapped
 }

--- a/LeafLog/LeafLog/App/Flows/AppStep.swift
+++ b/LeafLog/LeafLog/App/Flows/AppStep.swift
@@ -6,6 +6,7 @@
 //
 
 import RxFlow
+import Foundation
 
 /*
  - Step: 각 Step은 '앱의 네비게이션 상태(state)'를 의미합니다.
@@ -40,7 +41,7 @@ enum AppStep: Step {
     )
     
     case profileImageSourceSheet
-    
+    case record(UUID)
     // 예시용
     case pushButtonTapped
 }

--- a/LeafLog/LeafLog/App/Flows/CalendarTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/CalendarTabFlow.swift
@@ -21,6 +21,9 @@ final class CalendarTabFlow: Flow {
         switch step {
         case .calendarTab:
             let viewController = CalendarViewController()
+            let reactor = CalendarReactor()
+            
+            viewController.reactor = reactor
             navigationController.pushViewController(viewController, animated: true)
             return .one(flowContributor: .contribute(withNextPresentable: viewController, withNextStepper: viewController))
             

--- a/LeafLog/LeafLog/App/Flows/CalendarTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/CalendarTabFlow.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import RxFlow
+import ReactorKit
 
 final class CalendarTabFlow: Flow {
     private let navigationController = UINavigationController()

--- a/LeafLog/LeafLog/Model/MyPlant.swift
+++ b/LeafLog/LeafLog/Model/MyPlant.swift
@@ -82,7 +82,7 @@ struct PlantUpdateInput {
 }
 
 // MARK: - 앱 내에서 전반적으로 사용할 내 식물 모델
-struct MyPlant: Codable {
+struct MyPlant: Codable, Hashable {
     let id: UUID // 식물 자체 고유 ID
     let userID: UUID
     let category: PlantCategory

--- a/LeafLog/LeafLog/Network/CareRecordDBManager.swift
+++ b/LeafLog/LeafLog/Network/CareRecordDBManager.swift
@@ -69,6 +69,7 @@ final class CareRecordDBManager {
         }
     }
     
+    //MARK: - 특정 기간에 해당하는 관리 기록을 DB에서 불러옴
     func fetchAllCareRecordWithin(start: Date, end: Date, plants: [UUID]) async throws -> [CareRecord] {
         do {
             let startDate = LocalDate(date: start)
@@ -89,7 +90,7 @@ final class CareRecordDBManager {
                 .value
 
         } catch {
-            throw error
+            throw AuthError.careFailed("식물 상태 기록을 불러오지 못했어요: \(error.localizedDescription)")
         }
     }
     

--- a/LeafLog/LeafLog/Network/CareRecordDBManager.swift
+++ b/LeafLog/LeafLog/Network/CareRecordDBManager.swift
@@ -69,6 +69,30 @@ final class CareRecordDBManager {
         }
     }
     
+    func fetchAllCareRecordWithin(start: Date, end: Date, plants: [UUID]) async throws -> [CareRecord] {
+        do {
+            let startDate = LocalDate(date: start)
+            let endDate = LocalDate(date: end)
+            
+            guard !plants.isEmpty else { return [] }
+            let plantIds = plants
+                .map { "\"\($0.uuidString)\"" }
+                        .joined(separator: ",")
+            
+            return try await supabaseManager.client
+                .from("care_records")
+                .select()
+                .gte("record_date", value: startDate.rawValue)
+                .lte("record_date", value: endDate.rawValue)
+                .filter("plant_id", operator: "in", value: "(\(plantIds))")
+                .execute()
+                .value
+
+        } catch {
+            throw error
+        }
+    }
+    
     private struct CareRecordPayload: Encodable {
         let plantID: UUID
         let recordDate: LocalDate

--- a/LeafLog/LeafLog/Util/Custom/SelectionButton.swift
+++ b/LeafLog/LeafLog/Util/Custom/SelectionButton.swift
@@ -27,7 +27,7 @@ final class SelectionButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func setup(title: String) {
+    func setup(title: String) {
         var configuration = UIButton.Configuration.plain()
         configuration.title = title
         configuration.baseForegroundColor = .grayScale500

--- a/LeafLog/LeafLog/View/CalendarView/CalendarCollectionView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarCollectionView.swift
@@ -39,26 +39,16 @@ extension CalendarCollectionView {
             let detailHeaderItem = NSCollectionLayoutBoundarySupplementaryItem(
                 layoutSize: NSCollectionLayoutSize(
                     widthDimension: .fractionalWidth(1),
-                    heightDimension: .absolute(80)
+                    heightDimension: .absolute(48)
                 ),
                 elementKind: "headerKind",
                 alignment: .top
             )
-            
-            let footerItem = NSCollectionLayoutBoundarySupplementaryItem(
-                layoutSize: NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1),
-                    heightDimension: .absolute(52)
-                ),
-                elementKind: "footerKind",
-                alignment: .bottom
-            )
   
             let calendarBackgroundItem = NSCollectionLayoutDecorationItem.background(elementKind: "calendarBackground")
-            calendarBackgroundItem.contentInsets = .init(top: 0, leading: 0, bottom: 52, trailing: 0)
             
             let detailBackgroundItem = NSCollectionLayoutDecorationItem.background(elementKind: "detailBackground")
-            detailBackgroundItem.contentInsets = .init(top: 16, leading: 0, bottom: 8, trailing: 0)
+            detailBackgroundItem.contentInsets = .init(top: 0, leading: 0, bottom: 24, trailing: 0)
             
             switch CalendarView.Section(rawValue: sectionIndex) {
             case .title, .header, .filter:
@@ -67,15 +57,21 @@ extension CalendarCollectionView {
                 
             case .calendar:
                 let section = self?.calendarSectionLayout(environment)
-                section?.boundarySupplementaryItems = [calendarHeaderItem, footerItem]
+                section?.boundarySupplementaryItems = [calendarHeaderItem]
                 section?.decorationItems = [calendarBackgroundItem]
                 section?.contentInsets = .init(top: 0, leading: 24, bottom: 24, trailing: 24)
                 
                 return section
+                
+            case .label:
+                let section = self?.singleItemSectionLayout(height: 64)
+                return section
+                
             default:
                 let section = self?.detailSectionLayout()
                 section?.boundarySupplementaryItems = [detailHeaderItem]
                 section?.decorationItems = [detailBackgroundItem]
+                section?.contentInsets = .init(top: 0, leading: 0, bottom: 24, trailing: 0)
                 
                 return section
             }
@@ -87,17 +83,17 @@ extension CalendarCollectionView {
         return layout
     }
     
-    private func singleItemSectionLayout() -> NSCollectionLayoutSection {
+    private func singleItemSectionLayout(height: CGFloat = 48) -> NSCollectionLayoutSection {
         let item = NSCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1),
-                heightDimension: .absolute(48)
+                heightDimension: .absolute(height)
             ))
         
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1),
-                heightDimension: .absolute(48)),
+                heightDimension: .absolute(height)),
             subitems: [item]
         )
         
@@ -143,7 +139,7 @@ extension CalendarCollectionView {
             subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = .init(top: 0, leading: 0, bottom: 8, trailing: 0)
+        section.contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
         return section
     }
 }

--- a/LeafLog/LeafLog/View/CalendarView/CalendarDateCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarDateCell.swift
@@ -10,6 +10,12 @@ import SnapKit
 import Then
 
 final class CalendarDateCell: UICollectionViewCell {
+    private let selectedView = BaseCardView(cornerRadius: 12).then {
+        $0.backgroundColor = .white
+        $0.layer.borderWidth = 0.5
+        $0.layer.borderColor = UIColor.primary500.cgColor
+        $0.isHidden = true
+    }
     
     private let dateLabel = UILabel(text: "0", config: .label16).then {
         $0.textAlignment = .center
@@ -40,14 +46,25 @@ final class CalendarDateCell: UICollectionViewCell {
         
         dateLabel.textColor = .label
     }
+    
+    override var isSelected: Bool {
+        didSet {
+            selectedView.isHidden = !isSelected
+        }
+    }
 }
 
 extension CalendarDateCell {
     private func setLayout() {
         let badgeStack = generateBadgeStack()
         
+        contentView.addSubview(selectedView)
         contentView.addSubview(dateLabel)
         contentView.addSubview(badgeStack)
+        
+        selectedView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
         
         dateLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(8)
@@ -94,7 +111,7 @@ extension CalendarDateCell {
     func configure(_ data: CalendarView.ManageInfoByDate) {
         dateLabel.text = "\(data.day)"
         dateLabel.textColor =
-        data.currentMonth ? dateLabel.textColor
+        data.isCurrentMonth ? dateLabel.textColor
         : UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
         
         data.badge.prefix(badges.count).enumerated().forEach {

--- a/LeafLog/LeafLog/View/CalendarView/CalendarDateCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarDateCell.swift
@@ -37,6 +37,8 @@ final class CalendarDateCell: UICollectionViewCell {
         badges.forEach {
             $0.image = nil
         }
+        
+        dateLabel.textColor = .label
     }
 }
 

--- a/LeafLog/LeafLog/View/CalendarView/CalendarDateLabelCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarDateLabelCell.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Then
 
-class CalendarDateFooterView: UICollectionReusableView {    
+class CalendarDateLabelCell: UICollectionViewCell {
     let label = UILabel(text: "", config: .label16)
     
     override init(frame: CGRect) {
@@ -19,8 +19,9 @@ class CalendarDateFooterView: UICollectionReusableView {
         
         label.snp.makeConstraints {
 
-            $0.leading.equalToSuperview().offset(-24)
+            $0.leading.equalToSuperview()
             $0.top.equalToSuperview().offset(32)
+            $0.bottom.equalToSuperview().inset(16)
         }
     }
     
@@ -29,7 +30,7 @@ class CalendarDateFooterView: UICollectionReusableView {
     }
 }
 
-extension CalendarDateFooterView {
+extension CalendarDateLabelCell {
     func configure(_ dateString: String) {
         label.text = dateString
     }

--- a/LeafLog/LeafLog/View/CalendarView/CalendarDetailCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarDetailCell.swift
@@ -11,7 +11,7 @@ import Then
 
 final class CalendarDetailCell: UICollectionViewCell {
 
-    private let nameLabel = UILabel(text: "몬스테라", config: .body14)
+    private let nameLabel = UILabel(text: "", config: .body14)
     
     private let colorChip = UIView().then {
         $0.layer.cornerRadius = 4

--- a/LeafLog/LeafLog/View/CalendarView/CalendarDetailHeaderView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarDetailHeaderView.swift
@@ -69,7 +69,7 @@ extension CalendarDetailHeaderView {
 }
 
 extension CalendarDetailHeaderView {
-    func configure(_ manageCategory: CalendarView.Badge) {
+    func configure(_ manageCategory: Badge) {
         badge.image = UIImage(named: manageCategory.bigImage)
         manageLabel.text = manageCategory.rawValue
     }

--- a/LeafLog/LeafLog/View/CalendarView/CalendarDetailHeaderView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarDetailHeaderView.swift
@@ -18,14 +18,7 @@ class CalendarDetailHeaderView: UICollectionReusableView {
         }
     }
     
-    private let manageLabel = UILabel(text: "물주기", config: .title14)
-    
-    //TODO: 추후 colorchip label로 교체 필요
-    private let completeLabel = UILabel().then {
-        $0.text = "완료"
-        $0.backgroundColor = .systemGray
-        $0.layer.cornerRadius = 8
-    }
+    private let manageLabel = UILabel(text: "", config: .title14)
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -50,7 +43,7 @@ extension CalendarDetailHeaderView {
     }
     
     private func generateStackView() -> UIStackView {
-        let stackView = UIStackView(arrangedSubviews: [badge, manageLabel, completeLabel]).then {
+        let stackView = UIStackView(arrangedSubviews: [badge, manageLabel]).then {
             $0.axis = .horizontal
             $0.spacing = 8
             $0.alignment = .center
@@ -62,8 +55,6 @@ extension CalendarDetailHeaderView {
         badge.setContentHuggingPriority(.required, for: .horizontal)
         badge.setContentCompressionResistancePriority(.required, for: .horizontal)
         
-        completeLabel.setContentHuggingPriority(.required, for: .horizontal)
-        completeLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         return stackView
     }
 }

--- a/LeafLog/LeafLog/View/CalendarView/CalendarDetailHeaderView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarDetailHeaderView.swift
@@ -38,7 +38,7 @@ extension CalendarDetailHeaderView {
         
         stackView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.top.equalToSuperview().offset(39)
+            $0.top.equalToSuperview().offset(12)
         }
     }
     

--- a/LeafLog/LeafLog/View/CalendarView/CalendarFilterCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarFilterCell.swift
@@ -35,9 +35,6 @@ extension CalendarFilterCell {
     private func setButtonAttributes() {
         buttons.enumerated().forEach { button in
             button.element.tag = button.offset
-//            button.element.addAction(UIAction { _ in
-//                button.element.isSelected.toggle()
-//            }, for: .touchUpInside)
         }
     }
     

--- a/LeafLog/LeafLog/View/CalendarView/CalendarFilterCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarFilterCell.swift
@@ -10,14 +10,12 @@ import SnapKit
 import Then
 
 final class CalendarFilterCell: UICollectionViewCell {
-    
-    //TODO: 추후 component 교체 필요
+        
     private let buttons = [
-        UIButton(configuration: .plain()),
-        UIButton(configuration: .plain()),
-        UIButton(configuration: .plain()),
-        UIButton(configuration: .plain()),
-        UIButton(configuration: .plain())
+        SelectionButton(title: ""),
+        SelectionButton(title: ""),
+        SelectionButton(title: ""),
+        SelectionButton(title: ""),
     ]
     
     override init(frame: CGRect) {
@@ -33,8 +31,11 @@ final class CalendarFilterCell: UICollectionViewCell {
 
 extension CalendarFilterCell {
     private func setButtonAttributes() {
-        for i in 0..<buttons.count {
-            buttons[i].tag = i
+        buttons.enumerated().forEach { button in
+            button.element.tag = button.offset
+            button.element.addAction(UIAction { _ in
+                button.element.isSelected.toggle()
+            }, for: .touchUpInside)
         }
     }
     
@@ -64,7 +65,7 @@ extension CalendarFilterCell {
     func configure(_ data: [String]) {
         buttons.forEach {
             if $0.tag < data.count {
-                $0.setTitle(data[$0.tag], for: .normal)
+                $0.setup(title: data[$0.tag])
             } else {
                 $0.isHidden = true
             }

--- a/LeafLog/LeafLog/View/CalendarView/CalendarFilterCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarFilterCell.swift
@@ -8,10 +8,12 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 final class CalendarFilterCell: UICollectionViewCell {
         
-    private let buttons = [
+    fileprivate let buttons = [
         SelectionButton(title: ""),
         SelectionButton(title: ""),
         SelectionButton(title: ""),
@@ -33,9 +35,9 @@ extension CalendarFilterCell {
     private func setButtonAttributes() {
         buttons.enumerated().forEach { button in
             button.element.tag = button.offset
-            button.element.addAction(UIAction { _ in
-                button.element.isSelected.toggle()
-            }, for: .touchUpInside)
+//            button.element.addAction(UIAction { _ in
+//                button.element.isSelected.toggle()
+//            }, for: .touchUpInside)
         }
     }
     
@@ -70,5 +72,28 @@ extension CalendarFilterCell {
                 $0.isHidden = true
             }
         }
+    }
+}
+
+extension Reactive where Base: CalendarFilterCell {
+    var filterItemSelected: ControlEvent<[Badge]> {
+        let taps = Observable.merge(
+            base.buttons.map { button in
+                button.rx.tap
+                    .map { [weak base] in
+                        guard let base else { return [Badge]() }
+                        
+                        button.isSelected.toggle()
+                        
+                        return base.buttons.compactMap {
+                            guard $0.isSelected,
+                                  let title = $0.titleLabel?.text else { return nil }
+                            return Badge(rawValue: title)
+                        }
+                    }
+            }
+        )
+        
+        return ControlEvent(events: taps)
     }
 }

--- a/LeafLog/LeafLog/View/CalendarView/CalendarHeaderCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarHeaderCell.swift
@@ -8,14 +8,18 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 final class CalendarHeaderCell: UICollectionViewCell {
-    let previousButton = UIButton(configuration: .plain())
-    let nextButton = UIButton(configuration: .plain())
+    private(set) var disposeBag = DisposeBag()
+    
+    fileprivate let previousButton = UIButton(configuration: .plain())
+    fileprivate let nextButton = UIButton(configuration: .plain())
     
     private var year: Int = 0
     private var month: Int = 0
-    let dateLabel = UILabel(text: "", config: .label16)
+    private let dateLabel = UILabel(text: "", config: .label16)
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -25,6 +29,11 @@ final class CalendarHeaderCell: UICollectionViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
     }
 }
 
@@ -72,3 +81,12 @@ extension CalendarHeaderCell {
     }
 }
 
+extension Reactive where Base: CalendarHeaderCell {
+    var headerPreviousButtonTap: ControlEvent<Void> {
+        base.previousButton.rx.tap
+    }
+    
+    var headerNextButtonTap: ControlEvent<Void> {
+        base.nextButton.rx.tap
+    }
+}

--- a/LeafLog/LeafLog/View/CalendarView/CalendarHeaderCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarHeaderCell.swift
@@ -12,6 +12,9 @@ import Then
 final class CalendarHeaderCell: UICollectionViewCell {
     let previousButton = UIButton(configuration: .plain())
     let nextButton = UIButton(configuration: .plain())
+    
+    private var year: Int = 0
+    private var month: Int = 0
     let dateLabel = UILabel(text: "", config: .label16)
     
     override init(frame: CGRect) {
@@ -64,7 +67,8 @@ extension CalendarHeaderCell {
 }
 
 extension CalendarHeaderCell {
-    func configure(_ string: String) {
-        dateLabel.text = string
+    func configure(year: Int, month: Int) {
+        dateLabel.text = "\(year)년 \(month)월"
     }
 }
+

--- a/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
@@ -63,11 +63,6 @@ extension CalendarView {
             }
         }
         
-        let calendarFooterViewRegistration = UICollectionView.SupplementaryRegistration<CalendarDateFooterView>(elementKind: "footerKind") { supplementaryView, elementKind, indexPath in
-            //TODO: 수정 필요
-            supplementaryView.configure("4월 13일 월요일")
-        }
-        
         let titleCellRegistration = UICollectionView.CellRegistration<CalendarTitleCell, Item> { cell,indexPath,item in
             
         }
@@ -108,6 +103,15 @@ extension CalendarView {
             }
         }
         
+        let dateLabelCellRegistration = UICollectionView.CellRegistration<CalendarDateLabelCell, Item> { cell, indexPath, item in
+            switch item {
+            case .label(let text):
+                cell.configure(text)
+            default:
+                break
+            }
+        }
+        
         let detailCellRegistration = UICollectionView.CellRegistration<CalendarDetailCell, Item> { cell, indexPath, item in
             switch item {
             case .water(let info), .grow(let info), .sprout(let info), .treat(let info):
@@ -125,6 +129,8 @@ extension CalendarView {
                 collectionView.dequeueConfiguredReusableCell(using: headerCellRegistration, for: indexPath, item: item)
             case .filter:
                 collectionView.dequeueConfiguredReusableCell(using: filterCellRegistartion, for: indexPath, item: item)
+            case .label:
+                collectionView.dequeueConfiguredReusableCell(using: dateLabelCellRegistration, for: indexPath, item: item)
             case .calendar:
                 collectionView.dequeueConfiguredReusableCell(using: dateCellRegistration, for: indexPath, item: item)
             case .water, .grow, .sprout, .treat:
@@ -147,9 +153,6 @@ extension CalendarView {
                 default:
                     return collectionView.dequeueConfiguredReusableSupplementary(using: detailHeaderViewRegistration, for: indexPath)
                 }
-                
-            case "footerKind":
-                return collectionView.dequeueConfiguredReusableSupplementary(using: calendarFooterViewRegistration, for: indexPath)
                 
             default:
                 return UICollectionReusableView()
@@ -180,6 +183,7 @@ extension CalendarView {
         case header
         case filter
         case calendar
+        case label
         case water
         case grow
         case sprout
@@ -192,6 +196,7 @@ extension CalendarView {
         case header(Int, Int) // 년, 월
         case filter([String])
         case calendar(ManageInfoByDate)
+        case label(String)
         case water(DetailManageInfo)
         case grow(DetailManageInfo)
         case sprout(DetailManageInfo)

--- a/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
@@ -69,8 +69,8 @@ extension CalendarView {
         
         let headerCellRegistration = UICollectionView.CellRegistration<CalendarHeaderCell, Item> { cell, indexPath, item in
             switch item {
-            case .header(let date):
-                cell.configure(year: 2026, month: 4)
+            case .header(let year, let month):
+                cell.configure(year: year, month: month)
             default:
                 break
             }
@@ -212,7 +212,7 @@ extension CalendarView {
     nonisolated
     enum Item: Hashable {
         case title
-        case header(String)
+        case header(Int, Int) // 년, 월
         case filter([String])
         case calendar(ManageInfoByDate)
         case water(DetailManageInfo)

--- a/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
@@ -231,6 +231,14 @@ extension Reactive where Base: CalendarView {
         base.headerNextButtonTap
     }
     
+    var filterItemSelected: ControlEvent<[Badge]> {
+        let filterItemSelected = base.collectionView.rx.willDisplayCell
+            .compactMap { cell, _ in cell as? CalendarFilterCell }
+            .flatMapLatest { $0.rx.filterItemSelected.asObservable() }
+        
+        return ControlEvent(events: filterItemSelected)
+    }
+    
     var itemSelected: Observable<CalendarView.Item> {
         base.collectionView.rx.itemSelected
             .compactMap {

--- a/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
@@ -208,7 +208,7 @@ extension CalendarView {
 extension CalendarView {
     nonisolated
     struct ManageInfoByDate: Hashable {
-        let currentMonth: Bool // 표시되는 달 여부
+        let isCurrentMonth: Bool // 표시되는 달 여부
         let day: Int
         let date: Date
         let badge: Set<Badge>

--- a/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
@@ -70,7 +70,7 @@ extension CalendarView {
         let headerCellRegistration = UICollectionView.CellRegistration<CalendarHeaderCell, Item> { cell, indexPath, item in
             switch item {
             case .header(let date):
-                cell.configure(date)
+                cell.configure(year: 2026, month: 4)
             default:
                 break
             }
@@ -228,6 +228,7 @@ extension CalendarView {
     struct ManageInfoByDate: Hashable {
         let currentMonth: Bool // 표시되는 달 여부
         let day: Int
+        let date: Date
         let badge: Set<Badge>
     }
     

--- a/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
@@ -8,11 +8,16 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 final class CalendarView: UIView {
     //MARK: properties
-    private let collectionView = CalendarCollectionView()
+    fileprivate let collectionView = CalendarCollectionView()
     private lazy var dataSource = makeCollectionViewDiffableDataSource(collectionView)
+    
+    fileprivate let headerPreviousButtonTap = PublishRelay<Void>()
+    fileprivate let headerNextButtonTap = PublishRelay<Void>()
     
     init() {
         super.init(frame: .zero)
@@ -67,10 +72,19 @@ extension CalendarView {
             
         }
         
-        let headerCellRegistration = UICollectionView.CellRegistration<CalendarHeaderCell, Item> { cell, indexPath, item in
+        let headerCellRegistration = UICollectionView.CellRegistration<CalendarHeaderCell, Item> { [weak self] cell, indexPath, item in
+            guard let self else { return }
             switch item {
             case .header(let year, let month):
                 cell.configure(year: year, month: month)
+                
+                cell.rx.headerPreviousButtonTap
+                    .bind(to: self.headerPreviousButtonTap)
+                    .disposed(by: cell.disposeBag)
+                
+                cell.rx.headerNextButtonTap
+                    .bind(to: self.headerNextButtonTap)
+                    .disposed(by: cell.disposeBag)
             default:
                 break
             }
@@ -133,7 +147,7 @@ extension CalendarView {
                 default:
                     return collectionView.dequeueConfiguredReusableSupplementary(using: detailHeaderViewRegistration, for: indexPath)
                 }
-               
+                
             case "footerKind":
                 return collectionView.dequeueConfiguredReusableSupplementary(using: calendarFooterViewRegistration, for: indexPath)
                 
@@ -141,7 +155,7 @@ extension CalendarView {
                 return UICollectionReusableView()
             }
         }
-
+        
         return dataSource
     }
     
@@ -237,5 +251,15 @@ extension CalendarView {
         let id: UUID // 식물의 uuid
         let name: String // 식물의 이름(별명)
         let badge: Badge
+    }
+}
+
+extension Reactive where Base: CalendarView {
+    var headerPreviousButtonTap: PublishRelay<Void> {
+        base.headerPreviousButtonTap
+    }
+    
+    var headerNextButtonTap: PublishRelay<Void> {
+        base.headerNextButtonTap
     }
 }

--- a/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
@@ -14,7 +14,7 @@ import RxCocoa
 final class CalendarView: UIView {
     //MARK: properties
     fileprivate let collectionView = CalendarCollectionView()
-    private lazy var dataSource = makeCollectionViewDiffableDataSource(collectionView)
+    fileprivate lazy var dataSource = makeCollectionViewDiffableDataSource(collectionView)
     
     fileprivate let headerPreviousButtonTap = PublishRelay<Void>()
     fileprivate let headerNextButtonTap = PublishRelay<Void>()
@@ -173,43 +173,6 @@ extension CalendarView {
     }
 }
 
-//MARK: Badge enum
-//extension CalendarView {
-//    enum Badge: String {
-//        case water = "물주기"
-//        case grow = "분갈이"
-//        case sprout = "비료"
-//        case treat = "치료"
-//        
-//        var smallImage: String {
-//            switch self {
-//            case .water: "badgeWaterSmall"
-//            case .grow: "badgeGrowSmall"
-//            case .sprout: "badgeSproutSmall"
-//            case .treat: "badgeTreatSmall"
-//            }
-//        }
-//        
-//        var bigImage: String {
-//            switch self {
-//            case .water: "badgeWaterBig"
-//            case .grow: "badgeGrowBig"
-//            case .sprout: "badgeSproutBig"
-//            case .treat: "badgeTreatBig"
-//            }
-//        }
-//        
-//        var color: UIColor {
-//            switch self {
-//            case .water: .subBlue
-//            case .grow: .subBrown
-//            case .sprout: .primary600
-//            case .treat: .subRed
-//            }
-//        }
-//    }
-//}
-
 //MARK: CollectionView - Section, Item
 extension CalendarView {
     enum Section: Int {
@@ -261,5 +224,12 @@ extension Reactive where Base: CalendarView {
     
     var headerNextButtonTap: PublishRelay<Void> {
         base.headerNextButtonTap
+    }
+    
+    var itemSelected: Observable<CalendarView.Item> {
+        base.collectionView.rx.itemSelected
+            .compactMap {
+                base.dataSource.itemIdentifier(for: $0)
+            }
     }
 }

--- a/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
@@ -174,41 +174,41 @@ extension CalendarView {
 }
 
 //MARK: Badge enum
-extension CalendarView {
-    enum Badge: String {
-        case water = "물주기"
-        case grow = "분갈이"
-        case sprout = "비료"
-        case treat = "치료"
-        
-        var smallImage: String {
-            switch self {
-            case .water: "badgeWaterSmall"
-            case .grow: "badgeGrowSmall"
-            case .sprout: "badgeSproutSmall"
-            case .treat: "badgeTreatSmall"
-            }
-        }
-        
-        var bigImage: String {
-            switch self {
-            case .water: "badgeWaterBig"
-            case .grow: "badgeGrowBig"
-            case .sprout: "badgeSproutBig"
-            case .treat: "badgeTreatBig"
-            }
-        }
-        
-        var color: UIColor {
-            switch self {
-            case .water: .subBlue
-            case .grow: .subBrown
-            case .sprout: .primary600
-            case .treat: .subRed
-            }
-        }
-    }
-}
+//extension CalendarView {
+//    enum Badge: String {
+//        case water = "물주기"
+//        case grow = "분갈이"
+//        case sprout = "비료"
+//        case treat = "치료"
+//        
+//        var smallImage: String {
+//            switch self {
+//            case .water: "badgeWaterSmall"
+//            case .grow: "badgeGrowSmall"
+//            case .sprout: "badgeSproutSmall"
+//            case .treat: "badgeTreatSmall"
+//            }
+//        }
+//        
+//        var bigImage: String {
+//            switch self {
+//            case .water: "badgeWaterBig"
+//            case .grow: "badgeGrowBig"
+//            case .sprout: "badgeSproutBig"
+//            case .treat: "badgeTreatBig"
+//            }
+//        }
+//        
+//        var color: UIColor {
+//            switch self {
+//            case .water: .subBlue
+//            case .grow: .subBrown
+//            case .sprout: .primary600
+//            case .treat: .subRed
+//            }
+//        }
+//    }
+//}
 
 //MARK: CollectionView - Section, Item
 extension CalendarView {

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -48,7 +48,7 @@ class CalendarViewController: BaseViewController, View {
             .compactMap { item in
                 switch item {
                 case .calendar(let data):
-                    return CalendarReactor.Action.viewWillAppear
+                    return CalendarReactor.Action.dateSelected(data.date)
                 default:
                     return nil
                 }

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -98,3 +98,8 @@ extension CalendarView.ManageInfoByDate {
 }
 
 
+//MARK: CameraClassificationViewController Preview
+@available(iOS 17.0, *)
+#Preview {
+  CalendarViewController()
+}

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -34,6 +34,16 @@ class CalendarViewController: BaseViewController, View {
             .map { _ in CalendarReactor.Action.viewWillAppear}
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        calendarView.rx.headerPreviousButtonTap
+            .map { _ in CalendarReactor.Action.previousMonth }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        calendarView.rx.headerNextButtonTap
+            .map { _ in CalendarReactor.Action.nextMonth }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
     }
     
     private func bindState(reactor: CalendarReactor) {

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -43,6 +43,18 @@ class CalendarViewController: BaseViewController, View {
             .map { _ in CalendarReactor.Action.nextMonth }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        calendarView.rx.itemSelected
+            .compactMap { item in
+                switch item {
+                case .calendar(let data):
+                    return CalendarReactor.Action.viewWillAppear
+                default:
+                    return nil
+                }
+            }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
     }
     
     private func bindState(reactor: CalendarReactor) {

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -64,39 +64,15 @@ class CalendarViewController: BaseViewController, View {
                 self?.calendarView.setSnapshot(data)
             })
             .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$errorMessage)
+            .compactMap { $0 }
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(onNext: { [weak self] message in
+                self?.steps.accept(AppStep.alert("에러", message))
+            })
+            .disposed(by: disposeBag)
     }
-}
-
-extension CalendarViewController {
-//    private func setSample() {
-//        let monthlyData = CalendarView.ManageInfoByDate.generateMonthlySampleData()
-//        let calendarData = monthlyData.map {
-//            CalendarView.Item.calendar($0)
-//        }
-//
-//        // 1. Water 아이템 예시 (물을 준 식물 정보)
-//        let treatItem: [CalendarView.Item] = [
-//            .water(CalendarView.DetailManageInfo(id: UUID(), name: "행운목", badge: .treat)),
-//            .water(CalendarView.DetailManageInfo(id: UUID(), name: "스투키", badge: .treat)),
-//        ]
-//
-//        // 2. Grow 아이템 예시 (성장 기록이 있는 식물 정보)
-//        let growItem: [CalendarView.Item] = [
-//            .grow(CalendarView.DetailManageInfo(id: UUID(), name: "선인장", badge: .grow)),
-//            .grow(CalendarView.DetailManageInfo(id: UUID(), name: "다육이", badge: .grow))
-//        ]
-//        
-//        let data: [CalendarView.Section: [CalendarView.Item]] = [
-//            .title: [.title],
-//            .header: [.header("2026년 4월")],
-//            .filter: [.filter(["전체", "물주기", "분갈이", "비료", "치료"])],
-//            .calendar: calendarData,
-//            .grow: growItem,
-//            .treat: treatItem
-//        ]
-//        
-//        calendarView.setSnapshot(data)
-//    }
 }
 
 //MARK: CameraClassificationViewController Preview

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -70,7 +70,7 @@ class CalendarViewController: BaseViewController, View {
             .compactMap { item -> AppStep? in
                 switch item {
                 case .water(let data), .grow(let data), .sprout(let data), .treat(let data):
-                    return AppStep.record(data.id)
+                    return AppStep.record(plantID: data.id)
                 default:
                     return nil
                 }

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -20,7 +20,7 @@ class CalendarViewController: BaseViewController, View {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setSample()
+//        setSample()
     }
     
     // MARK: - Bind
@@ -37,82 +37,87 @@ class CalendarViewController: BaseViewController, View {
     }
     
     private func bindState(reactor: CalendarReactor) {
-        
+        reactor.state
+            .map { $0.data }
+            .subscribe(onNext: { [weak self] data in
+                self?.calendarView.setSnapshot(data)
+            })
+            .disposed(by: disposeBag)
     }
 }
 
 extension CalendarViewController {
-    private func setSample() {
-        let monthlyData = CalendarView.ManageInfoByDate.generateMonthlySampleData()
-        let calendarData = monthlyData.map {
-            CalendarView.Item.calendar($0)
-        }
-
-        // 1. Water 아이템 예시 (물을 준 식물 정보)
-        let treatItem: [CalendarView.Item] = [
-            .water(CalendarView.DetailManageInfo(id: UUID(), name: "행운목", badge: .treat)),
-            .water(CalendarView.DetailManageInfo(id: UUID(), name: "스투키", badge: .treat)),
-        ]
-
-        // 2. Grow 아이템 예시 (성장 기록이 있는 식물 정보)
-        let growItem: [CalendarView.Item] = [
-            .grow(CalendarView.DetailManageInfo(id: UUID(), name: "선인장", badge: .grow)),
-            .grow(CalendarView.DetailManageInfo(id: UUID(), name: "다육이", badge: .grow))
-        ]
-        
-        let data: [CalendarView.Section: [CalendarView.Item]] = [
-            .title: [.title],
-            .header: [.header("2026년 4월")],
-            .filter: [.filter(["전체", "물주기", "분갈이", "비료", "치료"])],
-            .calendar: calendarData,
-            .grow: growItem,
-            .treat: treatItem
-        ]
-        
-        calendarView.setSnapshot(data)
-    }
+//    private func setSample() {
+//        let monthlyData = CalendarView.ManageInfoByDate.generateMonthlySampleData()
+//        let calendarData = monthlyData.map {
+//            CalendarView.Item.calendar($0)
+//        }
+//
+//        // 1. Water 아이템 예시 (물을 준 식물 정보)
+//        let treatItem: [CalendarView.Item] = [
+//            .water(CalendarView.DetailManageInfo(id: UUID(), name: "행운목", badge: .treat)),
+//            .water(CalendarView.DetailManageInfo(id: UUID(), name: "스투키", badge: .treat)),
+//        ]
+//
+//        // 2. Grow 아이템 예시 (성장 기록이 있는 식물 정보)
+//        let growItem: [CalendarView.Item] = [
+//            .grow(CalendarView.DetailManageInfo(id: UUID(), name: "선인장", badge: .grow)),
+//            .grow(CalendarView.DetailManageInfo(id: UUID(), name: "다육이", badge: .grow))
+//        ]
+//        
+//        let data: [CalendarView.Section: [CalendarView.Item]] = [
+//            .title: [.title],
+//            .header: [.header("2026년 4월")],
+//            .filter: [.filter(["전체", "물주기", "분갈이", "비료", "치료"])],
+//            .calendar: calendarData,
+//            .grow: growItem,
+//            .treat: treatItem
+//        ]
+//        
+//        calendarView.setSnapshot(data)
+//    }
 }
 
 // MARK: - Sample Data Generation
 extension CalendarView.ManageInfoByDate {
-    static func generateMonthlySampleData() -> [CalendarView.ManageInfoByDate] {
-        var samples: [CalendarView.ManageInfoByDate] = []
-        let allBadges: [CalendarView.Badge] = [.grow, .sprout, .water, .treat]
-        
-        // 1. 이전 달 데이터 (말일 며칠)
-        for d in 28...31 {
-            samples.append(CalendarView.ManageInfoByDate(
-                currentMonth: false,
-                day: d,
-                badge: [] // 빈 Set
-            ))
-        }
-        
-        // 2. 이번 달 데이터 (1일 ~ 30일)
-        for d in 1...30 {
-            // 0~4개 사이의 랜덤한 개수 선택
-            let randomCount = Int.random(in: 0...4)
-            // 배지를 무작위로 섞어서 필요한 개수만큼 추출하여 Set으로 생성
-            let randomBadges = Set(allBadges.shuffled().prefix(randomCount))
-            
-            samples.append(CalendarView.ManageInfoByDate(
-                currentMonth: true,
-                day: d,
-                badge: randomBadges
-            ))
-        }
-        
-        // 3. 다음 달 데이터 (초순 며칠)
-        for d in 1...5 {
-            samples.append(CalendarView.ManageInfoByDate(
-                currentMonth: false,
-                day: d,
-                badge: [] // 빈 Set
-            ))
-        }
-        
-        return samples
-    }
+//    static func generateMonthlySampleData() -> [CalendarView.ManageInfoByDate] {
+//        var samples: [CalendarView.ManageInfoByDate] = []
+//        let allBadges: [CalendarView.Badge] = [.grow, .sprout, .water, .treat]
+//        
+//        // 1. 이전 달 데이터 (말일 며칠)
+//        for d in 28...31 {
+//            samples.append(CalendarView.ManageInfoByDate(
+//                currentMonth: false,
+//                day: d,
+//                badge: [] // 빈 Set
+//            ))
+//        }
+//        
+//        // 2. 이번 달 데이터 (1일 ~ 30일)
+//        for d in 1...30 {
+//            // 0~4개 사이의 랜덤한 개수 선택
+//            let randomCount = Int.random(in: 0...4)
+//            // 배지를 무작위로 섞어서 필요한 개수만큼 추출하여 Set으로 생성
+//            let randomBadges = Set(allBadges.shuffled().prefix(randomCount))
+//            
+//            samples.append(CalendarView.ManageInfoByDate(
+//                currentMonth: true,
+//                day: d,
+//                badge: randomBadges
+//            ))
+//        }
+//        
+//        // 3. 다음 달 데이터 (초순 며칠)
+//        for d in 1...5 {
+//            samples.append(CalendarView.ManageInfoByDate(
+//                currentMonth: false,
+//                day: d,
+//                badge: [] // 빈 Set
+//            ))
+//        }
+//        
+//        return samples
+//    }
 }
 
 

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -10,7 +10,7 @@ import SnapKit
 import ReactorKit
 import Then
 
-class CalendarViewController: BaseViewController {
+class CalendarViewController: BaseViewController, View {
     private let calendarView = CalendarView()
     
     override func loadView() {
@@ -20,6 +20,22 @@ class CalendarViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setSample()
+    }
+    
+    // MARK: - Bind
+    func bind(reactor: CalendarReactor) {
+        bindAction(reactor: reactor)
+        bindState(reactor: reactor)
+    }
+    
+    
+    private func bindAction(reactor: CalendarReactor) {
+        
+    }
+    
+    
+    private func bindState(reactor: CalendarReactor) {
+        
     }
 }
 

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -52,8 +52,10 @@ class CalendarViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        calendarView.rx.itemSelected
-            .compactMap { item in
+        let itemSelected: Observable<CalendarView.Item> = calendarView.rx.itemSelected.share()
+                
+        itemSelected
+            .compactMap { item -> CalendarReactor.Action? in
                 switch item {
                 case .calendar(let data):
                     return CalendarReactor.Action.dateSelected(data.date)
@@ -62,6 +64,18 @@ class CalendarViewController: BaseViewController, View {
                 }
             }
             .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        itemSelected
+            .compactMap { item -> AppStep? in
+                switch item {
+                case .water(let data), .grow(let data), .sprout(let data), .treat(let data):
+                    return AppStep.record(data.id)
+                default:
+                    return nil
+                }
+            }
+            .bind(to: steps)
             .disposed(by: disposeBag)
     }
     

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -44,6 +44,14 @@ class CalendarViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        calendarView.rx.filterItemSelected
+            .map { filterArray in
+                let filters = Set(filterArray)
+                return CalendarReactor.Action.updateFilter(filters)
+            }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         calendarView.rx.itemSelected
             .compactMap { item in
                 switch item {

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -20,7 +20,6 @@ class CalendarViewController: BaseViewController, View {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-//        setSample()
     }
     
     // MARK: - Bind
@@ -87,49 +86,6 @@ extension CalendarViewController {
 //        calendarView.setSnapshot(data)
 //    }
 }
-
-// MARK: - Sample Data Generation
-extension CalendarView.ManageInfoByDate {
-//    static func generateMonthlySampleData() -> [CalendarView.ManageInfoByDate] {
-//        var samples: [CalendarView.ManageInfoByDate] = []
-//        let allBadges: [CalendarView.Badge] = [.grow, .sprout, .water, .treat]
-//        
-//        // 1. 이전 달 데이터 (말일 며칠)
-//        for d in 28...31 {
-//            samples.append(CalendarView.ManageInfoByDate(
-//                currentMonth: false,
-//                day: d,
-//                badge: [] // 빈 Set
-//            ))
-//        }
-//        
-//        // 2. 이번 달 데이터 (1일 ~ 30일)
-//        for d in 1...30 {
-//            // 0~4개 사이의 랜덤한 개수 선택
-//            let randomCount = Int.random(in: 0...4)
-//            // 배지를 무작위로 섞어서 필요한 개수만큼 추출하여 Set으로 생성
-//            let randomBadges = Set(allBadges.shuffled().prefix(randomCount))
-//            
-//            samples.append(CalendarView.ManageInfoByDate(
-//                currentMonth: true,
-//                day: d,
-//                badge: randomBadges
-//            ))
-//        }
-//        
-//        // 3. 다음 달 데이터 (초순 며칠)
-//        for d in 1...5 {
-//            samples.append(CalendarView.ManageInfoByDate(
-//                currentMonth: false,
-//                day: d,
-//                badge: [] // 빈 Set
-//            ))
-//        }
-//        
-//        return samples
-//    }
-}
-
 
 //MARK: CameraClassificationViewController Preview
 @available(iOS 17.0, *)

--- a/LeafLog/LeafLog/View/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 import ReactorKit
 import Then
+import RxCocoa
 
 class CalendarViewController: BaseViewController, View {
     private let calendarView = CalendarView()
@@ -28,11 +29,12 @@ class CalendarViewController: BaseViewController, View {
         bindState(reactor: reactor)
     }
     
-    
     private func bindAction(reactor: CalendarReactor) {
-        
+        self.rx.viewWillAppear
+            .map { _ in CalendarReactor.Action.viewWillAppear}
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
     }
-    
     
     private func bindState(reactor: CalendarReactor) {
         

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -33,11 +33,15 @@ final class CalendarReactor: Reactor {
     
     //MARK: properties
     private let calendar = Calendar.current
+    @Dependency(\.plantDBManager) private var plantDBManager
+    @Dependency(\.careRecordDBManager) private var careRecordDBManager
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewWillAppear:
-            return calendarDates(of: Date())
+            return Observable.concat([
+                calendarDates(of: Date()),
+                ])
             
         case .previousMonth:
             return moveMonthTo(.previous)
@@ -81,54 +85,69 @@ extension CalendarReactor {
         Observable.create { [weak self] observer in
             guard let self else { return Disposables.create() }
             
-            let current = currentState.benchmarkDate
-            guard let currentBenchmark = calendar.dateInterval(of: .month, for: current)?.start else { return Disposables.create() }
-            
-            switch move {
+            let benchmark = switch move {
             case .previous:
-                guard let previous = calendar.date(byAdding: .month, value: -1, to: currentBenchmark),
-                      let year = calendar.dateComponents([.year, .month], from: previous).year,
-                      let month = calendar.dateComponents([.year, .month], from: previous).month else { return Disposables.create() }
-                
-                let dates = self.calculateDates(of: previous)
-                let items = datesConvertToItems(currentMonth: month, dates)
-                
-                observer.onNext(.calendarDates(previous, year, month, items))
-                observer.onCompleted()
+                benchmarkDate(of: currentState.benchmarkDate, moveTo: .previous)
             case .next:
-                guard let next = calendar.date(byAdding: .month, value: +1, to: currentBenchmark),
-                      let year = calendar.dateComponents([.year, .month], from: next).year,
-                      let month = calendar.dateComponents([.year, .month], from: next).month else { return Disposables.create() }
-                
-                let dates = self.calculateDates(of: next)
-                let items = datesConvertToItems(currentMonth: month, dates)
-                
-                observer.onNext(.calendarDates(next, year, month, items))
-                observer.onCompleted()
+                benchmarkDate(of: currentState.benchmarkDate, moveTo: .next)
+            case .none:
+                currentState.benchmarkDate
             }
+            
+            let dateComp = calendar.dateComponents([.year, .month], from: benchmark)
+            guard let year = dateComp.year,
+                  let month = dateComp.month else { return Disposables.create() }
+            
+            let dates = self.calculateDates(of: benchmark)
+            let items = self.datesConvertToItems(currentMonth: month, dates)
+            
+            observer.onNext(.calendarDates(benchmark, year, month, items))
+            observer.onCompleted()
             
             return Disposables.create()
         }
     }
+    
 }
 
 extension CalendarReactor {
-    private func calculateDates(of date: Date) -> [Date] {
+    private func benchmarkDate(of date: Date, moveTo: MoveMonth) -> Date {
+        switch moveTo {
+        case .none:
+            return date
+        case .previous:
+            guard let previous = calendar.date(byAdding: .month, value: -1, to: date) else { return date }
+            
+            return previous
+        case .next:
+            guard let next = calendar.date(byAdding: .month, value: 1, to: date) else { return date }
+            
+            return next
+        }
+    }
+    
+    private func calendarRange(of date: Date) -> (start: Date, end: Date)? {
         guard let monthInterval = calendar.dateInterval(of: .month, for: date),
               let end = calendar.date(byAdding: .day, value: -1, to: monthInterval.end),
               let startWeekday = calendar.dateComponents([.weekday], from: monthInterval.start).weekday,
-              let endWeekday = calendar.dateComponents([.weekday], from: end).weekday else { return [] }
+              let endWeekday = calendar.dateComponents([.weekday], from: end).weekday else { return nil }
         
         let pastFromMonday = (startWeekday + 5) % 7 // 첫 주에서 월요일까지 필요한 날짜 수
         let addToSunday = 6 - ((endWeekday + 5) % 7) // 마지막 주에서 일요일까지 필요한 날짜 수
         
         guard let startDate = calendar.date(byAdding: .day, value: -pastFromMonday, to: monthInterval.start),
-              let endDate = calendar.date(byAdding: .day, value: addToSunday, to: end) else { return [] }
+              let endDate = calendar.date(byAdding: .day, value: addToSunday, to: end) else { return nil }
+        
+        return (start: startDate, end: endDate)
+    }
+    
+    private func calculateDates(of date: Date) -> [Date] {
+        guard let range = calendarRange(of: date) else { return [] }
         
         var dates: [Date] = []
-        var current = startDate
+        var current = range.start
         
-        while current <= endDate {
+        while current <= range.end {
             dates.append(current)
             
             guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
@@ -159,11 +178,18 @@ extension CalendarReactor {
             return $0 + [item]
         }
     }
+    
+//    private func plantRecords(within start: Date, _ end: Date) -> [MyPlant] {
+//        do {
+//            let records = await careRecordDBManager.fetchAllCareRecordWithin(start: start, end: end, plants: <#T##[UUID]#>)
+//        }
+//    }
 }
 
 extension CalendarReactor {
     enum MoveMonth {
         case previous
         case next
+        case none
     }
 }

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -19,6 +19,8 @@ final class CalendarReactor: Reactor {
     
     enum Mutation {
         case calendarDates(Date, Int, Int, [CalendarView.Item]) // (기준 일자, 년, 월, [일])
+        case calendarRecords([CareRecord])
+        case error(String)
     }
     
     struct State {
@@ -39,8 +41,10 @@ final class CalendarReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewWillAppear:
+            let benchmark = currentState.benchmarkDate
             return Observable.concat([
-                calendarDates(of: Date()),
+                calendarDates(of: benchmark),
+                calendarCareRecords(of: benchmark)
                 ])
             
         case .previousMonth:
@@ -57,6 +61,12 @@ final class CalendarReactor: Reactor {
             newState.benchmarkDate = benchmark
             newState.data[.header] = [CalendarView.Item.header(year, month)]
             newState.data[.calendar] = calendarItems
+            
+        case .calendarRecords(let records):
+            print("calendarRecord Count: ", records.count)
+            print("calendarRecordMutation: ", records)
+        case .error(let message):
+            print("errorMutation: ", message)
         }
         return newState
     }
@@ -108,6 +118,27 @@ extension CalendarReactor {
         }
     }
     
+    private func calendarCareRecords(of date: Date) -> Observable<Mutation> {
+        Observable.create { [weak self] observer in
+            guard let self,
+                  let calendarRange = calendarRange(of: date) else {
+                return Disposables.create()
+            }
+
+            Task {
+                do {
+                    let records = try await self.plantRecords(within: calendarRange.start, calendarRange.end)
+                    
+                    observer.onNext(.calendarRecords(records))
+                    observer.onCompleted()
+                } catch {
+                    observer.onNext(.error("식물 기록을 가져올 수 없습니다."))
+                    observer.onCompleted()
+                }
+            }
+            return Disposables.create()
+        }
+    }
 }
 
 extension CalendarReactor {
@@ -179,11 +210,17 @@ extension CalendarReactor {
         }
     }
     
-//    private func plantRecords(within start: Date, _ end: Date) -> [MyPlant] {
-//        do {
-//            let records = await careRecordDBManager.fetchAllCareRecordWithin(start: start, end: end, plants: <#T##[UUID]#>)
-//        }
-//    }
+    private func plantRecords(within start: Date, _ end: Date) async throws -> [CareRecord] {
+        do {
+            let plants = try await plantDBManager.fetchMyPlants()
+            
+            let records = try await careRecordDBManager.fetchAllCareRecordWithin(start: start, end: end, plants: plants.map { $0.id })
+            
+            return records
+        } catch {
+            throw error
+        }
+    }
 }
 
 extension CalendarReactor {

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -18,10 +18,9 @@ final class CalendarReactor: Reactor {
     }
     
     enum Mutation {
+        case updateBenchmarkDate(Date)
         case setCalendarHeader(Int, Int) // 년, 월
         case setCalendarItem([CalendarView.Item])
-        case calendarDates(Date, Int, Int, [CalendarView.Item]) // (기준 일자, 년, 월, [일])
-        case calendarRecords([CareRecord])
         case error(String)
     }
     
@@ -45,6 +44,7 @@ final class CalendarReactor: Reactor {
         case .viewWillAppear:
             let benchmark = currentState.benchmarkDate
             return Observable.concat([
+                .just(.updateBenchmarkDate(benchmark)),
                 calendarHeaderItem(of: benchmark),
                 calendarItems(of: benchmark)
             ])
@@ -52,6 +52,7 @@ final class CalendarReactor: Reactor {
         case .previousMonth:
             let benchmark = benchmarkDate(of: currentState.benchmarkDate, moveTo: .previous)
             return Observable.concat([
+                .just(.updateBenchmarkDate(benchmark)),
                 calendarHeaderItem(of: benchmark),
                 calendarItems(of: benchmark)
             ])
@@ -59,6 +60,7 @@ final class CalendarReactor: Reactor {
         case .nextMonth:
             let benchmark = benchmarkDate(of: currentState.benchmarkDate, moveTo: .next)
             return Observable.concat([
+                .just(.updateBenchmarkDate(benchmark)),
                 calendarHeaderItem(of: benchmark),
                 calendarItems(of: benchmark)
             ])
@@ -67,21 +69,17 @@ final class CalendarReactor: Reactor {
     func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         switch mutation {
+        case .updateBenchmarkDate(let benchmark):
+            newState.benchmarkDate = benchmark
+            
         case .setCalendarHeader(let year, let month):
             newState.data[.header] = [CalendarView.Item.header(year, month)]
             
         case .setCalendarItem(let items):
             newState.data[.calendar] = items
             
-        case .calendarDates(let benchmark, let year, let month, let calendarItems):
-            newState.benchmarkDate = benchmark
-            newState.data[.calendar] = calendarItems
-            
-        case .calendarRecords(let records):
-            print("calendarRecord Count: ", records.count)
-            print("calendarRecordMutation: ", records)
         case .error(let message):
-            print("errorMutation: ", message)
+            print(message)
         }
         return newState
     }
@@ -119,97 +117,6 @@ extension CalendarReactor {
             return Disposables.create() {
                 task.cancel()
             }
-        }
-    }
-    
-    private func calendarDates(of date: Date) -> Observable<Mutation> {
-        Observable.create { [weak self] observer in
-            guard let self else { return Disposables.create() }
-            
-            let dateComp = calendar.dateComponents([.year, .month], from: date)
-            guard let year = dateComp.year,
-                  let month = dateComp.month else { return Disposables.create() }
-            
-            Task {
-                let records = try await self.plantRecords(of: date)
-                let dates = self.calculateDates(of: date)
-                let items = self.datesConvertToItems(current: date, dates, records: records)
-                
-                observer.onNext(.calendarDates(date, year, month, items))
-                observer.onCompleted()
-            }
-            
-            return Disposables.create()
-        }
-    }
-    
-//    private func calendarDates(of date: Date) -> Observable<Mutation> {
-//        Observable.create { [weak self] observer in
-//            guard let self else { return Disposables.create() }
-//            
-//            let dateComp = self.calendar.dateComponents([.year, .month], from: date)
-//            guard let year = dateComp.year,
-//                  let month = dateComp.month else { return Disposables.create() }
-//            
-//            let dates = self.calculateDates(of: date)
-//            let items = datesConvertToItems(currentMonth: month, dates)
-//            
-//            observer.onNext(.calendarDates(date, year, month, items))
-//            observer.onCompleted()
-//            
-//            return Disposables.create()
-//        }
-//    }
-    
-//    private func moveMonthTo(_ move: MoveMonth) -> Observable<Mutation> {
-//        Observable.create { [weak self] observer in
-//            guard let self else { return Disposables.create() }
-//            
-//            let benchmark = switch move {
-//            case .previous:
-//                benchmarkDate(of: currentState.benchmarkDate, moveTo: .previous)
-//            case .next:
-//                benchmarkDate(of: currentState.benchmarkDate, moveTo: .next)
-//            case .none:
-//                currentState.benchmarkDate
-//            }
-//            
-//            let dateComp = calendar.dateComponents([.year, .month], from: benchmark)
-//            guard let year = dateComp.year,
-//                  let month = dateComp.month else { return Disposables.create() }
-//            
-//            Task {
-//                let records = try await self.plantRecords(of: benchmark)
-//                let dates = self.calculateDates(of: benchmark)
-//                let items = self.datesConvertToItems(current: benchmark, dates, records: records)
-//                
-//                observer.onNext(.calendarDates(benchmark, year, month, items))
-//                observer.onCompleted()
-//            }
-//            
-//            return Disposables.create()
-//        }
-//    }
-    
-    private func calendarCareRecords(of date: Date) -> Observable<Mutation> {
-        Observable.create { [weak self] observer in
-            guard let self,
-                  let calendarRange = calendarRange(of: date) else {
-                return Disposables.create()
-            }
-            
-            Task {
-                do {
-                    let records = try await self.plantRecords(of: date)
-                    
-                    observer.onNext(.calendarRecords(records))
-                    observer.onCompleted()
-                } catch {
-                    observer.onNext(.error("식물 기록을 가져올 수 없습니다."))
-                    observer.onCompleted()
-                }
-            }
-            return Disposables.create()
         }
     }
 }

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -16,11 +16,13 @@ final class CalendarReactor: Reactor {
         case previousMonth
         case nextMonth
         
+        case updateFilter(Set<Badge>)
         case dateSelected(Date)
     }
     
     enum Mutation {
         case updateBenchmarkDate(Date)
+        case updateFilters(Set<Badge>)
         
         case setCalendarHeader(Int, Int) // 년, 월
         case setCalendarItem([CalendarView.Item])
@@ -36,9 +38,10 @@ final class CalendarReactor: Reactor {
     
     struct State {
         var benchmarkDate: Date = Date()
+        var filters: Set<Badge> = []
         var data: [CalendarView.Section: [CalendarView.Item]] = [
             .title: [.title],
-            .filter: [.filter(["물주기", "분갈이", "비료", "치료"])]
+            .filter: [.filter([Badge.water.rawValue, Badge.grow.rawValue, Badge.sprout.rawValue, Badge.treat.rawValue])]
         ]
         @Pulse var errorMessage: String? = nil
     }
@@ -54,27 +57,41 @@ final class CalendarReactor: Reactor {
         switch action {
         case .viewWillAppear:
             let benchmark = currentState.benchmarkDate
+            let filters = currentState.filters
+            
             return Observable.concat([
                 .just(.updateBenchmarkDate(benchmark)),
                 calendarHeaderItem(of: benchmark),
-                calendarItems(of: benchmark)
+                calendarItems(of: benchmark, filters: filters)
             ])
             
         case .previousMonth:
             let benchmark = benchmarkDate(of: currentState.benchmarkDate, moveTo: .previous)
+            let filters = currentState.filters
+            
             return Observable.concat([
                 .just(.updateBenchmarkDate(benchmark)),
                 calendarHeaderItem(of: benchmark),
-                calendarItems(of: benchmark)
+                calendarItems(of: benchmark, filters: filters)
             ])
             
         case .nextMonth:
             let benchmark = benchmarkDate(of: currentState.benchmarkDate, moveTo: .next)
+            let filters = currentState.filters
+            
             return Observable.concat([
                 .just(.updateBenchmarkDate(benchmark)),
                 calendarHeaderItem(of: benchmark),
-                calendarItems(of: benchmark)
+                calendarItems(of: benchmark, filters: filters)
             ])
+            
+        case .updateFilter(let filters):
+            let benchmark = currentState.benchmarkDate
+
+            return Observable.concat([
+                .just(.updateFilters(filters)),
+                calendarItems(of: benchmark, filters: filters)
+                ])
             
         case .dateSelected(let date):
             return detailItmes(of: date)
@@ -85,6 +102,9 @@ final class CalendarReactor: Reactor {
         switch mutation {
         case .updateBenchmarkDate(let benchmark):
             newState.benchmarkDate = benchmark
+            
+        case .updateFilters(let filters):
+            newState.filters = filters
             
         case .setCalendarHeader(let year, let month):
             newState.data[.header] = [CalendarView.Item.header(year, month)]
@@ -131,14 +151,14 @@ extension CalendarReactor {
         }
     }
     
-    private func calendarItems(of date: Date) -> Observable<Mutation> {
+    private func calendarItems(of date: Date, filters: Set<Badge>) -> Observable<Mutation> {
         Observable.create { [weak self] observer in
             guard let self else { return Disposables.create() }
             let task = Task {
                 do {
                     let dates = self.calculateDates(of: date) // 달력에 표시될 날짜들
                     let records = try await self.monthlyPlantRecords(of: date) // 달력 범위의 기록들
-                    let items = self.datesConvertToItems(current: date, dates, records: records) // 컬렉션뷰에 표시될 아이템
+                    let items = self.datesConvertToItems(current: date, dates, records: records, filters: filters) // 컬렉션뷰에 표시될 아이템
                     
                     observer.onNext(.setCalendarItem(items))
                     observer.onCompleted()
@@ -244,7 +264,7 @@ extension CalendarReactor {
         return dates
     }
     
-    private func datesConvertToItems(current: Date, _ dates: [Date], records: [CareRecord]) -> [CalendarView.Item] {
+    private func datesConvertToItems(current: Date, _ dates: [Date], records: [CareRecord], filters: Set<Badge>) -> [CalendarView.Item] {
         guard let currentMonth = calendar.dateComponents([.month], from: current).month else { return [] }
         
         // 날짜별로 기록 데이터 분류
@@ -270,13 +290,21 @@ extension CalendarReactor {
                     // 모든 뱃지가 존재할 경우
                     if badges.count == 4 { break }
                     
-                    if record.watered { badges.insert(Badge.water) }
+                    if record.watered && (filters.contains(Badge.water) || filters.isEmpty) {
+                        badges.insert(Badge.water)
+                    }
                     
-                    if record.repotted { badges.insert(Badge.grow) }
+                    if record.repotted && (filters.contains(Badge.grow) || filters.isEmpty) {
+                        badges.insert(Badge.grow)
+                    }
                     
-                    if record.fertilized { badges.insert(Badge.sprout) }
+                    if record.fertilized && (filters.contains(Badge.sprout) || filters.isEmpty) {
+                        badges.insert(Badge.sprout)
+                    }
                     
-                    if record.treated { badges.insert(Badge.treat) }
+                    if record.treated && (filters.contains(Badge.treat) || filters.isEmpty) {
+                        badges.insert(Badge.treat)
+                    }
                 }
             }
             

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -28,7 +28,7 @@ final class CalendarReactor: Reactor {
         var benchmarkDate: Date = Date()
         var data: [CalendarView.Section: [CalendarView.Item]] = [
             .title: [.title],
-            .filter: [.filter(["전체", "물주기", "분갈이", "비료", "치료"])]
+            .filter: [.filter(["물주기", "분갈이", "비료", "치료"])]
         ]
     }
     

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -21,13 +21,16 @@ final class CalendarReactor: Reactor {
     
     enum Mutation {
         case updateBenchmarkDate(Date)
+        
         case setCalendarHeader(Int, Int) // 년, 월
         case setCalendarItem([CalendarView.Item])
         case setLabelItem([CalendarView.Item])
+        
         case setDetailWaterItem([CalendarView.Item])
         case setDetailGrowItem([CalendarView.Item])
         case setDetailSproutItem([CalendarView.Item])
         case setDetailTreatItem([CalendarView.Item])
+        
         case error(String)
     }
     
@@ -257,8 +260,8 @@ extension CalendarReactor {
                   let month = dateComp.month,
                   let day = dateComp.day else { return arr }
             
-            let currentMonth = month == currentMonth ? true : false // 달력에 표시될 달(month)과 같은지 비교
-            let targetLocalDate = String(format: "%04d-%02d-%02d", year, month, day) // CardRecord.recordDate.rawValue와의 비교용 문자열
+            let isCurrentMonth = month == currentMonth ? true : false // 달력에 표시될 달(month)과 같은지 비교
+            let targetLocalDate = String(format: "%04d-%02d-%02d", year, month, day) // CareRecord.recordDate.rawValue와의 비교용 문자열
             
             var badges: Set<Badge> = []
             
@@ -278,7 +281,7 @@ extension CalendarReactor {
             }
             
             let manageInfoByDate = CalendarView.ManageInfoByDate(
-                currentMonth: currentMonth,
+                isCurrentMonth: isCurrentMonth,
                 day: day,
                 date: targetDate,
                 badge: badges

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -1,0 +1,40 @@
+//
+//  CalendarReactor.swift
+//  LeafLog
+//
+//  Created by t2025-m0143 on 4/19/26.
+//
+
+import Foundation
+import UIKit
+import ReactorKit
+import Dependencies
+
+final class CalendarReactor: Reactor {
+    enum Action {
+        
+    }
+    
+    enum Mutation {
+        
+    }
+    
+    struct State {
+        
+    }
+    
+    let initialState = State()
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+            
+        }
+    }
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+            
+        }
+        return newState
+    }
+}

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -16,11 +16,15 @@ final class CalendarReactor: Reactor {
     }
     
     enum Mutation {
-        
+        case calendarDates([CalendarView.Item])
     }
     
     struct State {
-        
+        var data: [CalendarView.Section: [CalendarView.Item]] = [
+                        .title: [.title],
+                        .header: [.header("2026년 4월")],
+                        .filter: [.filter(["전체", "물주기", "분갈이", "비료", "치료"])]
+                    ]
     }
     
     let initialState = State()
@@ -31,16 +35,35 @@ final class CalendarReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewWillAppear:
-            calculateDates(of: Date())
-            return .empty()
+            return calendarDates(of: Date())
         }
     }
     func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         switch mutation {
-            
+        case .calendarDates(let calendarItems):
+            newState.data[.calendar] = calendarItems
         }
         return newState
+    }
+}
+
+extension CalendarReactor {
+    private func calendarDates(of date: Date) -> Observable<Mutation> {
+        Observable.create { [weak self] observer in
+            guard let self else { return Disposables.create() }
+            
+            let dateComp = self.calendar.dateComponents([.month], from: date)
+            guard let month = dateComp.month else { return Disposables.create() }
+            
+            let dates = self.calculateDates(of: date)
+            let items = datesConvertToItems(currentMonth: month, dates)
+            
+            observer.onNext(.calendarDates(items))
+            observer.onCompleted()
+            
+            return Disposables.create()
+        }
     }
 }
 
@@ -68,5 +91,27 @@ extension CalendarReactor {
         }
         
         return dates
+    }
+    
+    private func datesConvertToItems(currentMonth: Int, _ dates: [Date]) -> [CalendarView.Item] {
+        return dates.reduce([CalendarView.Item]()) {
+            let dateComp = calendar.dateComponents([.month, .day], from: $1)
+            
+            guard let month = dateComp.month,
+                  let day = dateComp.day else { return $0 }
+            
+            let currentMonth = month == currentMonth ? true : false
+            
+            let manageInfoByDate = CalendarView.ManageInfoByDate(
+                currentMonth: currentMonth,
+                day: day,
+                date: $1,
+                badge: []
+            )
+            
+            let item = CalendarView.Item.calendar(manageInfoByDate)
+            
+            return $0 + [item]
+        }
     }
 }

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -16,15 +16,14 @@ final class CalendarReactor: Reactor {
     }
     
     enum Mutation {
-        case calendarDates([CalendarView.Item])
+        case calendarDates(Int, Int, [CalendarView.Item]) // (년, 월, [일])
     }
     
     struct State {
         var data: [CalendarView.Section: [CalendarView.Item]] = [
-                        .title: [.title],
-                        .header: [.header("2026년 4월")],
-                        .filter: [.filter(["전체", "물주기", "분갈이", "비료", "치료"])]
-                    ]
+            .title: [.title],
+            .filter: [.filter(["전체", "물주기", "분갈이", "비료", "치료"])]
+        ]
     }
     
     let initialState = State()
@@ -41,7 +40,8 @@ final class CalendarReactor: Reactor {
     func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         switch mutation {
-        case .calendarDates(let calendarItems):
+        case .calendarDates(let year, let month, let calendarItems):
+            newState.data[.header] = [CalendarView.Item.header(year, month)]
             newState.data[.calendar] = calendarItems
         }
         return newState
@@ -53,13 +53,14 @@ extension CalendarReactor {
         Observable.create { [weak self] observer in
             guard let self else { return Disposables.create() }
             
-            let dateComp = self.calendar.dateComponents([.month], from: date)
-            guard let month = dateComp.month else { return Disposables.create() }
+            let dateComp = self.calendar.dateComponents([.year, .month], from: date)
+            guard let year = dateComp.year,
+                  let month = dateComp.month else { return Disposables.create() }
             
             let dates = self.calculateDates(of: date)
             let items = datesConvertToItems(currentMonth: month, dates)
             
-            observer.onNext(.calendarDates(items))
+            observer.onNext(.calendarDates(year, month, items))
             observer.onCompleted()
             
             return Disposables.create()

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -19,6 +19,7 @@ final class CalendarReactor: Reactor {
     
     enum Mutation {
         case setCalendarHeader(Int, Int) // 년, 월
+        case setCalendarItem([CalendarView.Item])
         case calendarDates(Date, Int, Int, [CalendarView.Item]) // (기준 일자, 년, 월, [일])
         case calendarRecords([CareRecord])
         case error(String)
@@ -44,16 +45,23 @@ final class CalendarReactor: Reactor {
         case .viewWillAppear:
             let benchmark = currentState.benchmarkDate
             return Observable.concat([
-                setCalendarHeader(of: benchmark),
-                calendarDates(of: benchmark),
-                calendarCareRecords(of: benchmark)
-                ])
+                calendarHeaderItem(of: benchmark),
+                calendarItems(of: benchmark)
+            ])
             
         case .previousMonth:
-            return moveMonthTo(.previous)
+            let benchmark = benchmarkDate(of: currentState.benchmarkDate, moveTo: .previous)
+            return Observable.concat([
+                calendarHeaderItem(of: benchmark),
+                calendarItems(of: benchmark)
+            ])
             
         case .nextMonth:
-            return moveMonthTo(.next)
+            let benchmark = benchmarkDate(of: currentState.benchmarkDate, moveTo: .next)
+            return Observable.concat([
+                calendarHeaderItem(of: benchmark),
+                calendarItems(of: benchmark)
+            ])
         }
     }
     func reduce(state: State, mutation: Mutation) -> State {
@@ -61,6 +69,10 @@ final class CalendarReactor: Reactor {
         switch mutation {
         case .setCalendarHeader(let year, let month):
             newState.data[.header] = [CalendarView.Item.header(year, month)]
+            
+        case .setCalendarItem(let items):
+            newState.data[.calendar] = items
+            
         case .calendarDates(let benchmark, let year, let month, let calendarItems):
             newState.benchmarkDate = benchmark
             newState.data[.calendar] = calendarItems
@@ -76,7 +88,7 @@ final class CalendarReactor: Reactor {
 }
 
 extension CalendarReactor {
-    private func setCalendarHeader(of date: Date) -> Observable<Mutation> {
+    private func calendarHeaderItem(of date: Date) -> Observable<Mutation> {
         Observable.create { [weak self] observer in
             guard let self else { return Disposables.create() }
             
@@ -92,50 +104,92 @@ extension CalendarReactor {
         }
     }
     
+    private func calendarItems(of date: Date) -> Observable<Mutation> {
+        Observable.create { [weak self] observer in
+            guard let self else { return Disposables.create() }
+            let task = Task {
+                let dates = self.calculateDates(of: date) // 달력에 표시될 날짜들
+                let records = try await self.plantRecords(of: date) // 달력 범위의 기록들
+                let items = self.datesConvertToItems(current: date, dates, records: records) // 컬렉션뷰에 표시될 아이템
+                
+                observer.onNext(.setCalendarItem(items))
+                observer.onCompleted()
+            }
+            
+            return Disposables.create() {
+                task.cancel()
+            }
+        }
+    }
+    
     private func calendarDates(of date: Date) -> Observable<Mutation> {
         Observable.create { [weak self] observer in
             guard let self else { return Disposables.create() }
             
-            let dateComp = self.calendar.dateComponents([.year, .month], from: date)
+            let dateComp = calendar.dateComponents([.year, .month], from: date)
             guard let year = dateComp.year,
                   let month = dateComp.month else { return Disposables.create() }
             
-            let dates = self.calculateDates(of: date)
-            let items = datesConvertToItems(currentMonth: month, dates)
-            
-            observer.onNext(.calendarDates(date, year, month, items))
-            observer.onCompleted()
+            Task {
+                let records = try await self.plantRecords(of: date)
+                let dates = self.calculateDates(of: date)
+                let items = self.datesConvertToItems(current: date, dates, records: records)
+                
+                observer.onNext(.calendarDates(date, year, month, items))
+                observer.onCompleted()
+            }
             
             return Disposables.create()
         }
     }
     
-    private func moveMonthTo(_ move: MoveMonth) -> Observable<Mutation> {
-        Observable.create { [weak self] observer in
-            guard let self else { return Disposables.create() }
-            
-            let benchmark = switch move {
-            case .previous:
-                benchmarkDate(of: currentState.benchmarkDate, moveTo: .previous)
-            case .next:
-                benchmarkDate(of: currentState.benchmarkDate, moveTo: .next)
-            case .none:
-                currentState.benchmarkDate
-            }
-            
-            let dateComp = calendar.dateComponents([.year, .month], from: benchmark)
-            guard let year = dateComp.year,
-                  let month = dateComp.month else { return Disposables.create() }
-            
-            let dates = self.calculateDates(of: benchmark)
-            let items = self.datesConvertToItems(currentMonth: month, dates)
-            
-            observer.onNext(.calendarDates(benchmark, year, month, items))
-            observer.onCompleted()
-            
-            return Disposables.create()
-        }
-    }
+//    private func calendarDates(of date: Date) -> Observable<Mutation> {
+//        Observable.create { [weak self] observer in
+//            guard let self else { return Disposables.create() }
+//            
+//            let dateComp = self.calendar.dateComponents([.year, .month], from: date)
+//            guard let year = dateComp.year,
+//                  let month = dateComp.month else { return Disposables.create() }
+//            
+//            let dates = self.calculateDates(of: date)
+//            let items = datesConvertToItems(currentMonth: month, dates)
+//            
+//            observer.onNext(.calendarDates(date, year, month, items))
+//            observer.onCompleted()
+//            
+//            return Disposables.create()
+//        }
+//    }
+    
+//    private func moveMonthTo(_ move: MoveMonth) -> Observable<Mutation> {
+//        Observable.create { [weak self] observer in
+//            guard let self else { return Disposables.create() }
+//            
+//            let benchmark = switch move {
+//            case .previous:
+//                benchmarkDate(of: currentState.benchmarkDate, moveTo: .previous)
+//            case .next:
+//                benchmarkDate(of: currentState.benchmarkDate, moveTo: .next)
+//            case .none:
+//                currentState.benchmarkDate
+//            }
+//            
+//            let dateComp = calendar.dateComponents([.year, .month], from: benchmark)
+//            guard let year = dateComp.year,
+//                  let month = dateComp.month else { return Disposables.create() }
+//            
+//            Task {
+//                let records = try await self.plantRecords(of: benchmark)
+//                let dates = self.calculateDates(of: benchmark)
+//                let items = self.datesConvertToItems(current: benchmark, dates, records: records)
+//                
+//                observer.onNext(.calendarDates(benchmark, year, month, items))
+//                observer.onCompleted()
+//            }
+//            
+//            return Disposables.create()
+//        }
+//    }
     
     private func calendarCareRecords(of date: Date) -> Observable<Mutation> {
         Observable.create { [weak self] observer in
@@ -143,10 +197,10 @@ extension CalendarReactor {
                   let calendarRange = calendarRange(of: date) else {
                 return Disposables.create()
             }
-
+            
             Task {
                 do {
-                    let records = try await self.plantRecords(within: calendarRange.start, calendarRange.end)
+                    let records = try await self.plantRecords(of: date)
                     
                     observer.onNext(.calendarRecords(records))
                     observer.onCompleted()
@@ -207,33 +261,62 @@ extension CalendarReactor {
         return dates
     }
     
-    private func datesConvertToItems(currentMonth: Int, _ dates: [Date]) -> [CalendarView.Item] {
-        return dates.reduce([CalendarView.Item]()) {
-            let dateComp = calendar.dateComponents([.month, .day], from: $1)
+    private func datesConvertToItems(current: Date, _ dates: [Date], records: [CareRecord]) -> [CalendarView.Item] {
+        guard let currentMonth = calendar.dateComponents([.month], from: current).month else { return [] }
+        
+        // 날짜별로 기록 데이터 분류
+        var recordDates = [String: [CareRecord]]()
+        for record in records {
+            recordDates[record.recordDate.rawValue, default: []] += [record]
+        }
+        
+        return dates.reduce([CalendarView.Item]()) { arr, targetDate in
+            let dateComp = calendar.dateComponents([.year, .month, .day], from: targetDate)
             
-            guard let month = dateComp.month,
-                  let day = dateComp.day else { return $0 }
+            guard let year = dateComp.year,
+                  let month = dateComp.month,
+                  let day = dateComp.day else { return arr }
             
-            let currentMonth = month == currentMonth ? true : false
+            let currentMonth = month == currentMonth ? true : false // 달력에 표시될 달(month)과 같은지 비교
+            let targetLocalDate = String(format: "%04d-%02d-%02d", year, month, day) // CardRecord.recordDate.rawValue와의 비교용 문자열
+  
+            var badges: Set<Badge> = []
+            
+            if let targetRecords = recordDates[targetLocalDate] {
+                for record in targetRecords {
+                    // 모든 뱃지가 존재할 경우
+                    if badges.count == 4 { break }
+                    
+                    if record.watered { badges.insert(Badge.water) }
+                    
+                    if record.repotted { badges.insert(Badge.grow) }
+                    
+                    if record.fertilized { badges.insert(Badge.sprout) }
+                    
+                    if record.treated { badges.insert(Badge.treat) }
+                }
+            }
             
             let manageInfoByDate = CalendarView.ManageInfoByDate(
                 currentMonth: currentMonth,
                 day: day,
-                date: $1,
-                badge: []
+                date: targetDate,
+                badge: badges
             )
             
             let item = CalendarView.Item.calendar(manageInfoByDate)
             
-            return $0 + [item]
+            return arr + [item]
         }
     }
     
-    private func plantRecords(within start: Date, _ end: Date) async throws -> [CareRecord] {
+    private func plantRecords(of date: Date) async throws -> [CareRecord] {
         do {
+            guard let range = calendarRange(of: date) else { return [] }
+            
             let plants = try await plantDBManager.fetchMyPlants()
             
-            let records = try await careRecordDBManager.fetchAllCareRecordWithin(start: start, end: end, plants: plants.map { $0.id })
+            let records = try await careRecordDBManager.fetchAllCareRecordWithin(start: range.start, end: range.end, plants: plants.map { $0.id })
             
             return records
         } catch {

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -15,12 +15,18 @@ final class CalendarReactor: Reactor {
         case viewWillAppear
         case previousMonth
         case nextMonth
+        
+        case dateSelected(Date)
     }
     
     enum Mutation {
         case updateBenchmarkDate(Date)
         case setCalendarHeader(Int, Int) // 년, 월
         case setCalendarItem([CalendarView.Item])
+        case setDetailWaterItem([CalendarView.Item])
+        case setDetailGrowItem([CalendarView.Item])
+        case setDetailSproutItem([CalendarView.Item])
+        case setDetailTreatItem([CalendarView.Item])
         case error(String)
     }
     
@@ -64,6 +70,9 @@ final class CalendarReactor: Reactor {
                 calendarHeaderItem(of: benchmark),
                 calendarItems(of: benchmark)
             ])
+            
+        case .dateSelected(let date):
+            return detailItmes(of: date)
         }
     }
     func reduce(state: State, mutation: Mutation) -> State {
@@ -77,6 +86,18 @@ final class CalendarReactor: Reactor {
             
         case .setCalendarItem(let items):
             newState.data[.calendar] = items
+            
+        case .setDetailWaterItem(let items):
+            newState.data[.water] = items
+            
+        case .setDetailGrowItem(let items):
+            newState.data[.grow] = items
+            
+        case .setDetailSproutItem(let items):
+            newState.data[.sprout] = items
+            
+        case .setDetailTreatItem(let items):
+            newState.data[.treat] = items
             
         case .error(let message):
             print(message)
@@ -107,7 +128,7 @@ extension CalendarReactor {
             guard let self else { return Disposables.create() }
             let task = Task {
                 let dates = self.calculateDates(of: date) // 달력에 표시될 날짜들
-                let records = try await self.plantRecords(of: date) // 달력 범위의 기록들
+                let records = try await self.monthlyPlantRecords(of: date) // 달력 범위의 기록들
                 let items = self.datesConvertToItems(current: date, dates, records: records) // 컬렉션뷰에 표시될 아이템
                 
                 observer.onNext(.setCalendarItem(items))
@@ -115,6 +136,29 @@ extension CalendarReactor {
             }
             
             return Disposables.create() {
+                task.cancel()
+            }
+        }
+    }
+    
+    private func detailItmes(of date: Date) -> Observable<Mutation> {
+        Observable.create { [weak self] observer in
+            guard let self else { return Disposables.create() }
+            let task = Task {
+                let records = try await self.dailyPlantRecords(of: date) // 특정 날짜의 기록들
+                let water = self.dailyRecordConvertToItem(records, kind: .water)
+                let grow = self.dailyRecordConvertToItem(records, kind: .grow)
+                let sprout = self.dailyRecordConvertToItem(records, kind: .sprout)
+                let treat = self.dailyRecordConvertToItem(records, kind: .treat)
+                
+                observer.onNext(.setDetailWaterItem(water))
+                observer.onNext(.setDetailGrowItem(grow))
+                observer.onNext(.setDetailSproutItem(sprout))
+                observer.onNext(.setDetailTreatItem(treat))
+                observer.onCompleted()
+            }
+            
+            return Disposables.create {
                 task.cancel()
             }
         }
@@ -186,7 +230,7 @@ extension CalendarReactor {
             
             let currentMonth = month == currentMonth ? true : false // 달력에 표시될 달(month)과 같은지 비교
             let targetLocalDate = String(format: "%04d-%02d-%02d", year, month, day) // CardRecord.recordDate.rawValue와의 비교용 문자열
-  
+            
             var badges: Set<Badge> = []
             
             if let targetRecords = recordDates[targetLocalDate] {
@@ -217,18 +261,71 @@ extension CalendarReactor {
         }
     }
     
-    private func plantRecords(of date: Date) async throws -> [CareRecord] {
+    private func monthlyPlantRecords(of date: Date) async throws -> [CareRecord] {
         do {
             guard let range = calendarRange(of: date) else { return [] }
             
-            let plants = try await plantDBManager.fetchMyPlants()
-            
+            let plants = try await plantDBManager.fetchMyPlants() // 유저가 등록한 모든 식물
             let records = try await careRecordDBManager.fetchAllCareRecordWithin(start: range.start, end: range.end, plants: plants.map { $0.id })
             
             return records
         } catch {
             throw error
         }
+    }
+    
+    private func dailyPlantRecords(of date: Date) async throws -> [MyPlant: CareRecord] {
+        let dateComp = calendar.dateComponents([.year, .month, .day], from: date)
+        
+        guard let year = dateComp.year,
+              let month = dateComp.month,
+              let day = dateComp.day else { return [:] }
+        
+        let dateRawValue = String(format: "%04d-%02d-%02d", year, month, day) // LocaleDate를 만들기 위한 date 문자열
+        let targetDate = LocalDate(rawValue: dateRawValue)
+        
+        let plants = try await plantDBManager.fetchMyPlants() // 유저가 등록한 모든 식물
+        
+        var records: [MyPlant: CareRecord] = [:]
+        
+        for plant in plants {
+            guard let record = try await careRecordDBManager.fetchCareRecord(plantID: plant.id, recordDate: targetDate) else { continue }
+            records[plant] = record
+        }
+        
+        return records
+    }
+    
+    private func dailyRecordConvertToItem(_ record: [MyPlant: CareRecord], kind: Badge) -> [CalendarView.Item] {
+        switch kind {
+        case .water:
+            let watered = record.filter { $0.value.watered }
+            return watered.map {
+                let data = CalendarView.DetailManageInfo(id: $0.key.id, name: $0.key.speciesName, badge: .water)
+                return CalendarView.Item.water(data)
+            }
+        case .grow:
+            let repotted = record.filter { $0.value.repotted }
+            return repotted.map {
+                let data = CalendarView.DetailManageInfo(id: $0.key.id, name: $0.key.speciesName, badge: .grow)
+                return CalendarView.Item.grow(data)
+            }
+        case .sprout:
+            let fertilized = record.filter { $0.value.fertilized }
+            return fertilized.map {
+                let data = CalendarView.DetailManageInfo(id: $0.key.id, name: $0.key.speciesName, badge: .sprout)
+                return CalendarView.Item.sprout(data)
+            }
+        case .treat:
+            let treated = record.filter { $0.value.treated }
+            return treated.map {
+                let data = CalendarView.DetailManageInfo(id: $0.key.id, name: $0.key.speciesName, badge: .treat)
+                return CalendarView.Item.treat(data)
+            }
+        default:
+            return []
+        }
+        
     }
 }
 

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -12,7 +12,7 @@ import Dependencies
 
 final class CalendarReactor: Reactor {
     enum Action {
-        
+        case viewWillAppear
     }
     
     enum Mutation {
@@ -25,9 +25,14 @@ final class CalendarReactor: Reactor {
     
     let initialState = State()
     
+    //MARK: properties
+    private let calendar = Calendar.current
+    
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-            
+        case .viewWillAppear:
+            calculateDates(of: Date())
+            return .empty()
         }
     }
     func reduce(state: State, mutation: Mutation) -> State {
@@ -36,5 +41,32 @@ final class CalendarReactor: Reactor {
             
         }
         return newState
+    }
+}
+
+extension CalendarReactor {
+    private func calculateDates(of date: Date) -> [Date] {
+        guard let monthInterval = calendar.dateInterval(of: .month, for: date),
+              let end = calendar.date(byAdding: .day, value: -1, to: monthInterval.end),
+              let startWeekday = calendar.dateComponents([.weekday], from: monthInterval.start).weekday,
+              let endWeekday = calendar.dateComponents([.weekday], from: end).weekday else { return [] }
+        
+        let pastFromMonday = (startWeekday + 5) % 7 // 첫 주에서 월요일까지 필요한 날짜 수
+        let addToSunday = 6 - ((endWeekday + 5) % 7) // 마지막 주에서 일요일까지 필요한 날짜 수
+        
+        guard let startDate = calendar.date(byAdding: .day, value: -pastFromMonday, to: monthInterval.start),
+              let endDate = calendar.date(byAdding: .day, value: addToSunday, to: end) else { return [] }
+        
+        var dates: [Date] = []
+        var current = startDate
+        
+        while current <= endDate {
+            dates.append(current)
+            
+            guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
+            current = next
+        }
+        
+        return dates
     }
 }

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -13,13 +13,16 @@ import Dependencies
 final class CalendarReactor: Reactor {
     enum Action {
         case viewWillAppear
+        case previousMonth
+        case nextMonth
     }
     
     enum Mutation {
-        case calendarDates(Int, Int, [CalendarView.Item]) // (년, 월, [일])
+        case calendarDates(Date, Int, Int, [CalendarView.Item]) // (기준 일자, 년, 월, [일])
     }
     
     struct State {
+        var benchmarkDate: Date = Date()
         var data: [CalendarView.Section: [CalendarView.Item]] = [
             .title: [.title],
             .filter: [.filter(["전체", "물주기", "분갈이", "비료", "치료"])]
@@ -35,12 +38,19 @@ final class CalendarReactor: Reactor {
         switch action {
         case .viewWillAppear:
             return calendarDates(of: Date())
+            
+        case .previousMonth:
+            return moveMonthTo(.previous)
+            
+        case .nextMonth:
+            return moveMonthTo(.next)
         }
     }
     func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         switch mutation {
-        case .calendarDates(let year, let month, let calendarItems):
+        case .calendarDates(let benchmark, let year, let month, let calendarItems):
+            newState.benchmarkDate = benchmark
             newState.data[.header] = [CalendarView.Item.header(year, month)]
             newState.data[.calendar] = calendarItems
         }
@@ -60,8 +70,42 @@ extension CalendarReactor {
             let dates = self.calculateDates(of: date)
             let items = datesConvertToItems(currentMonth: month, dates)
             
-            observer.onNext(.calendarDates(year, month, items))
+            observer.onNext(.calendarDates(date, year, month, items))
             observer.onCompleted()
+            
+            return Disposables.create()
+        }
+    }
+    
+    private func moveMonthTo(_ move: MoveMonth) -> Observable<Mutation> {
+        Observable.create { [weak self] observer in
+            guard let self else { return Disposables.create() }
+            
+            let current = currentState.benchmarkDate
+            guard let currentBenchmark = calendar.dateInterval(of: .month, for: current)?.start else { return Disposables.create() }
+            
+            switch move {
+            case .previous:
+                guard let previous = calendar.date(byAdding: .month, value: -1, to: currentBenchmark),
+                      let year = calendar.dateComponents([.year, .month], from: previous).year,
+                      let month = calendar.dateComponents([.year, .month], from: previous).month else { return Disposables.create() }
+                
+                let dates = self.calculateDates(of: previous)
+                let items = datesConvertToItems(currentMonth: month, dates)
+                
+                observer.onNext(.calendarDates(previous, year, month, items))
+                observer.onCompleted()
+            case .next:
+                guard let next = calendar.date(byAdding: .month, value: +1, to: currentBenchmark),
+                      let year = calendar.dateComponents([.year, .month], from: next).year,
+                      let month = calendar.dateComponents([.year, .month], from: next).month else { return Disposables.create() }
+                
+                let dates = self.calculateDates(of: next)
+                let items = datesConvertToItems(currentMonth: month, dates)
+                
+                observer.onNext(.calendarDates(next, year, month, items))
+                observer.onCompleted()
+            }
             
             return Disposables.create()
         }
@@ -114,5 +158,12 @@ extension CalendarReactor {
             
             return $0 + [item]
         }
+    }
+}
+
+extension CalendarReactor {
+    enum MoveMonth {
+        case previous
+        case next
     }
 }

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -23,6 +23,7 @@ final class CalendarReactor: Reactor {
         case updateBenchmarkDate(Date)
         case setCalendarHeader(Int, Int) // 년, 월
         case setCalendarItem([CalendarView.Item])
+        case setLabelItem([CalendarView.Item])
         case setDetailWaterItem([CalendarView.Item])
         case setDetailGrowItem([CalendarView.Item])
         case setDetailSproutItem([CalendarView.Item])
@@ -42,7 +43,7 @@ final class CalendarReactor: Reactor {
     let initialState = State()
     
     //MARK: properties
-    private let calendar = Calendar.current
+    fileprivate let calendar = Calendar.current
     @Dependency(\.plantDBManager) private var plantDBManager
     @Dependency(\.careRecordDBManager) private var careRecordDBManager
     
@@ -87,6 +88,9 @@ final class CalendarReactor: Reactor {
             
         case .setCalendarItem(let items):
             newState.data[.calendar] = items
+            
+        case .setLabelItem(let item):
+            newState.data[.label] = item
             
         case .setDetailWaterItem(let items):
             newState.data[.water] = items
@@ -157,12 +161,17 @@ extension CalendarReactor {
             guard let self else { return Disposables.create() }
             let task = Task {
                 do {
+                    let dateString = self.dateToString(date, forLabel: true)
+                    let labelItem = [CalendarView.Item.label(dateString)]
+                    
                     let records = try await self.dailyPlantRecords(of: date) // 특정 날짜의 기록들
+                    
                     let water = self.dailyRecordConvertToItem(records, kind: .water)
                     let grow = self.dailyRecordConvertToItem(records, kind: .grow)
                     let sprout = self.dailyRecordConvertToItem(records, kind: .sprout)
                     let treat = self.dailyRecordConvertToItem(records, kind: .treat)
                     
+                    observer.onNext(.setLabelItem(labelItem))
                     observer.onNext(.setDetailWaterItem(water))
                     observer.onNext(.setDetailGrowItem(grow))
                     observer.onNext(.setDetailSproutItem(sprout))
@@ -295,13 +304,9 @@ extension CalendarReactor {
     }
     
     private func dailyPlantRecords(of date: Date) async throws -> [MyPlant: CareRecord] {
-        let dateComp = calendar.dateComponents([.year, .month, .day], from: date)
+        let dateRawValue = dateToString(date, forLabel: false)
         
-        guard let year = dateComp.year,
-              let month = dateComp.month,
-              let day = dateComp.day else { return [:] }
-        
-        let dateRawValue = String(format: "%04d-%02d-%02d", year, month, day) // LocaleDate를 만들기 위한 date 문자열
+        guard !dateRawValue.isEmpty else { return [:] }
         let targetDate = LocalDate(rawValue: dateRawValue)
         
         let plants = try await plantDBManager.fetchMyPlants() // 유저가 등록한 모든 식물
@@ -346,6 +351,21 @@ extension CalendarReactor {
             return []
         }
         
+    }
+}
+
+extension CalendarReactor {
+    private func dateToString(_ date: Date, forLabel: Bool) -> String {
+        let dateComp = calendar.dateComponents([.year, .month, .day], from: date)
+        
+        guard let year = dateComp.year,
+              let month = dateComp.month,
+              let day = dateComp.day else { return "" }
+        
+        let dateRawValue = String(format: "%04d-%02d-%02d", year, month, day) // LocaleDate를 만들기 위한 date 문자열
+        let labelString = "\(year)년 \(month)월 \(day)일"
+        
+        return forLabel ? labelString : dateRawValue
     }
 }
 

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -36,6 +36,7 @@ final class CalendarReactor: Reactor {
             .title: [.title],
             .filter: [.filter(["물주기", "분갈이", "비료", "치료"])]
         ]
+        @Pulse var errorMessage: String? = nil
     }
     
     let initialState = State()
@@ -100,7 +101,7 @@ final class CalendarReactor: Reactor {
             newState.data[.treat] = items
             
         case .error(let message):
-            print(message)
+            newState.errorMessage = message
         }
         return newState
     }
@@ -127,12 +128,22 @@ extension CalendarReactor {
         Observable.create { [weak self] observer in
             guard let self else { return Disposables.create() }
             let task = Task {
-                let dates = self.calculateDates(of: date) // 달력에 표시될 날짜들
-                let records = try await self.monthlyPlantRecords(of: date) // 달력 범위의 기록들
-                let items = self.datesConvertToItems(current: date, dates, records: records) // 컬렉션뷰에 표시될 아이템
-                
-                observer.onNext(.setCalendarItem(items))
-                observer.onCompleted()
+                do {
+                    let dates = self.calculateDates(of: date) // 달력에 표시될 날짜들
+                    let records = try await self.monthlyPlantRecords(of: date) // 달력 범위의 기록들
+                    let items = self.datesConvertToItems(current: date, dates, records: records) // 컬렉션뷰에 표시될 아이템
+                    
+                    observer.onNext(.setCalendarItem(items))
+                    observer.onCompleted()
+                } catch {
+                    if let authError = error as? AuthError {
+                        observer.onNext(.error(authError.userMessage))
+                        observer.onCompleted()
+                    } else {
+                        observer.onNext(.error("알 수 없는 에러입니다."))
+                        observer.onCompleted()
+                    }
+                }
             }
             
             return Disposables.create() {
@@ -145,17 +156,28 @@ extension CalendarReactor {
         Observable.create { [weak self] observer in
             guard let self else { return Disposables.create() }
             let task = Task {
-                let records = try await self.dailyPlantRecords(of: date) // 특정 날짜의 기록들
-                let water = self.dailyRecordConvertToItem(records, kind: .water)
-                let grow = self.dailyRecordConvertToItem(records, kind: .grow)
-                let sprout = self.dailyRecordConvertToItem(records, kind: .sprout)
-                let treat = self.dailyRecordConvertToItem(records, kind: .treat)
-                
-                observer.onNext(.setDetailWaterItem(water))
-                observer.onNext(.setDetailGrowItem(grow))
-                observer.onNext(.setDetailSproutItem(sprout))
-                observer.onNext(.setDetailTreatItem(treat))
-                observer.onCompleted()
+                do {
+                    let records = try await self.dailyPlantRecords(of: date) // 특정 날짜의 기록들
+                    let water = self.dailyRecordConvertToItem(records, kind: .water)
+                    let grow = self.dailyRecordConvertToItem(records, kind: .grow)
+                    let sprout = self.dailyRecordConvertToItem(records, kind: .sprout)
+                    let treat = self.dailyRecordConvertToItem(records, kind: .treat)
+                    
+                    observer.onNext(.setDetailWaterItem(water))
+                    observer.onNext(.setDetailGrowItem(grow))
+                    observer.onNext(.setDetailSproutItem(sprout))
+                    observer.onNext(.setDetailTreatItem(treat))
+                    observer.onCompleted()
+                }
+                catch {
+                    if let authError = error as? AuthError {
+                        observer.onNext(.error(authError.userMessage))
+                        observer.onCompleted()
+                    } else {
+                        observer.onNext(.error("알 수 없는 에러입니다."))
+                        observer.onCompleted()
+                    }
+                }
             }
             
             return Disposables.create {
@@ -172,11 +194,9 @@ extension CalendarReactor {
             return date
         case .previous:
             guard let previous = calendar.date(byAdding: .month, value: -1, to: date) else { return date }
-            
             return previous
         case .next:
             guard let next = calendar.date(byAdding: .month, value: 1, to: date) else { return date }
-            
             return next
         }
     }

--- a/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
+++ b/LeafLog/LeafLog/ViewModel/CalendarReactor.swift
@@ -18,6 +18,7 @@ final class CalendarReactor: Reactor {
     }
     
     enum Mutation {
+        case setCalendarHeader(Int, Int) // 년, 월
         case calendarDates(Date, Int, Int, [CalendarView.Item]) // (기준 일자, 년, 월, [일])
         case calendarRecords([CareRecord])
         case error(String)
@@ -43,6 +44,7 @@ final class CalendarReactor: Reactor {
         case .viewWillAppear:
             let benchmark = currentState.benchmarkDate
             return Observable.concat([
+                setCalendarHeader(of: benchmark),
                 calendarDates(of: benchmark),
                 calendarCareRecords(of: benchmark)
                 ])
@@ -57,9 +59,10 @@ final class CalendarReactor: Reactor {
     func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         switch mutation {
+        case .setCalendarHeader(let year, let month):
+            newState.data[.header] = [CalendarView.Item.header(year, month)]
         case .calendarDates(let benchmark, let year, let month, let calendarItems):
             newState.benchmarkDate = benchmark
-            newState.data[.header] = [CalendarView.Item.header(year, month)]
             newState.data[.calendar] = calendarItems
             
         case .calendarRecords(let records):
@@ -73,6 +76,22 @@ final class CalendarReactor: Reactor {
 }
 
 extension CalendarReactor {
+    private func setCalendarHeader(of date: Date) -> Observable<Mutation> {
+        Observable.create { [weak self] observer in
+            guard let self else { return Disposables.create() }
+            
+            let dateComp = self.calendar.dateComponents([.year, .month], from: date)
+            
+            guard let year = dateComp.year,
+                  let month = dateComp.month else { return Disposables.create() }
+            
+            observer.onNext(.setCalendarHeader(year, month))
+            observer.onCompleted()
+            
+            return Disposables.create()
+        }
+    }
+    
     private func calendarDates(of date: Date) -> Observable<Mutation> {
         Observable.create { [weak self] observer in
             guard let self else { return Disposables.create() }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #77

## 🛠 작업 내용 (What I did)
- 월간 캘린더 화면에 날짜별 관리 기록 뱃지를 표시하는 기능을 구현했습니다.
- 날짜 선택 시 해당 일자의 상세 관리 기록이 하단 리스트에 표시되도록 연결했습니다.
- 캘린더 필터 셀을 추가하고, 선택한 관리 종류에 따라 날짜 뱃지를 필터링하도록 구현했습니다.
- 캘린더 셀 선택 상태와 날짜 라벨 표시 흐름을 정리했습니다.
- 상세 화면 셀 선택 시 record step이 방출되도록 연결했습니다.

## 💻 구현 상세 (Implementation Details)
- `CareRecord` / `LocalDate` 모델과 `CareRecordDBManager`를 통해 Supabase의 `care_records` 데이터를 기간 단위로 조회하도록 구성했습니다.
- 달력에 표시할 날짜 범위를 계산한 뒤, 날짜별 기록을 그룹핑하여 `Badge` 집합으로 변환해 캘린더 셀에 반영했습니다.
- `CalendarView`, `CalendarCollectionView`, `CalendarReactor`를 중심으로 캘린더 UI와 상태 관리를 Reactor 패턴으로 연결했습니다.
- 필터 버튼 선택 이벤트를 RxSwift로 수집해 `Set<Badge>` 형태의 필터 상태로 변환하고, 필터 변경 시 달력 아이템을 다시 계산하도록 구성했습니다.
- 기존 `CalendarFooterView` 역할은 `CalendarLabelCell`로 대체하여 선택 날짜 표시 흐름을 단순화했습니다.

## 📸 스크린샷 (Screenshots)
<p align=center>
<img width=40% src="https://github.com/user-attachments/assets/d1dc56b3-1399-4750-97e9-0e406a5dcc0d" />
<img width=40% src="https://github.com/user-attachments/assets/0bbf2bb0-df97-4010-93b9-9c752aafb6d2" /></p>


## 🧐 리뷰 포인트 (Review Points)
- 날짜 계산 로직이 로컬 날짜 기준으로 의도한 달력 셀과 정확히 매칭되는지 확인 부탁드립니다.
- 필터 버튼 선택 시 선택한 필터에 맞게 제대로 필터링되는지 확인해주시면 감사하겠습니다.
- `CareRecordDBManager`에 특정 기간에 해당하는 관리 기록을 불러오는 `fetchAllCareRecordWithin` 메서드가 추가되었습니다. 참고 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
