### PR TITLE
[FIX] 등록/수정 화면 리팩토링 및 캘린더에서 수정 안되는 버그 픽스

### DIFF
--- a/LeafLog/LeafLog/App/Flows/AppStep.swift
+++ b/LeafLog/LeafLog/App/Flows/AppStep.swift
@@ -37,7 +37,8 @@ enum AppStep: Step {
     case alarmCenter
     
     // PlantTab
-    case plantRegister(SelectedPlant? = nil)
+    case plantRegister
+    case plantRegisterSelectedPlant(SelectedPlant)
     case plantEdit(MyPlant)
     case plantSearch
     case plantSearchDetail(String)

--- a/LeafLog/LeafLog/App/Flows/AppStep.swift
+++ b/LeafLog/LeafLog/App/Flows/AppStep.swift
@@ -25,7 +25,8 @@ enum AppStep: Step {
     
     // Tab
     case plantTab
-    case endPlantRegister
+    case endPlantRegisterEdit
+    case endPlantDelete
     case calendarTab
     case myInfoTab
     case profileEdit // 프로필 수정 화면

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -42,15 +42,15 @@ final class MainFlow: Flow {
         case .record(let plantID):
             return navigateToPlantRecord(plantID: plantID)
             
-//        case .plantEdit(let plant):
-//            let plantRegisterViewController = makePlantEditViewController(plant: plant)
-//            navigate(to: plantRegisterViewController, animated: true)
-//            
-//            return .one(
-//                flowContributor: .contribute(
-//                    withNextPresentable: plantRegisterViewController,
-//                    withNextStepper: plantRegisterViewController
-//                ))
+        case .plantEdit(let plant):
+            let plantRegisterViewController = makePlantEditViewController(plant: plant)
+            navigate(to: plantRegisterViewController, animated: true)
+            
+            return .one(
+                flowContributor: .contribute(
+                    withNextPresentable: plantRegisterViewController,
+                    withNextStepper: plantRegisterViewController
+                ))
           
         case .alarmCenter:
             return navigateToAlarmCenter()

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -8,8 +8,10 @@
 import UIKit
 import RxFlow
 import ReactorKit
+import Dependencies
 
 final class MainFlow: Flow {
+    @Dependency(\.uiApplication) private var uiApplication
     private let window: UIWindow
     private let tabBarController = MainViewController()
     
@@ -55,6 +57,27 @@ final class MainFlow: Flow {
                     withNextPresentable: plantRegisterViewController,
                     withNextStepper: plantRegisterViewController
                 ))
+
+        case .plantSearch:
+            return navigateToPlantSearch()
+
+        case .plantSearchDetail(let contentNumber):
+            return navigateToPlantSearchDetail(contentNumber: contentNumber)
+
+        case .classificationResult(let result):
+            return navigateToClassificationResult(result)
+
+        case .plantRegisterSelectedPlant(let selectedPlant):
+            return updatePlantRegister(selectedPlant)
+
+        case .cameraRequired:
+            return navigateToCameraClassification()
+
+        case .applicatoinSettingRequired:
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                uiApplication.open(url)
+            }
+            return .none
 
         case let .confirmAlert(title, message, okTitle, onConfirm):
             presentConfirmAlert(
@@ -192,9 +215,102 @@ extension MainFlow {
             withNextPresentable: notificationCenterViewController,
             withNextStepper: notificationCenterViewController))
     }
+
+    private func navigateToPlantSearch() -> FlowContributors {
+        let searchViewController = SearchViewController()
+        searchViewController.hidesBottomBarWhenPushed = true
+        navigate(to: searchViewController, animated: true)
+
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: searchViewController,
+                withNextStepper: searchViewController
+            )
+        )
+    }
+
+    private func navigateToPlantSearchDetail(contentNumber: String) -> FlowContributors {
+        let reactor = SearchDetailReactor(contentNumber: contentNumber)
+        let viewController = SearchDetailViewController(reactor: reactor)
+        viewController.hidesBottomBarWhenPushed = true
+        navigate(to: viewController, animated: true)
+
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: viewController,
+                withNextStepper: viewController
+            )
+        )
+    }
+
+    private func navigateToClassificationResult(_ result: [String: PlantClassificationService.Confidence]) -> FlowContributors {
+        let searchViewController = SearchViewController(classficationResult: result)
+        searchViewController.hidesBottomBarWhenPushed = true
+        navigate(to: searchViewController, animated: true)
+
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: searchViewController,
+                withNextStepper: searchViewController
+            )
+        )
+    }
+
+    private func navigateToCameraClassification() -> FlowContributors {
+        let cameraViewController = CameraClassificationViewController()
+        navigate(to: cameraViewController, animated: true)
+
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: cameraViewController,
+                withNextStepper: cameraViewController
+            )
+        )
+    }
+
+    private func updatePlantRegister(_ selectedPlant: SelectedPlant) -> FlowContributors {
+        guard let navigationController = tabBarController.selectedViewController as? UINavigationController else {
+            return .none
+        }
+
+        if let registerViewController = navigationController.topViewController as? PlantRegisterViewController {
+            registerViewController.updateSelectedPlant(selectedPlant)
+            return .none
+        }
+
+        if let registerIndex = navigationController.viewControllers.lastIndex(where: { $0 is PlantRegisterViewController }),
+           let registerViewController = navigationController.viewControllers[registerIndex] as? PlantRegisterViewController {
+            registerViewController.updateSelectedPlant(selectedPlant)
+
+            let previousViewControllers = Array(navigationController.viewControllers.prefix(registerIndex))
+            let searchViewControllers = navigationController.viewControllers
+                .dropFirst(registerIndex + 1)
+                .filter { $0 is SearchViewController }
+            let updatedViewControllers = previousViewControllers + searchViewControllers + [registerViewController]
+            navigationController.setViewControllers(updatedViewControllers, animated: true)
+            return .none
+        }
+
+        let plantRegisterViewController = makePlantRegisterViewController(selectedPlant: selectedPlant)
+        navigate(to: plantRegisterViewController, animated: true)
+
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: plantRegisterViewController,
+                withNextStepper: plantRegisterViewController
+            )
+        )
+    }
 }
 
 extension MainFlow {
+    private func makePlantRegisterViewController(selectedPlant: SelectedPlant?) -> PlantRegisterViewController {
+        let reactor = PlantRegisterReactor(selectedPlant: selectedPlant)
+        let viewController = PlantRegisterViewController(reactor: reactor)
+        viewController.hidesBottomBarWhenPushed = true
+        return viewController
+    }
+
     private func makePlantEditViewController(plant: MyPlant) -> PlantRegisterViewController {
         let reactor = PlantRegisterReactor(mode: .edit(plant))
         let viewController = PlantRegisterViewController(reactor: reactor)

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -38,6 +38,10 @@ final class MainFlow: Flow {
         case .pageBack:
             pop(animated: true)
             return .none
+
+        case .endPlantDelete:
+            popTwice(animated: true)
+            return .none
             
         case .record(let plantID):
             return navigateToPlantRecord(plantID: plantID)
@@ -51,6 +55,15 @@ final class MainFlow: Flow {
                     withNextPresentable: plantRegisterViewController,
                     withNextStepper: plantRegisterViewController
                 ))
+
+        case let .confirmAlert(title, message, okTitle, onConfirm):
+            presentConfirmAlert(
+                title: title,
+                message: message,
+                okTitle: okTitle,
+                onConfirm: onConfirm
+            )
+            return .none
           
         case .alarmCenter:
             return navigateToAlarmCenter()
@@ -77,6 +90,21 @@ final class MainFlow: Flow {
             navigationController.popViewController(animated: animated)
         } else {
             tabBarController.selectedViewController?.dismiss(animated: animated)
+        }
+    }
+
+    private func popTwice(animated: Bool) {
+        guard let navigationController = tabBarController.selectedViewController as? UINavigationController else {
+            tabBarController.selectedViewController?.dismiss(animated: animated)
+            return
+        }
+
+        let targetIndex = navigationController.viewControllers.count - 3
+        if targetIndex >= 0 {
+            let targetViewController = navigationController.viewControllers[targetIndex]
+            navigationController.popToViewController(targetViewController, animated: animated)
+        } else {
+            navigationController.popToRootViewController(animated: animated)
         }
     }
 }
