### PR TITLE
[Fix] PHPickerViewController Delegate Rx 확장

### DIFF
--- a/LeafLog/LeafLog.xcodeproj/project.pbxproj
+++ b/LeafLog/LeafLog.xcodeproj/project.pbxproj
@@ -275,11 +275,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0AE522C32F8600A50075F8D6 /* Secrets.xcconfig */;
 			buildSettings = {
-					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-					ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-					CODE_SIGN_ENTITLEMENTS = LeafLog/LeafLog.entitlements;
-					"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-					CODE_SIGN_STYLE = Manual;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = LeafLog/LeafLog.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Q7HGK38S83;
@@ -317,11 +317,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0AE522C32F8600A50075F8D6 /* Secrets.xcconfig */;
 			buildSettings = {
-					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-					ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-					CODE_SIGN_ENTITLEMENTS = LeafLog/LeafLog.entitlements;
-					"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-					CODE_SIGN_STYLE = Manual;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = LeafLog/LeafLog.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Q7HGK38S83;

--- a/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
@@ -46,9 +46,6 @@ final class PlantTabFlow: Flow {
 
         case .plantRegister(let selectedPlant):
             let plantRegisterViewController = makePlantRegisterViewController(selectedPlant: selectedPlant)
-
-            prepareImagePicker()
-            imagePicker?.delegate = plantRegisterViewController
             
             if navigationController.viewControllers.isEmpty {
                 let homeViewController = HomeViewController()
@@ -130,49 +127,36 @@ extension PlantTabFlow {
         let steps = PublishRelay<Step>()
     }
     
+    //TODO: 추후 수정 필요 - 등록 화면의 카메라 검색 버튼과 연동하여 수정 필요
     private func presentPhotoSelect() -> FlowContributors {
         let alert = UIAlertController()
         let cameraAction = UIAlertAction(title: "촬영하기", style: .default) { [weak self] _ in
             self?.photoSelectStepper.steps.accept(AppStep.cameraRequired)
         }
         
-        let galleryAction = UIAlertAction(title: "이미지 불러오기", style: .default) { [weak self] _ in
-            guard let self else { return }
-            
-           let imagePicker = imagePicker ?? makeImagePicker()
-            
-            alert.dismiss(animated: true) {
-                self.navigationController.present(imagePicker, animated: true)
-            }
-        }
+//        let galleryAction = UIAlertAction(title: "이미지 불러오기", style: .default) { [weak self] _ in
+//            guard let self else { return }
+//            
+//           let imagePicker = imagePicker ?? makeImagePicker()
+//            
+//            alert.dismiss(animated: true) {
+//                self.navigationController.present(imagePicker, animated: true)
+//            }
+//        }
         
         let cancel = UIAlertAction(title: "취소", style: .cancel)
         
         alert.addAction(cameraAction)
-        alert.addAction(galleryAction)
+//        alert.addAction(galleryAction)
         alert.addAction(cancel)
         
         navigationController.present(alert, animated: true)
         
         return .none
     }
-    
-    private func prepareImagePicker() {
-        guard imagePicker == nil else { return }
-        imagePicker = makeImagePicker()
-    }
 
     private func makePlantRegisterViewController(selectedPlant: SelectedPlant?) -> PlantRegisterViewController {
         let reactor = PlantRegisterReactor(selectedPlant: selectedPlant)
         return PlantRegisterViewController(reactor: reactor)
-    }
-
-    private func makeImagePicker() -> PHPickerViewController {
-        var config = PHPickerConfiguration()
-        config.filter = .images // 라이브러리에서 보여줄 asset의 종류 지정
-        config.selectionLimit = 1 // 선택 개수 설정 (0은 무제한)
-        
-        let imagePicker = PHPickerViewController(configuration: config)
-        return imagePicker
     }
 }

--- a/LeafLog/LeafLog/Util/Custom/CameraProfileButton.swift
+++ b/LeafLog/LeafLog/Util/Custom/CameraProfileButton.swift
@@ -14,7 +14,12 @@ import Then
 final class CameraProfileButton: UIControl {
     
     // MARK: - UI Components
-    let cameraImageView = UIImageView().then {
+    let backgroundImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.clipsToBounds = true
+    }
+    
+    private let cameraImageView = UIImageView().then {
         $0.image = .camera.withRenderingMode(.alwaysTemplate)
         $0.tintColor = .grayScale400
         $0.contentMode = .scaleAspectFit
@@ -40,7 +45,13 @@ final class CameraProfileButton: UIControl {
             $0.size.equalTo(140)
         }
         
+        addSubview(backgroundImageView)
         addSubview(cameraImageView)
+        
+        backgroundImageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
         cameraImageView.snp.makeConstraints {
             $0.center.equalToSuperview()
             $0.size.equalTo(24)

--- a/LeafLog/LeafLog/Util/Custom/CameraProfileButton.swift
+++ b/LeafLog/LeafLog/Util/Custom/CameraProfileButton.swift
@@ -14,7 +14,7 @@ import Then
 final class CameraProfileButton: UIControl {
     
     // MARK: - UI Components
-    private let cameraImageView = UIImageView().then {
+    let cameraImageView = UIImageView().then {
         $0.image = .camera.withRenderingMode(.alwaysTemplate)
         $0.tintColor = .grayScale400
         $0.contentMode = .scaleAspectFit

--- a/LeafLog/LeafLog/Util/Extension/PHPickerViewController+.swift
+++ b/LeafLog/LeafLog/Util/Extension/PHPickerViewController+.swift
@@ -1,0 +1,86 @@
+//
+//  PHPickerViewController+.swift
+//  LeafLog
+//
+//  Created by t2025-m0143 on 4/21/26.
+//
+
+import PhotosUI
+import RxCocoa
+import RxSwift
+
+extension Reactive where Base: PHPickerViewController {
+    var delegate: RxPHPickerViewControllerDelegateProxy {
+        return RxPHPickerViewControllerDelegateProxy.proxy(for: base)
+    }
+
+    func setDelegate(_ delegate: PHPickerViewControllerDelegate) -> Disposable {
+        return RxPHPickerViewControllerDelegateProxy.installForwardDelegate(delegate, retainDelegate: false, onProxyForObject: base)
+    }
+
+    var selectedImages: ControlEvent<[UIImage]> {
+        let source = delegate.didFinishPickingRelay
+            .map {
+                $0.map { $0.rx.loadImage().catchAndReturn(nil).compactMap { $0 } }
+            }
+            .flatMap { Observable.zip($0) }
+        return ControlEvent(events: source.take(until: base.rx.deallocated))
+    }
+}
+nonisolated
+class RxPHPickerViewControllerDelegateProxy: DelegateProxy<PHPickerViewController, PHPickerViewControllerDelegate>, DelegateProxyType, PHPickerViewControllerDelegate {
+    let didFinishPickingRelay = PublishSubject<[PHPickerResult]>()
+
+    // delegate를 가진 클래스를 RxDelegateProxy 클래스로 등록
+    static func registerKnownImplementations() {
+        register {
+            RxPHPickerViewControllerDelegateProxy(parentObject: $0, delegateProxy: RxPHPickerViewControllerDelegateProxy.self)
+        }
+    }
+
+    static func currentDelegate(for object: PHPickerViewController) -> PHPickerViewControllerDelegate? {
+        MainActor.assumeIsolated {
+            return object.delegate
+        }
+    }
+
+    static func setCurrentDelegate(_ delegate: PHPickerViewControllerDelegate?, to object: PHPickerViewController) {
+        MainActor.assumeIsolated {
+            object.delegate = delegate
+        }
+    }
+
+    // 선택한 이미지(PHPickerResult)를 Relay로 방출
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        didFinishPickingRelay.on(.next(results))
+        picker.dismiss(animated: true)
+    }
+
+    // Relay가 onCompleted되면 메모리에서 해제
+    deinit {
+        didFinishPickingRelay.on(.completed)
+    }
+}
+
+extension PHPickerResult: @retroactive ReactiveCompatible {}
+
+extension Reactive where Base == PHPickerResult {
+    func loadImage() -> Observable<UIImage?> {
+        return Observable.create { [base] observer in
+            if base.itemProvider.canLoadObject(ofClass: UIImage.self) {
+                base.itemProvider.loadObject(ofClass: UIImage.self) { item, error in
+                    if let image = item as? UIImage {
+                        observer.on(.next(image))
+                    } else if let error {
+                        observer.on(.error(error))
+                    }
+                    observer.on(.completed)
+                }
+            } else {
+                observer.on(.next(nil))
+                observer.on(.completed)
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/LeafLog/LeafLog/Util/Extension/UIControl+.swift
+++ b/LeafLog/LeafLog/Util/Extension/UIControl+.swift
@@ -1,0 +1,16 @@
+//
+//  UIControl+.swift
+//  LeafLog
+//
+//  Created by t2025-m0143 on 4/21/26.
+//
+
+import RxCocoa
+import RxSwift
+import UIKit
+
+extension Reactive where Base: UIControl {
+    var tap: ControlEvent<Void> {
+        controlEvent(.touchUpInside)
+    }
+}

--- a/LeafLog/LeafLog/View/MyPageView/ProfileEditViewController.swift
+++ b/LeafLog/LeafLog/View/MyPageView/ProfileEditViewController.swift
@@ -157,8 +157,7 @@ final class ProfileEditViewController: BaseViewController, View {
     }
 
     private func applyProfileImage(_ image: UIImage?) {
-        profileEditView.profileImageButton.layer.contents = image?.cgImage
-        profileEditView.profileImageButton.layer.contentsGravity = .resizeAspectFill
+        profileEditView.profileImageButton.backgroundImageView.image = image
         profileEditView.profileImageButton.backgroundColor = image == nil ? .grayScale50 : .clear
     }
 

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -45,7 +45,9 @@ final class PlantRegisterViewController: BaseViewController, View {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-//        bindUI(reactor: reactor)
+        
+        guard let reactor else { return }
+        bindUI(reactor: reactor)
     }
     
     func bind(reactor: PlantRegisterReactor) {
@@ -129,8 +131,6 @@ final class PlantRegisterViewController: BaseViewController, View {
                 self?.steps.accept(AppStep.alert("저장 실패", message))
             })
             .disposed(by: disposeBag)
-        
-        bindUI(reactor: reactor)
     }
     
     private func bindUI(reactor: PlantRegisterReactor) {

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -219,12 +219,6 @@ final class PlantRegisterViewController: BaseViewController, View {
         buttons.forEach { $0.isSelected = ($0 === selectedButton) }
     }
     
-//    @objc private func handleFormValueChanged() {
-//        reactor?.action.onNext(
-//            .updateWateringInterval(registerView.wateringCycleTextField.text ?? "")
-//        )
-//    }
-    
     private func notifyCategorySelectionChanged() {
         reactor?.action.onNext(.updateCategory(selectedCategoryFromButtons))
     }
@@ -266,16 +260,6 @@ final class PlantRegisterViewController: BaseViewController, View {
     private func handlePlantTypeSearchTap() {
         view.endEditing(true)
         steps.accept(AppStep.plantSearch)
-    }
-    
-    private func presentPhotoPicker() {
-        var configuration = PHPickerConfiguration()
-        configuration.filter = .images
-        configuration.selectionLimit = 1
-        
-        let pickerViewController = PHPickerViewController(configuration: configuration)
-        pickerViewController.delegate = self
-        present(pickerViewController, animated: true)
     }
     
     private func configureLastWateredDatePicker() {
@@ -345,52 +329,5 @@ extension PlantRegisterViewController {
         
         let imagePicker = PHPickerViewController(configuration: config)
         return imagePicker
-    }
-}
-
-extension PlantRegisterViewController: PHPickerViewControllerDelegate {
-    //TODO: 추후 수정 필요!!!
-    //    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-    //        picker.dismiss(animated: true)
-    //
-    //        guard let result = results.first,
-    //              result.itemProvider.canLoadObject(ofClass: UIImage.self)
-    //        else {
-    //            return
-    //        }
-    //
-    //        result.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] image, _ in
-    //            guard let selectedImage = image as? UIImage else { return }
-    //
-    //            DispatchQueue.main.async {
-    //                self?.selectedImage = selectedImage
-    //                self?.registerView.cameraButton.layer.contents = selectedImage.cgImage
-    //                self?.registerView.cameraButton.layer.contentsGravity = .resizeAspectFill
-    //                self?.registerView.cameraButton.backgroundColor = .clear
-    //            }
-    //        }
-    //    }
-    
-    // picker에서 이미지 선택 시(picker 종료 시) 동작
-    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-        guard let item = results.first,
-              item.itemProvider.canLoadObject(ofClass: UIImage.self) else {
-            picker.dismiss(animated: true)
-            return
-        }
-        
-        // itemProvider에서 UIImage로 로드가 가능하다면 UIImage로 선택된 사진 load
-        item.itemProvider.loadObject(ofClass: UIImage.self) { [weak self, weak picker] image, error in // loadObject는 비동기로 작동하므로 picker도 약한 참조
-            guard let image = image as? UIImage else {
-                picker?.dismiss(animated: true)
-                return
-            }
-            
-            Task { @MainActor [weak self, weak picker] in
-                picker?.dismiss(animated: true) { [weak self] in
-                    self?.reactor?.action.onNext(PlantRegisterReactor.Action.classificationImageSelected(image))
-                }
-            }
-        }
     }
 }

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -315,6 +315,17 @@ final class PlantRegisterViewController: BaseViewController, View {
     }
 }
 
+extension PlantRegisterViewController {
+    private func makeImagePicker() -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.filter = .images // 라이브러리에서 보여줄 asset의 종류 지정
+        config.selectionLimit = 1 // 선택 개수 설정 (0은 무제한)
+        
+        let imagePicker = PHPickerViewController(configuration: config)
+        return imagePicker
+    }
+}
+
 extension PlantRegisterViewController: PHPickerViewControllerDelegate {
     //TODO: 추후 수정 필요!!!
     //    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -141,12 +141,22 @@ final class PlantRegisterViewController: BaseViewController, View {
             .bind(to: steps)
             .disposed(by: disposeBag)
         
-        registerView.cameraButton.addAction(
-            UIAction { [weak self] _ in
-                self?.presentPhotoPicker()
-            },
-            for: .touchUpInside
-        )
+        registerView.cameraButton.rx.tap
+            .compactMap { [weak self] _ -> PHPickerViewController? in
+                return self?.makeImagePicker()
+            }
+            .withUnretained(self)
+            .do(onNext: { $0.present($1, animated: true) }) // $0 == self, $1 == PHPickerViewController
+            .flatMap { $1.rx.selectedImages }
+            .compactMap(\.first)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] image in
+                self?.selectedImage = image
+                self?.registerView.cameraButton.layer.contents = image.cgImage
+                self?.registerView.cameraButton.layer.contentsGravity = .resizeAspectFill
+                self?.registerView.cameraButton.backgroundColor = .clear
+            })
+            .disposed(by: disposeBag)
         
         registerView.plantTypeSearchButton.addAction(
             UIAction { [weak self] _ in

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -146,7 +146,7 @@ final class PlantRegisterViewController: BaseViewController, View {
                 return self?.makeImagePicker()
             }
             .withUnretained(self)
-            .do(onNext: { $0.present($1, animated: true) }) // $0 == self, $1 == PHPickerViewController
+            .do(onNext: { $0.present($1, animated: true) }) // $0 == self, $1 == PHPickerViewController - 이미지 피커 띄우기
             .flatMap { $1.rx.selectedImages }
             .compactMap(\.first)
             .observe(on: MainScheduler.instance)
@@ -163,6 +163,19 @@ final class PlantRegisterViewController: BaseViewController, View {
             },
             for: .touchUpInside
         )
+        
+        //TODO: 검색 카메라 버튼 구현 시 아래 주석 풀고 사용 예정입니다. (단, 이벤트 보내는 주체 변경 필요)
+//        registerView.plantTypeSearchButton.rx.tap
+//            .compactMap { [weak self] _ -> PHPickerViewController? in
+//                return self?.makeImagePicker()
+//            }
+//            .withUnretained(self)
+//            .do(onNext: { $0.present($1, animated: true) })
+//            .flatMap { $1.rx.selectedImages }
+//            .compactMap(\.first)
+//            .map { PlantRegisterReactor.Action.classificationImageSelected($0) }
+//            .bind(to: reactor.action)
+//            .disposed(by: disposeBag)
         
         registerView.categoryButtons.forEach { button in
             button.rx.tap

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -45,7 +45,7 @@ final class PlantRegisterViewController: BaseViewController, View {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        bindUI()
+//        bindUI(reactor: reactor)
     }
     
     func bind(reactor: PlantRegisterReactor) {
@@ -129,15 +129,17 @@ final class PlantRegisterViewController: BaseViewController, View {
                 self?.steps.accept(AppStep.alert("저장 실패", message))
             })
             .disposed(by: disposeBag)
+        
+        bindUI(reactor: reactor)
     }
     
-    private func bindUI() {
-        registerView.headerView.backButton.addAction(
-            UIAction { [weak self] _ in
-                self?.steps.accept(AppStep.pageBack)
-            },
-            for: .touchUpInside
-        )
+    private func bindUI(reactor: PlantRegisterReactor) {
+        registerView.headerView.backButton.rx.tap
+            .map {
+                AppStep.pageBack
+            }
+            .bind(to: steps)
+            .disposed(by: disposeBag)
         
         registerView.cameraButton.addAction(
             UIAction { [weak self] _ in
@@ -154,43 +156,38 @@ final class PlantRegisterViewController: BaseViewController, View {
         )
         
         registerView.categoryButtons.forEach { button in
-            button.addAction(
-                UIAction { [weak self] _ in
+            button.rx.tap
+                .subscribe(onNext: { [weak self] in
                     self?.updateSingleSelection(
                         selectedButton: button,
-                        in: self?.registerView.categoryButtons ?? []
-                    )
+                        in: self?.registerView.categoryButtons ?? [])
                     self?.notifyCategorySelectionChanged()
-                },
-                for: .touchUpInside
-            )
+                })
+                .disposed(by: disposeBag)
         }
         
         registerView.locationButtons.forEach { button in
-            button.addAction(
-                UIAction { [weak self] _ in
+            button.rx.tap
+                .subscribe(onNext: { [weak self] in
                     self?.updateSingleSelection(
                         selectedButton: button,
                         in: self?.registerView.locationButtons ?? []
                     )
                     self?.notifyLocationSelectionChanged()
-                },
-                for: .touchUpInside
-            )
+                })
+                .disposed(by: disposeBag)
         }
         
-        registerView.wateringCycleTextField.addTarget(
-            self,
-            action: #selector(handleFormValueChanged),
-            for: .editingChanged
-        )
+        registerView.wateringCycleTextField.rx.text.orEmpty
+            .map { PlantRegisterReactor.Action.updateWateringInterval($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         
-        registerView.registerButton.addAction(
-            UIAction { [weak self] _ in
+        registerView.registerButton.rx.tap
+            .subscribe(onNext: { [weak self] in
                 self?.handleRegisterTap()
-            },
-            for: .touchUpInside
-        )
+            })
+            .disposed(by: disposeBag)
         
         configureLastWateredDatePicker()
         syncInitialFormState()
@@ -200,11 +197,11 @@ final class PlantRegisterViewController: BaseViewController, View {
         buttons.forEach { $0.isSelected = ($0 === selectedButton) }
     }
     
-    @objc private func handleFormValueChanged() {
-        reactor?.action.onNext(
-            .updateWateringInterval(registerView.wateringCycleTextField.text ?? "")
-        )
-    }
+//    @objc private func handleFormValueChanged() {
+//        reactor?.action.onNext(
+//            .updateWateringInterval(registerView.wateringCycleTextField.text ?? "")
+//        )
+//    }
     
     private func notifyCategorySelectionChanged() {
         reactor?.action.onNext(.updateCategory(selectedCategoryFromButtons))

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -152,8 +152,7 @@ final class PlantRegisterViewController: BaseViewController, View {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] image in
                 self?.selectedImage = image
-                self?.registerView.cameraButton.layer.contents = image.cgImage
-                self?.registerView.cameraButton.layer.contentsGravity = .resizeAspectFill
+                self?.registerView.cameraButton.backgroundImageView.image = image
                 self?.registerView.cameraButton.backgroundColor = .clear
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #84 

## 🛠 작업 내용 (What I did)
- PHPickerViewController Delegate RxSwift화
- CameraProfileButton에 이미지가 상하 반전되어 들어가는 현상 수정 

## 💻 구현 상세 (Implementation Details)
- PHPickerViewController Delegate를 Reactive 확장하여 기존 1:1 관계로 작동하던 코드를 1:다 관계로 작동할 수 있도록 수정
- CameraProfileButton에 이미지가 상하 반전되어 들어가는 현상 수정
- PlantRegisterViewController bindUI 함수 수정: addAction 대신 rx.tap을 사용하는 코드로 수정 

## 🧐 리뷰 포인트 (Review Points)
- reactive가 적용되면서 수정된 코드들 확인 부탁드립니다.
- PlantRegisterViewController의 bindUI 함수가 수정되었으나, 완전히 ReactorKit처럼 리팩토링하지는 못했습니다. 확인 후 추후 구현 시 수정 부탁드립니다.
- CameraProfileButton에 backgroundImageView가 추가되었습니다. 참고부탁드립니다.  

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?