### PR TITLE
[Feat] 등록 이미지 사이즈 압축 구현

### DIFF
--- a/LeafLog/LeafLog/App/SupabaseManager.swift
+++ b/LeafLog/LeafLog/App/SupabaseManager.swift
@@ -78,6 +78,11 @@ extension SupabaseManager {
         static let exceededMessage = "5MB를 초과하는 이미지는 등록할 수 없습니다."
     }
 
+    private enum ImageUploadCompression {
+        static let maxPixelLength: CGFloat = 1280 // 긴쪽이 1280 넘으면 1280으로
+        static let jpegQuality: CGFloat = 0.75 // 75% 품질로 압축
+    }
+
     // 프로필 이미지를 private bucket에 업로드하고, DB에는 storage path만 저장
     func uploadProfileImage(_ image: UIImage, userID: UUID) async throws -> String {
         let normalizedUserID = userID.uuidString.lowercased()
@@ -153,7 +158,7 @@ extension SupabaseManager {
         conversionError: AuthError,
         sizeLimitError: AuthError
     ) async throws -> String {
-        guard let fileData = image.jpegData(compressionQuality: 0.8) else {
+        guard let fileData = compressedImageData(from: image) else {
             throw conversionError
         }
 
@@ -184,6 +189,39 @@ extension SupabaseManager {
         }
         
         return objectPath
+    }
+
+    // MARK: - 이미지 압축하는 메서드
+    private func compressedImageData(from image: UIImage) -> Data? {
+        let resizedImage = resizedImageForUpload(from: image)
+        // 품질 압축
+        return resizedImage.jpegData(compressionQuality: ImageUploadCompression.jpegQuality)
+    }
+
+    private func resizedImageForUpload(from image: UIImage) -> UIImage {
+        let longestSide = max(image.size.width, image.size.height)
+
+        // 1280보다 작으면 통과
+        guard longestSide > ImageUploadCompression.maxPixelLength else {
+            return image
+        }
+
+        // 1280 기준으로 비율 유지해서 리사이즈
+        let ratio = ImageUploadCompression.maxPixelLength / longestSide
+        let targetSize = CGSize(
+            width: image.size.width * ratio,
+            height: image.size.height * ratio
+        )
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+
+        return UIGraphicsImageRenderer(size: targetSize, format: format).image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(origin: .zero, size: targetSize))
+            image.draw(in: CGRect(origin: .zero, size: targetSize))
+        }
     }
 
     private static func isStorageSizeLimitError(_ error: Error) -> Bool {

--- a/LeafLog/LeafLog/App/SupabaseManager.swift
+++ b/LeafLog/LeafLog/App/SupabaseManager.swift
@@ -199,7 +199,8 @@ extension SupabaseManager {
     }
 
     private func resizedImageForUpload(from image: UIImage) -> UIImage {
-        let longestSide = max(image.size.width, image.size.height)
+        let pixelSize = CGSize(width: image.size.width * image.scale, height: image.size.height * image.scale)
+        let longestSide = max(pixelSize.width, pixelSize.height)
 
         // 1280보다 작으면 통과
         guard longestSide > ImageUploadCompression.maxPixelLength else {


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #134

## 🛠 작업 내용 (What I did)

- 이미지 업로드 전 공통 압축 로직을 추가했습니다.
- 업로드 이미지의 긴 변이 1280px을 초과하면 비율을 유지한 채 리사이즈하도록 변경했습니다.
- 리사이즈된 이미지를 JPEG 품질 0.75로 변환해 Supabase Storage에 저장되도록 개선했습니다.
- 프로필 이미지, 식물 대표 이미지, 일기 사진 업로드가 모두 기존 `SupabaseManager.uploadImage` 흐름을 그대로 사용하면서 압축 로직을 공유하도록 했습니다.

## 🤔변경 이유

- 기존에는 `jpegData(compressionQuality: 0.8)`만 적용되어 JPEG 품질 압축은 되었지만, 원본 사진의 픽셀 크기는 그대로 유지되었습니다.

- 아이폰 원본 사진처럼 해상도가 큰 이미지는 품질 압축만으로는 용량이 충분히 줄어들지 않을 수 있어, 서버 저장 용량과 업로드 효율을 개선하기 위해 리사이즈 단계를 추가했습니다.

## 📸 스크린샷 (Screenshots)
|기능 실행 전|
<img width="234" height="265" alt="스크린샷 2026-04-30 오후 8 57 34" src="https://github.com/user-attachments/assets/f55652d6-7cfe-4ae1-87a0-296a408ed0c9" />

|기능 실행 후|
<img width="350" height="662" alt="스크린샷 2026-04-30 오후 8 58 58" src="https://github.com/user-attachments/assets/a9b8791a-4955-490b-bd4f-ca8197af654c" />



## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