@@ -127,6 +155,25 @@ extension MainFlow {
         
         present(alert, animated: true)
         return .none
+    }
+
+    private func presentConfirmAlert(
+        title: String,
+        message: String,
+        okTitle: String,
+        onConfirm: @escaping () -> Void
+    ) {
+        let alert = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        alert.addAction(UIAlertAction(title: okTitle, style: .destructive) { _ in
+            onConfirm()
+        })
+
+        present(alert, animated: true)
     }
     
     private func navigateToPlantRecord(plantID: UUID) -> FlowContributors {

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -42,7 +42,7 @@ final class MainFlow: Flow {
             return .none
 
         case .endPlantDelete:
-            popTwice(animated: true)
+            popAfterDeletePlant(animated: true)
             return .none
             
         case .record(let plantID):
@@ -116,15 +116,24 @@ final class MainFlow: Flow {
         }
     }
 
-    private func popTwice(animated: Bool) {
+    private func popAfterDeletePlant(animated: Bool) {
         guard let navigationController = tabBarController.selectedViewController as? UINavigationController else {
             tabBarController.selectedViewController?.dismiss(animated: animated)
             return
         }
 
-        let targetIndex = navigationController.viewControllers.count - 3
+        let viewControllers = navigationController.viewControllers
+
+        guard let registerIndex = viewControllers.lastIndex(where: { $0 is PlantRegisterViewController }),
+              registerIndex > 0,
+              viewControllers[registerIndex - 1] is PlantCareViewController else {
+            navigationController.popToRootViewController(animated: animated)
+            return
+        }
+
+        let targetIndex = registerIndex - 2
         if targetIndex >= 0 {
-            let targetViewController = navigationController.viewControllers[targetIndex]
+            let targetViewController = viewControllers[targetIndex]
             navigationController.popToViewController(targetViewController, animated: animated)
         } else {
             navigationController.popToRootViewController(animated: animated)

--- a/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
@@ -52,7 +52,7 @@ final class PlantTabFlow: Flow {
             navigationController.pushViewController(viewController, animated: true)
             return .one(flowContributor: .contribute(withNextPresentable: viewController, withNextStepper: viewController))
             
-        case .endPlantRegister:
+        case .endPlantRegisterEdit:
             navigationController.popToRootViewController(animated: true)
             return .none
 
@@ -145,15 +145,6 @@ final class PlantTabFlow: Flow {
         case .diaryImageSourceSheet:
             presentDiaryImageSourceSheet()
             return .none
-
-        case let .confirmAlert(title, message, okTitle, onConfirm):
-            presentConfirmAlert(
-                title: title,
-                message: message,
-                okTitle: okTitle,
-                onConfirm: onConfirm
-            )
-            return .none
             
         case .cameraRequired:
             let camera = CameraClassificationViewController()
@@ -215,25 +206,6 @@ extension PlantTabFlow {
                 viewController?.deleteDiaryPhoto()
             }
         )
-    }
-
-    private func presentConfirmAlert(
-        title: String,
-        message: String,
-        okTitle: String,
-        onConfirm: @escaping () -> Void
-    ) {
-        let alert = UIAlertController(
-            title: title,
-            message: message,
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
-        alert.addAction(UIAlertAction(title: okTitle, style: .destructive) { _ in
-            onConfirm()
-        })
-
-        navigationController.present(alert, animated: true)
     }
 
     private func updateAndRestorePlantRegister(

--- a/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
@@ -56,59 +56,57 @@ final class PlantTabFlow: Flow {
             navigationController.popToRootViewController(animated: true)
             return .none
 
-        case .plantRegister(let selectedPlant):
-            if let selectedPlant,
-               let registerViewController = navigationController.topViewController as? PlantRegisterViewController {
-                registerViewController.updateSelectedPlant(selectedPlant)
+            // 새 식물 등록 시작
+        case .plantRegister:
+            let plantRegisterViewController = makePlantRegisterViewController(selectedPlant: nil)
 
-                return .none
-            }
-
-            if let selectedPlant,
-               let registerIndex = navigationController.viewControllers.lastIndex(where: { $0 is PlantRegisterViewController }),
-               let registerViewController = navigationController.viewControllers[registerIndex] as? PlantRegisterViewController {
-                registerViewController.updateSelectedPlant(selectedPlant)
-
-                let previousViewControllers = Array(navigationController.viewControllers.prefix(registerIndex))
-                let searchViewControllers = navigationController.viewControllers
-                    .dropFirst(registerIndex + 1)
-                    .filter { $0 is SearchViewController }
-                let updatedViewControllers = previousViewControllers + searchViewControllers + [registerViewController]
-                navigationController.setViewControllers(updatedViewControllers, animated: true)
-
-                return .none
-            }
-
-            let plantRegisterViewController = makePlantRegisterViewController(selectedPlant: selectedPlant)
-            
             if navigationController.viewControllers.isEmpty {
                 let homeViewController = HomeViewController()
                 navigationController.setViewControllers([homeViewController, plantRegisterViewController], animated: false)
-            } else if selectedPlant == nil,
-                      let registerIndex = navigationController.viewControllers.lastIndex(where: { $0 is PlantRegisterViewController }) {
+            } else if let registerIndex = navigationController.viewControllers.lastIndex(where: { $0 is PlantRegisterViewController }) {
                 var updatedViewControllers = Array(navigationController.viewControllers.prefix(registerIndex))
                 updatedViewControllers.append(plantRegisterViewController)
                 navigationController.setViewControllers(updatedViewControllers, animated: true)
             } else {
                 navigationController.pushViewController(plantRegisterViewController, animated: true)
             }
-            
+
             return .one(
                 flowContributor: .contribute(
                     withNextPresentable: plantRegisterViewController,
                     withNextStepper: CompositeStepper(
                         steppers: [plantRegisterViewController, photoSelectStepper]
-                    )))
-
-        case .plantEdit(let plant):
-            let plantRegisterViewController = makePlantEditViewController(plant: plant)
-            navigationController.pushViewController(plantRegisterViewController, animated: true)
+                    )
+                )
+            )
             
+            // 검색, 상세 등에서 식물 정보 가지고 시작
+        case .plantRegisterSelectedPlant(let selectedPlant):
+            if let registerViewController = navigationController.topViewController as? PlantRegisterViewController {
+                registerViewController.updateSelectedPlant(selectedPlant)
+                return .none
+            }
+
+            if let registerIndex = navigationController.viewControllers.lastIndex(where: { $0 is PlantRegisterViewController }),
+               let registerViewController = navigationController.viewControllers[registerIndex] as? PlantRegisterViewController {
+                updateAndRestorePlantRegister(
+                    registerViewController: registerViewController,
+                    selectedPlant: selectedPlant,
+                    registerIndex: registerIndex
+                )
+                return .none
+            }
+
+            let plantRegisterViewController = makePlantRegisterViewController(selectedPlant: selectedPlant)
+            navigationController.pushViewController(plantRegisterViewController, animated: true)
             return .one(
                 flowContributor: .contribute(
                     withNextPresentable: plantRegisterViewController,
-                    withNextStepper: plantRegisterViewController
-                ))
+                    withNextStepper: CompositeStepper(
+                        steppers: [plantRegisterViewController, photoSelectStepper]
+                    )
+                )
+            )
 
         case .plantSearch:
             let searchViewController = SearchViewController()
@@ -238,15 +236,23 @@ extension PlantTabFlow {
         navigationController.present(alert, animated: true)
     }
 
-    private func makePlantRegisterViewController(selectedPlant: SelectedPlant?) -> PlantRegisterViewController {
-        let reactor = PlantRegisterReactor(selectedPlant: selectedPlant)
-        let viewController = PlantRegisterViewController(reactor: reactor)
-        viewController.hidesBottomBarWhenPushed = true
-        return viewController
+    private func updateAndRestorePlantRegister(
+        registerViewController: PlantRegisterViewController,
+        selectedPlant: SelectedPlant,
+        registerIndex: Int
+    ) {
+        registerViewController.updateSelectedPlant(selectedPlant)
+
+        let previousViewControllers = Array(navigationController.viewControllers.prefix(registerIndex))
+        let searchViewControllers = navigationController.viewControllers
+            .dropFirst(registerIndex + 1)
+            .filter { $0 is SearchViewController }
+        let updatedViewControllers = previousViewControllers + searchViewControllers + [registerViewController]
+        navigationController.setViewControllers(updatedViewControllers, animated: true)
     }
 
-    private func makePlantEditViewController(plant: MyPlant) -> PlantRegisterViewController {
-        let reactor = PlantRegisterReactor(mode: .edit(plant))
+    private func makePlantRegisterViewController(selectedPlant: SelectedPlant?) -> PlantRegisterViewController {
+        let reactor = PlantRegisterReactor(selectedPlant: selectedPlant)
         let viewController = PlantRegisterViewController(reactor: reactor)
         viewController.hidesBottomBarWhenPushed = true
         return viewController

--- a/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
+++ b/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
@@ -48,7 +48,7 @@ extension HomeViewController {
                         guard let id = plant.id else { return nil }
                         return AppStep.record(plantID: id)
                     } else if plant.emptyShelf == .first {
-                        return AppStep.plantRegister()
+                        return AppStep.plantRegister
                     } else {
                         return nil
                     }

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
@@ -10,14 +10,13 @@ import Then
 import UIKit
 
 final class PlantRegisterView: UIView {
-
-    let headerView = TitleHeaderView(text: "식물 등록", hasBackButton: true)
-
-    private let scrollView = UIScrollView().then {
+    let scrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
         $0.alwaysBounceVertical = true
         $0.keyboardDismissMode = .onDrag
     }
+
+    let headerView = TitleHeaderView(text: "식물 등록", hasBackButton: true)
 
     private let contentView = UIView()
 

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -182,7 +182,7 @@ final class PlantRegisterViewController: BaseViewController, View {
                 self.resetFormUI()
                 switch reactor.currentState.mode {
                 case .create:
-                    self.steps.accept(AppStep.endPlantRegister)
+                    self.steps.accept(AppStep.endPlantRegisterEdit)
                 case .edit:
                     self.steps.accept(AppStep.pageBack)
                 }
@@ -193,7 +193,13 @@ final class PlantRegisterViewController: BaseViewController, View {
             .filter { $0 }
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] _ in
-                self?.steps.accept(AppStep.endPlantRegister)
+                guard let self else { return }
+                switch reactor.currentState.mode {
+                case .create:
+                    self.steps.accept(AppStep.endPlantRegisterEdit)
+                case .edit:
+                    self.steps.accept(AppStep.endPlantDelete)
+                }
             })
             .disposed(by: disposeBag)
         

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -7,6 +7,7 @@
 
 import PhotosUI
 import ReactorKit
+import RxKeyboard
 import RxSwift
 import UIKit
 import RxCocoa
@@ -62,6 +63,8 @@ final class PlantRegisterViewController: BaseViewController, View {
         maximumDynamicTypeCategory = .accessibilityLarge
         super.viewDidLoad()
         view.backgroundColor = .white
+        setKeyboardDismissGesture()
+        setKeyboard()
 
         guard let reactor else { return }
         bindUI(reactor: reactor)
@@ -301,6 +304,18 @@ final class PlantRegisterViewController: BaseViewController, View {
             .map { PlantRegisterReactor.Action.updateWateringInterval($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+
+        registerView.plantNameTextField.rx.controlEvent(.editingDidBegin)
+            .subscribe(onNext: { [weak self] in
+                self?.scrollToViewIfNeeded(self?.registerView.plantNameTextField)
+            })
+            .disposed(by: disposeBag)
+
+        registerView.lastWateredDateTextField.rx.controlEvent(.editingDidBegin)
+            .subscribe(onNext: { [weak self] in
+                self?.scrollToViewIfNeeded(self?.registerView.lastWateredDateTextField)
+            })
+            .disposed(by: disposeBag)
         
         registerView.registerButton.rx.tap
             .subscribe(onNext: { [weak self] in
@@ -366,6 +381,47 @@ final class PlantRegisterViewController: BaseViewController, View {
             button.isSelected = (buttonTitle == location?.rawValue)
         }
     }
+
+    private func setKeyboard() {
+        RxKeyboard.instance.visibleHeight
+            .drive(onNext: { [weak self] keyboardHeight in
+                guard let self else { return }
+
+                let isShowingLastWateredDatePicker = self.registerView.lastWateredDateTextField.isFirstResponder
+                let bottomInset: CGFloat
+
+                if isShowingLastWateredDatePicker {
+                    bottomInset = (keyboardHeight * 0.5) + 32
+                } else {
+                    bottomInset = keyboardHeight > 0 ? keyboardHeight + 32 : 32
+                }
+
+                self.registerView.scrollView.contentInset.bottom = bottomInset
+                self.registerView.scrollView.verticalScrollIndicatorInsets.bottom = bottomInset
+
+                if keyboardHeight > 0, !isShowingLastWateredDatePicker {
+                    self.scrollToCurrentResponderIfNeeded()
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func scrollToCurrentResponderIfNeeded() {
+        guard let responder = view.currentFirstResponder,
+              responder.isDescendant(of: registerView.scrollView) else {
+            return
+        }
+
+        scrollToViewIfNeeded(responder)
+    }
+
+    private func scrollToViewIfNeeded(_ targetView: UIView?) {
+        guard let targetView else { return }
+
+        let targetFrame = targetView.convert(targetView.bounds, to: registerView.scrollView)
+        let visibleRect = targetFrame.insetBy(dx: 0, dy: -16)
+        registerView.scrollView.scrollRectToVisible(visibleRect, animated: false)
+    }
     
     private func handlePlantTypeSearchTap() {
         view.endEditing(true)
@@ -414,5 +470,21 @@ extension PlantRegisterViewController {
         
         let imagePicker = PHPickerViewController(configuration: config)
         return imagePicker
+    }
+}
+
+private extension UIView {
+    var currentFirstResponder: UIView? {
+        if isFirstResponder {
+            return self
+        }
+
+        for subview in subviews {
+            if let responder = subview.currentFirstResponder {
+                return responder
+            }
+        }
+
+        return nil
     }
 }

--- a/LeafLog/LeafLog/View/SearchDetailView/SearchDetailViewController.swift
+++ b/LeafLog/LeafLog/View/SearchDetailView/SearchDetailViewController.swift
@@ -80,7 +80,7 @@ final class SearchDetailViewController: BaseViewController, View {
             .compactMap { $0 }
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] selectedPlant in
-                self?.steps.accept(AppStep.plantRegister(selectedPlant))
+                self?.steps.accept(AppStep.plantRegisterSelectedPlant(selectedPlant))
             })
             .disposed(by: disposeBag)
     }

--- a/LeafLog/LeafLog/View/SearchView/SearchViewController.swift
+++ b/LeafLog/LeafLog/View/SearchView/SearchViewController.swift
@@ -116,7 +116,7 @@ final class SearchViewController: BaseViewController, View {
             }
 
             view.onRegisterOtherTap = { [weak self] in
-                self?.steps.accept(AppStep.plantRegister(.other))
+                self?.steps.accept(AppStep.plantRegisterSelectedPlant(.other))
             }
 
             return view
@@ -213,7 +213,7 @@ final class SearchViewController: BaseViewController, View {
             .compactMap { $0 }
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] selectedPlant in
-                self?.steps.accept(AppStep.plantRegister(selectedPlant))
+                self?.steps.accept(AppStep.plantRegisterSelectedPlant(selectedPlant))
             })
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #130

## 🛠 작업 내용 (What I did)
- 캘린더 탭에서 식물 상세로 진입한 뒤 수정 화면으로 이동되지 않던 문제를 수정
- PlantTabFlow의 plantRegister 관련 분기를 정리해, 새 등록 진입과 검색 후 식물 선택 반영 흐름을 더 읽기 쉽게 수정
- 식물 수정 화면의 삭제 확인 alert와 삭제 후 화면 복귀 흐름을 보완
- 식물 등록/수정 화면에서 키보드와 마지막 급수일 날짜 피커 입력 UX를 개선

## 💻 구현 상세 (Implementation Details)
- MainFlow에서 plantEdit와 confirmAlert를 처리하도록 정리해, 홈/캘린더 어느 경로에서 들어와도 수정 화면과 삭제 확인 alert가 동일하게 동작하도록 리팩토링
- AppStep.plantRegister를 plantRegister와 plantRegisterSelectedPlant(SelectedPlant)로 분리해, 등록 시작과 검색 선택 결과 반영 분기를 나눔
- PlantRegisterViewController에 키보드 dismiss 제스처, 키보드 높이에 따른 스크롤 inset 조정, 별명 입력 시 가려짐 방지 스크롤, 날짜 피커 외부 탭 dismiss를 추가


## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
