### PR TITLE
[Refactor] 5MB 초과 이미지 업로드 에러 메세지 지정

### DIFF
--- a/LeafLog/LeafLog/App/SupabaseManager.swift
+++ b/LeafLog/LeafLog/App/SupabaseManager.swift
@@ -73,6 +73,11 @@ extension SupabaseManager {
         static let lifetime: TimeInterval = 50 * 60 // 캐시에서 URL 유지하는 시간
     }
 
+    private enum ImageUploadLimit {
+        static let maxByteCount = 5 * 1024 * 1024 // 5MB
+        static let exceededMessage = "5MB를 초과하는 이미지는 등록할 수 없습니다."
+    }
+
     // 프로필 이미지를 private bucket에 업로드하고, DB에는 storage path만 저장
     func uploadProfileImage(_ image: UIImage, userID: UUID) async throws -> String {
         let normalizedUserID = userID.uuidString.lowercased()
@@ -81,7 +86,8 @@ extension SupabaseManager {
             image,
             bucket: StorageBucket.profileImages,
             objectPath: objectPath,
-            conversionError: .profileFailed("프로필 이미지를 변환하지 못했어요.")
+            conversionError: .profileFailed("프로필 이미지를 변환하지 못했어요."),
+            sizeLimitError: .profileFailed(ImageUploadLimit.exceededMessage)
         )
     }
     
@@ -94,7 +100,8 @@ extension SupabaseManager {
             image,
             bucket: StorageBucket.plantImages,
             objectPath: objectPath,
-            conversionError: .plantFailed("식물 이미지를 변환하지 못했어요.")
+            conversionError: .plantFailed("식물 이미지를 변환하지 못했어요."),
+            sizeLimitError: .plantFailed(ImageUploadLimit.exceededMessage)
         )
     }
     
@@ -107,7 +114,8 @@ extension SupabaseManager {
             image,
             bucket: StorageBucket.plantImages,
             objectPath: objectPath,
-            conversionError: .careFailed("일기 사진을 변환하지 못했어요.")
+            conversionError: .careFailed("일기 사진을 변환하지 못했어요."),
+            sizeLimitError: .careFailed(ImageUploadLimit.exceededMessage)
         )
     }
     
@@ -142,25 +150,46 @@ extension SupabaseManager {
         _ image: UIImage,
         bucket: String,
         objectPath: String,
-        conversionError: AuthError
+        conversionError: AuthError,
+        sizeLimitError: AuthError
     ) async throws -> String {
         guard let fileData = image.jpegData(compressionQuality: 0.8) else {
             throw conversionError
         }
+
+        // 이미지 용량 검사
+        guard fileData.count <= ImageUploadLimit.maxByteCount else {
+            throw sizeLimitError
+        }
         
-        _ = try await client.storage
-            .from(bucket)
-            .upload(
-                path: objectPath,
-                file: fileData,
-                options: FileOptions(
-                    cacheControl: "3600",
-                    contentType: "image/jpeg",
-                    upsert: true
+        do {
+            _ = try await client.storage
+                .from(bucket)
+                .upload(
+                    path: objectPath,
+                    file: fileData,
+                    options: FileOptions(
+                        cacheControl: "3600",
+                        contentType: "image/jpeg",
+                        upsert: true
+                    )
                 )
-            )
+        } catch {
+            if Self.isStorageSizeLimitError(error) {
+                // 한국어 에러 반환
+                throw sizeLimitError
+            }
+
+            throw error
+        }
         
         return objectPath
+    }
+
+    private static func isStorageSizeLimitError(_ error: Error) -> Bool {
+        let message = "\(error.localizedDescription) \(String(describing: error))".lowercased()
+        return message.contains("maximum allowed size")
+            || message.contains("object exceeded")
     }
 
     // URL 변환 로직

--- a/LeafLog/LeafLog/App/SupabaseManager.swift
+++ b/LeafLog/LeafLog/App/SupabaseManager.swift
@@ -187,7 +187,7 @@ extension SupabaseManager {
     }
 
     private static func isStorageSizeLimitError(_ error: Error) -> Bool {
-        let message = "\(error.localizedDescription) \(String(describing: error))".lowercased()
+        let message = (String(describing: error)).lowercased()
         return message.contains("maximum allowed size")
             || message.contains("object exceeded")
     }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #127 

## 🛠 작업 내용 (What I did)
- Supabase Storage 이미지 업로드 시 5MB 초과 이미지에 대한 사용자 안내 메시지를 한국어로 표시하도록 수정했습니다.
- 프로필 이미지, 식물 대표 이미지, 일기 사진 업로드에 동일한 5MB 제한 처리를 적용했습니다.
- 기존 Reactor 에러 처리 및 알럿 표시 흐름을 그대로 활용하도록 `SupabaseManager`의 공통 이미지 업로드 로직에서 처리했습니다.


## 💻 구현 상세 (Implementation Details)
- `ImageUploadLimit`를 추가해 이미지 업로드 제한 크기와 안내 문구를 한 곳에서 관리하도록 했습니다.
  - 최대 크기: `5 * 1024 * 1024`
  - 안내 문구: `5MB를 초과하는 이미지는 등록할 수 없습니다.`
- `UIImage`를 `jpegData(compressionQuality: 0.8)`로 변환한 뒤, 실제 업로드될 데이터 크기인 `fileData.count`를 기준으로 5MB 초과 여부를 검사했습니다.
- 5MB를 초과하면 Supabase 요청을 보내기 전에 각 업로드 상황에 맞는 `AuthError`를 throw하도록 처리했습니다.
  - 프로필 이미지: `.profileFailed(...)`
  - 식물 이미지: `.plantFailed(...)`
  - 일기 사진: `.careFailed(...)`
- Supabase 서버에서 `The object exceeded the maximum allowed size` 계열의 에러가 내려오는 경우도 대비해, 해당 에러를 한국어 안내 메시지로 매핑했습니다.


## 📸 스크린샷 (Screenshots)
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/3f2e9e5c-7c45-4922-83f7-c503da39101e" />

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
