### PR TITLE
[FIX] 첫 화면에서 등록하기 동작이 실행되지 않던 현상 수정

### DIFF
--- a/LeafLog/LeafLog/View/HomeView/EmptyPlantView.swift
+++ b/LeafLog/LeafLog/View/HomeView/EmptyPlantView.swift
@@ -8,6 +8,8 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 final class EmptyPlantView: UIView {
     private let imageView = UIImageView(image: .plantCategoryShrub).then {
@@ -83,5 +85,11 @@ extension EmptyPlantView {
         subLabel.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         
         return stackView
+    }
+}
+
+extension Reactive where Base: EmptyPlantView {
+    var registerButtonTap: ControlEvent<Void> {
+        base.registerButton.rx.tap
     }
 }

--- a/LeafLog/LeafLog/View/HomeView/HomeView.swift
+++ b/LeafLog/LeafLog/View/HomeView/HomeView.swift
@@ -183,4 +183,8 @@ extension Reactive where Base: HomeView {
                 base.dataSource.itemIdentifier(for: $0)
             }
     }
+    
+    var registerButtonTap: ControlEvent<Void> {
+        base.emptyView.rx.registerButtonTap
+    }
 }

--- a/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
+++ b/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
@@ -72,6 +72,13 @@ extension HomeViewController {
             }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        // 등록하기 버튼 탭시
+        homeView.rx.registerButtonTap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .map { _ in AppStep.plantRegister() }
+            .bind(to: steps)
+            .disposed(by: disposeBag)
     }
     
     private func bindState(reactor: HomeReactor) {

--- a/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
+++ b/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
@@ -75,7 +75,7 @@ extension HomeViewController {
         
         // 등록하기 버튼 탭시
         homeView.rx.registerButtonTap
-            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .throttle(.milliseconds(500), latest: false, scheduler: MainScheduler.instance)
             .map { _ in AppStep.plantRegister() }
             .bind(to: steps)
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #135 

## 🛠 작업 내용 (What I did)
- 등록 식물이 존재하지 않을 때 등록하기 동작이 실행되지 않던 현상 수정

## 💻 구현 상세 (Implementation Details)
- EmptyPlantView의 registerButton과 HomeReactor 연동

## 🧐 리뷰 포인트 (Review Points)
- 등록하기 버튼이 정상 작동하는지 확인 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
