### PR TITLE
[Feat] 약관 및 개인정보처리방침 웹 페이지 연결

### DIFF
--- a/LeafLog/LeafLog/View/LoginView/LoginView.swift
+++ b/LeafLog/LeafLog/View/LoginView/LoginView.swift
@@ -60,14 +60,24 @@ final class LoginView: UIView {
         $0.textAlignment = .center
         $0.isHidden = true
     }
-    
-    let privacyLabel = UILabel(text: "시작하면 이용약관 및 개인정보처리방침에 동의하게 됩니다.", config: .label12, color: .grayScale800)
-    
-    
+
+    private let agreementPrefixLabel = UILabel(text: "시작하면 ", config: .label12, color: .grayScale800)
+    let termsButton = UIButton(type: .system)
+    private let agreementMiddleLabel = UILabel(text: " 및 ", config: .label12, color: .grayScale800)
+    let privacyPolicyButton = UIButton(type: .system)
+    private let agreementSuffixLabel = UILabel(text: "에 동의하게 됩니다.", config: .label12, color: .grayScale800)
+
+    private let agreementStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.alignment = .center
+        $0.spacing = 0
+    }
+
     // MARK: -  Initialization
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .systemBackground
+        setupAgreementButtons()
         setupUI()
     }
     
@@ -83,19 +93,27 @@ final class LoginView: UIView {
             appleLoginCooldownLabel,
             kakaoLoginButton,
             googleLoginButton,
-            privacyLabel
+            agreementStackView
         ].forEach { addSubview($0) }
-        
-        privacyLabel.snp.makeConstraints {
+
+        [
+            agreementPrefixLabel,
+            termsButton,
+            agreementMiddleLabel,
+            privacyPolicyButton,
+            agreementSuffixLabel
+        ].forEach { agreementStackView.addArrangedSubview($0) }
+
+        agreementStackView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.bottom.equalToSuperview().inset(70)
         }
-        
+
         googleLoginButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.height.equalTo(50)
             $0.horizontalEdges.equalToSuperview().inset(15)
-            $0.bottom.equalTo(privacyLabel.snp.top).offset(-106)
+            $0.bottom.equalTo(agreementStackView.snp.top).offset(-106)
         }
         
         kakaoLoginButton.snp.makeConstraints {
@@ -132,5 +150,29 @@ final class LoginView: UIView {
         appleLoginCooldownLabel.text = isVisible ? "Apple 계정 연결 해제 처리 중입니다. 잠시 후 다시 시도해주세요." : nil
         appleLoginCooldownLabel.isHidden = !isVisible
         appleLoginButton.alpha = isVisible ? 0.45 : 1
+    }
+
+    private func setupAgreementButtons() {
+        configureAgreementLinkButton(termsButton, title: "이용약관")
+        configureAgreementLinkButton(privacyPolicyButton, title: "개인정보처리방침")
+    }
+
+    private func configureAgreementLinkButton(_ button: UIButton, title: String) {
+        let font = UIFontMetrics(forTextStyle: .footnote).scaledFont(
+            for: .systemFont(ofSize: 12, weight: .medium)
+        )
+        let attributedTitle = NSAttributedString(
+            string: title,
+            attributes: [
+                .font: font,
+                .foregroundColor: UIColor.grayScale800,
+                .underlineStyle: NSUnderlineStyle.single.rawValue
+            ]
+        )
+
+        button.setAttributedTitle(attributedTitle, for: .normal)
+        button.backgroundColor = .clear
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.accessibilityTraits.insert(.link)
     }
 }

--- a/LeafLog/LeafLog/View/LoginView/LoginViewController.swift
+++ b/LeafLog/LeafLog/View/LoginView/LoginViewController.swift
@@ -9,10 +9,13 @@ import UIKit
 import ReactorKit
 import RxSwift
 import RxCocoa
