### PR TITLE
[FEAT] 식물 상태 반영 UI 추가

### DIFF
--- a/LeafLog/LeafLog/Reactor/PlantCareReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantCareReactor.swift
@@ -1074,6 +1074,10 @@ private extension PlantCareReactor {
     // 식물 정보 디테일
     static func makePlantInfoRows(from plant: MyPlant) -> [PlantCarePlantInfoRow] {
         [
+            PlantCarePlantInfoRow(
+                title: "식물 상태",
+                value: displayHealthStatus(from: plant.healthStatus)
+            ),
             PlantCarePlantInfoRow(title: "데려온 날", value: displayDate(from: plant.createdAt)),
             PlantCarePlantInfoRow(title: "위치", value: plant.location?.rawValue ?? "미지정"),
             PlantCarePlantInfoRow(title: "마지막 급수일", value: displayDate(from: plant.lastWateredAt))
@@ -1096,6 +1100,10 @@ private extension PlantCareReactor {
 
     static func displayDate(from date: Date) -> String {
         plantInfoDateFormatter.string(from: date)
+    }
+
+    static func displayHealthStatus(from status: String) -> String {
+        PlantCareStatus.make(from: status)?.title ?? nonEmptyText(status, fallback: "정보 없음")
     }
 
     static let plantInfoDateFormatter: DateFormatter = {

--- a/LeafLog/LeafLog/View/PlantCareView/PlantDetailCell.swift
+++ b/LeafLog/LeafLog/View/PlantCareView/PlantDetailCell.swift
@@ -73,6 +73,14 @@ final class PlantDetailCell: UICollectionViewCell {
     private let adoptedDateRow = PlantDetailInfoRowView(title: "데려온 날", value: "", showSeparator: true)
     private let locationRow = PlantDetailInfoRowView(title: "위치", value: "", showSeparator: true)
     private let lastWateredDateRow = PlantDetailInfoRowView(title: "마지막 급수일", value: "", showSeparator: false)
+    private var rowDefinitions: [(view: PlantDetailInfoRowView, title: String)] {
+        [
+            (healthStatusRow, "식물 상태"),
+            (adoptedDateRow, "데려온 날"),
+            (locationRow, "위치"),
+            (lastWateredDateRow, "마지막 급수일")
+        ]
+    }
 
     private let wateringGuideRow = PlantDetailGuideRowView(
         icon: .asset("badgeWaterBig"),
@@ -139,8 +147,8 @@ extension PlantDetailCell {
         cardView.addSubview(stackView)
         guideCardView.addSubview(guideStackView)
 
-        [healthStatusRow, adoptedDateRow, locationRow, lastWateredDateRow].forEach {
-            stackView.addArrangedSubview($0)
+        rowDefinitions.forEach { row in
+            stackView.addArrangedSubview(row.view)
         }
 
         [wateringGuideRow, temperatureGuideRow, humidityGuideRow, pestGuideRow].forEach {
@@ -183,22 +191,18 @@ extension PlantDetailCell {
     }
 
     func configure(rows: [RowData], guide: GuideData, isGuideEnabled: Bool) {
-        let defaultRows = [
-            RowData(title: "식물 상태", value: ""),
-            RowData(title: "데려온 날", value: ""),
-            RowData(title: "위치", value: ""),
-            RowData(title: "마지막 급수일", value: "")
-        ]
-
+        let defaultRows = rowDefinitions.map { RowData(title: $0.title, value: "") }
         let appliedRows = rows.isEmpty ? defaultRows : rows
-        let rowViews = [healthStatusRow, adoptedDateRow, locationRow, lastWateredDateRow]
 
-        for (index, rowView) in rowViews.enumerated() {
+        for (index, rowDefinition) in rowDefinitions.enumerated() {
             if index < appliedRows.count {
-                rowView.isHidden = false
-                rowView.configure(title: appliedRows[index].title, value: appliedRows[index].value)
+                rowDefinition.view.isHidden = false
+                rowDefinition.view.configure(
+                    title: appliedRows[index].title,
+                    value: appliedRows[index].value
+                )
             } else {
-                rowView.isHidden = true
+                rowDefinition.view.isHidden = true
             }
         }
 

--- a/LeafLog/LeafLog/View/PlantCareView/PlantDetailCell.swift
+++ b/LeafLog/LeafLog/View/PlantCareView/PlantDetailCell.swift
@@ -69,6 +69,7 @@ final class PlantDetailCell: UICollectionViewCell {
         $0.spacing = 28
     }
 
+    private let healthStatusRow = PlantDetailInfoRowView(title: "식물 상태", value: "", showSeparator: true)
     private let adoptedDateRow = PlantDetailInfoRowView(title: "데려온 날", value: "", showSeparator: true)
     private let locationRow = PlantDetailInfoRowView(title: "위치", value: "", showSeparator: true)
     private let lastWateredDateRow = PlantDetailInfoRowView(title: "마지막 급수일", value: "", showSeparator: false)
@@ -138,7 +139,7 @@ extension PlantDetailCell {
         cardView.addSubview(stackView)
         guideCardView.addSubview(guideStackView)
 
-        [adoptedDateRow, locationRow, lastWateredDateRow].forEach {
+        [healthStatusRow, adoptedDateRow, locationRow, lastWateredDateRow].forEach {
             stackView.addArrangedSubview($0)
         }
 
@@ -183,13 +184,14 @@ extension PlantDetailCell {
 
     func configure(rows: [RowData], guide: GuideData, isGuideEnabled: Bool) {
         let defaultRows = [
+            RowData(title: "식물 상태", value: ""),
             RowData(title: "데려온 날", value: ""),
             RowData(title: "위치", value: ""),
             RowData(title: "마지막 급수일", value: "")
         ]
 
         let appliedRows = rows.isEmpty ? defaultRows : rows
-        let rowViews = [adoptedDateRow, locationRow, lastWateredDateRow]
+        let rowViews = [healthStatusRow, adoptedDateRow, locationRow, lastWateredDateRow]
 
         for (index, rowView) in rowViews.enumerated() {
             if index < appliedRows.count {


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #126

## 🛠 작업 내용 (What I did)
- 식물 상세 탭에서 식물 상태를 볼 수 있도록 추가

## 💻 구현 상세 (Implementation Details)
- healthStatusRow를 새로 만들고 스택 순서를 식물 상태가 가장 상단에 오도록 배치
- PlantCareReactor에서 plant.healthStatus를 받아와서 healthy/sick/unrecoverable 값이 각각 건강함/아픔/회복불가로 표시되게 정리했습니다.

## 📸 스크린샷 (Screenshots)
|기능 실행 전|
|:---:|
|<img width="400" height="900" alt="image" src="https://github.com/user-attachments/assets/37e038bc-4845-4fad-b533-2a11d9327669" />|

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?
