### PR TITLE
[Feat] 식물 처음 데려온 날 firstMetDate 추가

### DIFF
--- a/LeafLog/LeafLog/Model/MyPlant.swift
+++ b/LeafLog/LeafLog/Model/MyPlant.swift
@@ -64,6 +64,7 @@ struct PlantCreateInput {
     let image: UIImage?
     let wateringIntervalDays: Int
     let lastWateredAt: Date
+    let firstMetDate: Date?
 }
 
 // MARK: - 사용자 Update Input Model
@@ -81,6 +82,7 @@ struct PlantUpdateInput {
     
     let wateringIntervalDays: Int
     let lastWateredAt: Date
+    let firstMetDate: Date?
 }
 
 // MARK: - 앱 내에서 전반적으로 사용할 내 식물 모델
@@ -94,6 +96,7 @@ struct MyPlant: Codable, Hashable {
     let imagePath: String?
     let wateringIntervalDays: Int
     let lastWateredAt: Date
+    let firstMetDate: Date?
     let healthStatus: String
     let guideEnabled: Bool
     let createdAt: Date
@@ -138,6 +141,7 @@ struct MyPlant: Codable, Hashable {
         case guideEnabled = "guide_enabled"
         case createdAt = "created_at"
         case updatedAt = "updated_at"
-        case contentNumber
+        case contentNumber = "content_number"
+        case firstMetDate = "first_met_date"
     }
 }

--- a/LeafLog/LeafLog/Network/PlantDBManager.swift
+++ b/LeafLog/LeafLog/Network/PlantDBManager.swift
@@ -78,7 +78,8 @@ final class PlantDBManager {
             contentNumber: input.contentNumber,
             imagePath: imagePath,
             wateringIntervalDays: input.wateringIntervalDays,
-            lastWateredAt: input.lastWateredAt
+            lastWateredAt: input.lastWateredAt,
+            firstMetDate: input.firstMetDate
         )
         
         // Supabase Insert 실행 후 생성된 데이터를 모델로 바로 디코딩
@@ -126,6 +127,7 @@ final class PlantDBManager {
         let imagePath: String?
         let wateringIntervalDays: Int
         let lastWateredAt: Date
+        let firstMetDate: Date?
         
         enum CodingKeys: String, CodingKey {
             case id
@@ -138,6 +140,7 @@ final class PlantDBManager {
             case imagePath = "image_path"
             case wateringIntervalDays = "watering_interval_days"
             case lastWateredAt = "last_watered_at"
+            case firstMetDate = "first_met_date"
         }
     }
     
@@ -163,7 +166,8 @@ final class PlantDBManager {
             contentNumber: input.contentNumber,
             imagePath: imagePath,
             wateringIntervalDays: input.wateringIntervalDays,
-            lastWateredAt: input.lastWateredAt
+            lastWateredAt: input.lastWateredAt,
+            firstMetDate: input.firstMetDate
         )
         
         // Supabase Update 실행
@@ -236,6 +240,7 @@ final class PlantDBManager {
         let imagePath: String?
         let wateringIntervalDays: Int
         let lastWateredAt: Date
+        let firstMetDate: Date?
         
         enum CodingKeys: String, CodingKey {
             case category
@@ -246,6 +251,7 @@ final class PlantDBManager {
             case imagePath = "image_path"
             case wateringIntervalDays = "watering_interval_days"
             case lastWateredAt = "last_watered_at"
+            case firstMetDate = "first_met_date"
         }
     }
     

--- a/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
@@ -53,6 +53,7 @@ final class PlantRegisterReactor: Reactor {
         case updateNickname(String)
         case updateWateringInterval(String)
         case updateLastWateredDate(Date?)
+        case updateFirstMetDate(Date?)
         case saveTapped(nickname: String?, image: UIImage?)
         case deleteTapped
         
@@ -66,6 +67,7 @@ final class PlantRegisterReactor: Reactor {
         case setNicknameText(String)
         case setWateringIntervalText(String)
         case setLastWateredDate(Date?)
+        case setFirstMetDate(Date?)
         case setExistingImage(UIImage?)
         case setSaving(Bool)
         case setSaveCompleted
@@ -87,6 +89,7 @@ final class PlantRegisterReactor: Reactor {
         var wateringIntervalText = ""
         var lastWateredDate: Date? = nil
         var lastWateredDateText = ""
+        var firstMetDate: Date? = nil
         var isRegisterEnabled = false
         var isSaving = false
         @Pulse var existingImage: UIImage? = nil
@@ -123,6 +126,8 @@ final class PlantRegisterReactor: Reactor {
             return .just(.setWateringIntervalText(text))
         case .updateLastWateredDate(let date):
             return .just(.setLastWateredDate(date))
+        case .updateFirstMetDate(let date):
+            return .just(.setFirstMetDate(date))
         case .saveTapped(let nickname, let image):
             return savePlant(state: currentState, nickname: nickname, image: image)
         case .deleteTapped:
@@ -154,6 +159,8 @@ final class PlantRegisterReactor: Reactor {
         case .setLastWateredDate(let date):
             newState.lastWateredDate = date
             newState.lastWateredDateText = Self.makeLastWateredDateText(from: date)
+        case .setFirstMetDate(let date):
+            newState.firstMetDate = date
         case .setExistingImage(let image):
             newState.existingImage = image
         case .setSaving(let isSaving):
@@ -351,7 +358,8 @@ final class PlantRegisterReactor: Reactor {
                 contentNumber: state.selectedPlant?.contentNumber,
                 image: image,
                 wateringIntervalDays: wateringIntervalDays,
-                lastWateredAt: lastWateredAt
+                lastWateredAt: lastWateredAt,
+                firstMetDate: state.firstMetDate
             )
         )
     }
@@ -402,7 +410,8 @@ final class PlantRegisterReactor: Reactor {
                 image: image,
                 existingImagePath: plant.imagePath,
                 wateringIntervalDays: wateringIntervalDays,
-                lastWateredAt: lastWateredAt
+                lastWateredAt: lastWateredAt,
+                firstMetDate: state.firstMetDate
             )
         )
     }
@@ -450,6 +459,7 @@ final class PlantRegisterReactor: Reactor {
             state.wateringIntervalText = "\(plant.wateringIntervalDays)"
             state.lastWateredDate = plant.lastWateredAt
             state.lastWateredDateText = makeLastWateredDateText(from: plant.lastWateredAt)
+            state.firstMetDate = plant.firstMetDate
         }
 
         state.isRegisterEnabled = isRegisterEnabled(for: state)


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #139

## 🛠 작업 내용 (What I did)
- 식물 등록/수정 데이터 모델에 `firstMetDate` 값을 추가했습니다.
- Supabase `plants.first_met_date` 컬럼과 앱 모델의 `firstMetDate`를 매핑했습니다.
- 식물 등록 시 `first_met_date`가 함께 저장되도록 payload에 추가했습니다.
- 식물 수정 시 `first_met_date`를 변경할 수 있도록 update payload에 추가했습니다.

## 수정 이유
식물을 등록할 때 “식물을 데려온 날”을 저장하고, 수정 화면에서도 변경할 수 있도록 DB 로직이 필요했습니다.  


## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