+import SafariServices
 
 class LoginViewController: BaseViewController, View {
     
     private let loginView = LoginView()
+    private let privacyPolicyURLString = "https://leaflog.notion.site/LeafLog-34c4589f9d0f803eb977fb600be7bf94"
+    private let termsURLString = "https://leaflog.notion.site/LeafLog-34c4589f9d0f80b59f9fcc02fd11ca78?source=copy_link"
     
     
     // MARK: - Lifecycle
@@ -57,6 +60,20 @@ class LoginViewController: BaseViewController, View {
         loginView.kakaoLoginButton.rx.tap
             .map { LoginReactor.Action.kakaoLoginTapped }
             .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        loginView.termsButton.rx.tap
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                self?.presentWebPage(urlString: self?.termsURLString)
+            })
+            .disposed(by: disposeBag)
+
+        loginView.privacyPolicyButton.rx.tap
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                self?.presentWebPage(urlString: self?.privacyPolicyURLString)
+            })
             .disposed(by: disposeBag)
     }
     
@@ -104,5 +121,17 @@ class LoginViewController: BaseViewController, View {
                 self?.steps.accept(AppStep.alert("에러", message))
             })
             .disposed(by: disposeBag)
+    }
+
+    private func presentWebPage(urlString: String?) {
+        guard let urlString,
+              let url = URL(string: urlString) else {
+            steps.accept(AppStep.alert("오류", "페이지 주소를 열 수 없습니다."))
+            return
+        }
+
+        let safariViewController = SFSafariViewController(url: url)
+        safariViewController.modalPresentationStyle = .pageSheet
+        present(safariViewController, animated: true)
     }
 }

--- a/LeafLog/LeafLog/View/MyPageView/MyPageViewController.swift
+++ b/LeafLog/LeafLog/View/MyPageView/MyPageViewController.swift
@@ -11,12 +11,15 @@ import RxSwift
 import RxCocoa
 import Dependencies
 import MessageUI
+import SafariServices
 
 final class MyPageViewController: BaseViewController, View {
     
     @Dependency(\.supabaseManager) private var supabaseManager
     private let myPageView = MyPageView()
     private var imageLoadTask: Task<Void, Never>?
+    private let privacyPolicyURLString = "https://leaflog.notion.site/LeafLog-34c4589f9d0f803eb977fb600be7bf94"
+    private let termsURLString = "https://leaflog.notion.site/LeafLog-34c4589f9d0f80b59f9fcc02fd11ca78?source=copy_link"
     
     override func loadView() {
         view = myPageView
@@ -87,6 +90,22 @@ final class MyPageViewController: BaseViewController, View {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in
                 self?.presentMailComposeViewController(isError: true)
+            })
+            .disposed(by: disposeBag)
+
+        // 개인정보처리방침
+        myPageView.privacyPolicyButton.rx.tap
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                self?.presentWebPage(urlString: self?.privacyPolicyURLString)
+            })
+            .disposed(by: disposeBag)
+
+        // 이용약관
+        myPageView.termsButton.rx.tap
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                self?.presentWebPage(urlString: self?.termsURLString)
             })
             .disposed(by: disposeBag)
     }
@@ -213,6 +232,18 @@ final class MyPageViewController: BaseViewController, View {
         }
 
         return "\(path)?updatedAt=\(updatedAt.timeIntervalSince1970)"
+    }
+
+    private func presentWebPage(urlString: String?) {
+        guard let urlString,
+              let url = URL(string: urlString) else {
+            steps.accept(AppStep.alert("오류", "페이지 주소를 열 수 없습니다."))
+            return
+        }
+
+        let safariViewController = SFSafariViewController(url: url)
+        safariViewController.modalPresentationStyle = .pageSheet
+        present(safariViewController, animated: true)
     }
 }
 


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #111

## 🛠 작업 내용 (What I did)
- 마이페이지의 `개인정보처리방침`, `이용약관` 셀 탭 시 Notion 페이지가 열리도록 구현했습니다.
- 로그인 페이지 하단 안내 문구에서 `이용약관`, `개인정보처리방침` 텍스트를 밑줄 링크 버튼으로 분리했습니다.
- 로그인 페이지에서도 각 링크 탭 시 `SFSafariViewController`로 웹 페이지가 앱 안에서 열리도록 연결했습니다.

## 📸 스크린샷 (Screenshots)
<img width="603" height="1311" alt="스크린샷, 2026-04-24 오후 7 09 41" src="https://github.com/user-attachments/assets/e6e1b5c9-9b78-4b16-869c-8f99c478b4c1" />


## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
