### PR TITLE
[FEAT] 데려온 날 입력 기능 추가, 상세 페이지에도 반영되도록 추가

### DIFF
--- a/LeafLog/LeafLog/Reactor/PlantCareReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantCareReactor.swift
@@ -1085,7 +1085,10 @@ private extension PlantCareReactor {
                 title: "식물 상태",
                 value: displayHealthStatus(from: plant.healthStatus)
             ),
-            PlantCarePlantInfoRow(title: "데려온 날", value: displayDate(from: plant.createdAt)),
+            PlantCarePlantInfoRow(
+                title: "데려온 날",
+                value: displayDate(from: plant.firstMetDate ?? plant.createdAt)
+            ),
             PlantCarePlantInfoRow(title: "위치", value: plant.location?.rawValue ?? "미지정"),
             PlantCarePlantInfoRow(title: "마지막 급수일", value: displayDate(from: plant.lastWateredAt))
         ]

--- a/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
@@ -351,6 +351,10 @@ final class PlantRegisterReactor: Reactor {
             return .failure(ValidationError(message: "마지막 급수일을 선택해주세요."))
         }
 
+        guard let firstMetDate = state.firstMetDate else {
+            return .failure(ValidationError(message: "데려온 날을 선택해주세요."))
+        }
+
         return .success(
             PlantCreateInput(
                 category: category,
@@ -361,7 +365,7 @@ final class PlantRegisterReactor: Reactor {
                 image: image,
                 wateringIntervalDays: wateringIntervalDays,
                 lastWateredAt: lastWateredAt,
-                firstMetDate: state.firstMetDate
+                firstMetDate: firstMetDate
             )
         )
     }
@@ -401,6 +405,10 @@ final class PlantRegisterReactor: Reactor {
             return .failure(ValidationError(message: "마지막 급수일을 선택해주세요."))
         }
 
+        guard let firstMetDate = state.firstMetDate else {
+            return .failure(ValidationError(message: "데려온 날을 선택해주세요."))
+        }
+
         return .success(
             PlantUpdateInput(
                 id: plant.id,
@@ -413,7 +421,7 @@ final class PlantRegisterReactor: Reactor {
                 existingImagePath: plant.imagePath,
                 wateringIntervalDays: wateringIntervalDays,
                 lastWateredAt: lastWateredAt,
-                firstMetDate: state.firstMetDate
+                firstMetDate: firstMetDate
             )
         )
     }
@@ -425,6 +433,7 @@ final class PlantRegisterReactor: Reactor {
         let hasLocation = state.selectedLocation != nil
         let hasWateringInterval = Int(state.wateringIntervalText.trimmingCharacters(in: .whitespacesAndNewlines)) != nil
         let hasLastWateredDate = state.lastWateredDate != nil
+        let hasFirstMetDate = state.firstMetDate != nil
         let isNotSaving = !state.isSaving
 
         return hasCategory
@@ -433,6 +442,7 @@ final class PlantRegisterReactor: Reactor {
             && hasLocation
             && hasWateringInterval
             && hasLastWateredDate
+            && hasFirstMetDate
             && isNotSaving
     }
 

--- a/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
@@ -90,6 +90,7 @@ final class PlantRegisterReactor: Reactor {
         var lastWateredDate: Date? = nil
         var lastWateredDateText = ""
         var firstMetDate: Date? = nil
+        var firstMetDateText = ""
         var isRegisterEnabled = false
         var isSaving = false
         @Pulse var existingImage: UIImage? = nil
@@ -158,9 +159,10 @@ final class PlantRegisterReactor: Reactor {
             newState.wateringIntervalText = text
         case .setLastWateredDate(let date):
             newState.lastWateredDate = date
-            newState.lastWateredDateText = Self.makeLastWateredDateText(from: date)
+            newState.lastWateredDateText = Self.makeDateText(from: date)
         case .setFirstMetDate(let date):
             newState.firstMetDate = date
+            newState.firstMetDateText = Self.makeDateText(from: date)
         case .setExistingImage(let image):
             newState.existingImage = image
         case .setSaving(let isSaving):
@@ -458,8 +460,9 @@ final class PlantRegisterReactor: Reactor {
             state.selectedLocation = plant.location
             state.wateringIntervalText = "\(plant.wateringIntervalDays)"
             state.lastWateredDate = plant.lastWateredAt
-            state.lastWateredDateText = makeLastWateredDateText(from: plant.lastWateredAt)
+            state.lastWateredDateText = makeDateText(from: plant.lastWateredAt)
             state.firstMetDate = plant.firstMetDate
+            state.firstMetDateText = makeDateText(from: plant.firstMetDate)
         }
 
         state.isRegisterEnabled = isRegisterEnabled(for: state)
@@ -506,7 +509,7 @@ final class PlantRegisterReactor: Reactor {
         return ""
     }
 
-    private static func makeLastWateredDateText(from date: Date?) -> String {
+    private static func makeDateText(from date: Date?) -> String {
         guard let date else { return "" }
         var calendar = lastWateredDateCalendar
         calendar.timeZone = lastWateredDateTimeZone

--- a/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
@@ -14,8 +14,8 @@ import OSLog
 final class PlantRegisterReactor: Reactor {
     @Dependency(\.plantService) private var plantService
     @Dependency(\.plantClassificationService) private var plantClassificationService
-    private static let lastWateredDateCalendar = Calendar(identifier: .gregorian)
-    private static let lastWateredDateTimeZone = TimeZone(identifier: "Asia/Seoul") ?? .current
+    private static let dateCalendar = Calendar.current
+    private static let dateTimeZone = TimeZone.current
     private let logger = Logger(subsystem: "LeafLog", category: "PlantRegisterReactor")
 
     enum Mode: Equatable {
@@ -521,8 +521,8 @@ final class PlantRegisterReactor: Reactor {
 
     private static func makeDateText(from date: Date?) -> String {
         guard let date else { return "" }
-        var calendar = lastWateredDateCalendar
-        calendar.timeZone = lastWateredDateTimeZone
+        var calendar = dateCalendar
+        calendar.timeZone = dateTimeZone
         let components = calendar.dateComponents([.year, .month, .day], from: date)
 
         guard let year = components.year,

--- a/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
+++ b/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
@@ -76,7 +76,7 @@ extension HomeViewController {
         // 등록하기 버튼 탭시
         homeView.rx.registerButtonTap
             .throttle(.milliseconds(500), latest: false, scheduler: MainScheduler.instance)
-            .map { _ in AppStep.plantRegister() }
+            .map { _ in AppStep.plantRegister }
             .bind(to: steps)
             .disposed(by: disposeBag)
     }

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
@@ -100,7 +100,7 @@ final class PlantRegisterView: UIView {
         }
     }
     
-    private let firstMetDateTitleLabel = PlantRegisterView.makeRequiredSectionLabel(text: "식물을 키우기 시작한 날")
+    private let firstMetDateTitleLabel = PlantRegisterView.makeRequiredSectionLabel(text: "데려 온 날")
     let firstMetDateTextField = PlantRegisterView.makeTextField(placeholder: "년 / 월 / 일").then {
         $0.keyboardType = .numbersAndPunctuation
     }
@@ -141,8 +141,22 @@ final class PlantRegisterView: UIView {
     var onLastWateredDateDone: ((Date) -> Void)?
     var onFirstMetDateDone: ((Date) -> Void)?
 
+    private let formStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = Layout.sectionSpacing
+    }
+
     private lazy var categoryStackView = makeSelectionGrid(buttons: categoryButtons)
     private lazy var locationStackView = makeSelectionGrid(buttons: locationButtons)
+    private lazy var wateringCycleInputStackView = UIStackView(
+        arrangedSubviews: [wateringCycleTextField, wateringCycleUnitLabel]
+    ).then {
+        $0.axis = .horizontal
+        $0.alignment = .center
+        $0.spacing = Layout.guideSpacing
+    }
+    private lazy var lastWateredDateFieldContainer = makeLeadingAlignedContainer(for: lastWateredDateTextField)
+    private lazy var firstMetDateFieldContainer = makeLeadingAlignedContainer(for: firstMetDateTextField)
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -176,6 +190,8 @@ final class PlantRegisterView: UIView {
         plantTypeSearchBar.textField.text = name
         if let suggestedWateringCycle = WateringGuideView.suggestedInputValue(from: springWaterCycle) {
             wateringCycleTextField.text = suggestedWateringCycle
+        } else {
+            wateringCycleTextField.text = nil
         }
 
         // 카테고리가 기타일 경우 비활성화
@@ -209,8 +225,7 @@ final class PlantRegisterView: UIView {
 
     // 입력화면 초기화
     func resetForm() {
-        cameraButton.layer.contents = nil
-        cameraButton.layer.contentsGravity = .resize
+        cameraButton.backgroundImageView.image = nil
         cameraButton.backgroundColor = .grayScale50
         plantTypeSearchBar.textField.text = nil
         plantNameTextField.text = nil
@@ -245,6 +260,15 @@ final class PlantRegisterView: UIView {
 
 // MARK: UI 구현
 private extension PlantRegisterView {
+    enum Layout {
+        static let horizontalInset: CGFloat = 16
+        static let topInset: CGFloat = 20
+        static let sectionSpacing: CGFloat = 24
+        static let fieldSpacing: CGFloat = 12
+        static let guideSpacing: CGFloat = 8
+        static let bottomInset: CGFloat = 24
+    }
+
     func setupSelectionState() {
         categoryButtons.first?.isSelected = true
         locationButtons[3].isSelected = true
@@ -256,6 +280,9 @@ private extension PlantRegisterView {
         addSubview(registerButton)
 
         scrollView.addSubview(contentView)
+        contentView.addSubview(cameraButton)
+        contentView.addSubview(formStackView)
+        contentView.addSubview(plantTypeSearchButton)
 
         headerView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(64)
@@ -264,8 +291,8 @@ private extension PlantRegisterView {
         }
 
         registerButton.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.bottom.equalTo(safeAreaLayoutGuide).inset(24)
+            $0.horizontalEdges.equalToSuperview().inset(Layout.horizontalInset)
+            $0.bottom.equalTo(safeAreaLayoutGuide).inset(Layout.bottomInset)
             $0.height.equalTo(48)
         }
 
@@ -280,139 +307,66 @@ private extension PlantRegisterView {
             $0.width.equalToSuperview()
         }
 
-        [
-            cameraButton,
-            plantTypeTitleLabel,
-            plantTypeSearchBar,
-            plantTypeSearchButton,
-            categoryTitleLabel,
-            categoryStackView,
-            categoryGuideView,
-            plantNameTitleLabel,
-            plantNameTextField,
-            locationTitleLabel,
-            locationStackView,
-            lightGuideView,
-            wateringCycleTitleLabel,
-            wateringCycleTextField,
-            wateringCycleUnitLabel,
-            wateringGuideBannerView,
-            lastWateredTitleLabel,
-            lastWateredDateTextField,
-            firstMetDateTitleLabel,
-            firstMetDateTextField
-        ].forEach { contentView.addSubview($0) }
-
         cameraButton.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(20)
+            $0.top.equalToSuperview().offset(Layout.topInset)
             $0.centerX.equalToSuperview()
         }
 
-        plantTypeTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(cameraButton.snp.bottom).offset(28)
-            $0.horizontalEdges.equalToSuperview().inset(16)
+        formStackView.snp.makeConstraints {
+            $0.top.equalTo(cameraButton.snp.bottom).offset(Layout.sectionSpacing)
+            $0.horizontalEdges.equalToSuperview().inset(Layout.horizontalInset)
+            $0.bottom.equalToSuperview().inset(Layout.bottomInset)
         }
 
         plantTypeSearchBar.snp.makeConstraints {
-            $0.top.equalTo(plantTypeTitleLabel.snp.bottom).offset(12)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
             $0.height.equalTo(48)
-        }
-
-        plantTypeSearchButton.snp.makeConstraints {
-            $0.top.leading.bottom.equalTo(plantTypeSearchBar)
-            $0.trailing.equalTo(plantTypeSearchBar.cameraButton.snp.leading).offset(-8)
-        }
-
-        categoryTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(plantTypeSearchBar.snp.bottom).offset(20)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
-        }
-
-        categoryStackView.snp.makeConstraints {
-            $0.top.equalTo(categoryTitleLabel.snp.bottom).offset(12)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
-        }
-
-        categoryGuideView.snp.makeConstraints {
-            $0.top.equalTo(categoryStackView.snp.bottom).offset(8)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
-        }
-
-        plantNameTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(categoryGuideView.snp.bottom).offset(24)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
         }
 
         plantNameTextField.snp.makeConstraints {
-            $0.top.equalTo(plantNameTitleLabel.snp.bottom).offset(12)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
             $0.height.equalTo(48)
         }
 
-        locationTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(plantNameTextField.snp.bottom).offset(24)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
-        }
-
-        locationStackView.snp.makeConstraints {
-            $0.top.equalTo(locationTitleLabel.snp.bottom).offset(12)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
-        }
-
-        lightGuideView.snp.makeConstraints {
-            $0.top.equalTo(locationStackView.snp.bottom).offset(8)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
-        }
-
-        wateringCycleTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(lightGuideView.snp.bottom).offset(24)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
-        }
-
         wateringCycleTextField.snp.makeConstraints {
-            $0.top.equalTo(wateringCycleTitleLabel.snp.bottom).offset(12)
-            $0.leading.equalTo(plantTypeTitleLabel)
             $0.width.equalTo(84)
             $0.height.equalTo(48)
         }
 
-        wateringCycleUnitLabel.snp.makeConstraints {
-            $0.leading.equalTo(wateringCycleTextField.snp.trailing).offset(8)
-            $0.centerY.equalTo(wateringCycleTextField)
-        }
-
-        wateringGuideBannerView.snp.makeConstraints {
-            $0.top.equalTo(wateringCycleTextField.snp.bottom).offset(8)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
-        }
-
-        lastWateredTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(wateringGuideBannerView.snp.bottom).offset(24)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
-        }
-
         lastWateredDateTextField.snp.makeConstraints {
-            $0.top.equalTo(lastWateredTitleLabel.snp.bottom).offset(12)
-            $0.leading.equalTo(plantTypeTitleLabel)
             $0.width.equalTo(126)
             $0.height.equalTo(48)
-        }
-
-        firstMetDateTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(lastWateredDateTextField.snp.bottom).offset(32)
-            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
         }
 
         firstMetDateTextField.snp.makeConstraints {
-            $0.top.equalTo(firstMetDateTitleLabel.snp.bottom).offset(12)
-            $0.leading.equalTo(plantTypeTitleLabel)
             $0.width.equalTo(126)
             $0.height.equalTo(48)
-            $0.bottom.equalToSuperview().inset(24)
         }
+
         categoryGuideView.snp.makeConstraints {
             $0.height.greaterThanOrEqualTo(32)
+        }
+
+        [
+            makeSectionStack(arrangedSubviews: [plantTypeTitleLabel, plantTypeSearchBar]),
+            makeSectionStack(
+                arrangedSubviews: [categoryTitleLabel, categoryStackView, categoryGuideView],
+                customSpacings: [categoryStackView: Layout.guideSpacing]
+            ),
+            makeSectionStack(arrangedSubviews: [plantNameTitleLabel, plantNameTextField]),
+            makeSectionStack(
+                arrangedSubviews: [locationTitleLabel, locationStackView, lightGuideView],
+                customSpacings: [locationStackView: Layout.guideSpacing]
+            ),
+            makeSectionStack(arrangedSubviews: [firstMetDateTitleLabel, firstMetDateFieldContainer]),
+            makeSectionStack(
+                arrangedSubviews: [wateringCycleTitleLabel, wateringCycleInputStackView, wateringGuideBannerView],
+                customSpacings: [wateringCycleInputStackView: Layout.guideSpacing]
+            ),
+            makeSectionStack(arrangedSubviews: [lastWateredTitleLabel, lastWateredDateFieldContainer])
+        ].forEach { formStackView.addArrangedSubview($0) }
+
+        plantTypeSearchButton.snp.makeConstraints {
+            $0.top.leading.bottom.equalTo(plantTypeSearchBar)
+            $0.trailing.equalTo(plantTypeSearchBar.cameraButton.snp.leading).offset(-8)
         }
     }
 
@@ -455,6 +409,26 @@ private extension PlantRegisterView {
         return UIStackView(arrangedSubviews: rows).then {
             $0.axis = .vertical
             $0.spacing = 8
+        }
+    }
+
+    func makeSectionStack(arrangedSubviews: [UIView], customSpacings: [UIView: CGFloat] = [:]) -> UIStackView {
+        UIStackView(arrangedSubviews: arrangedSubviews).then {
+            $0.axis = .vertical
+            $0.spacing = Layout.fieldSpacing
+
+            for (view, spacing) in customSpacings {
+                $0.setCustomSpacing(spacing, after: view)
+            }
+        }
+    }
+
+    func makeLeadingAlignedContainer(for contentView: UIView) -> UIView {
+        UIView().then { containerView in
+            containerView.addSubview(contentView)
+            contentView.snp.makeConstraints {
+                $0.top.leading.bottom.equalToSuperview()
+            }
         }
     }
 

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
@@ -188,11 +188,6 @@ final class PlantRegisterView: UIView {
         selectedCategory: PlantCategory?
     ) {
         plantTypeSearchBar.textField.text = name
-        if let suggestedWateringCycle = WateringGuideView.suggestedInputValue(from: springWaterCycle) {
-            wateringCycleTextField.text = suggestedWateringCycle
-        } else {
-            wateringCycleTextField.text = nil
-        }
 
         // 카테고리가 기타일 경우 비활성화
         if selectedCategory == .other {

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
@@ -71,7 +71,7 @@ final class PlantRegisterView: UIView {
         $0.datePickerMode = .date
         $0.preferredDatePickerStyle = .wheels
         $0.locale = Locale(identifier: "ko_KR")
-        $0.timeZone = TimeZone(identifier: "Asia/Seoul")
+        $0.timeZone = .current
         $0.maximumDate = Date()
     }
     private lazy var lastWateredDateInputView = UIView(
@@ -108,7 +108,7 @@ final class PlantRegisterView: UIView {
         $0.datePickerMode = .date
         $0.preferredDatePickerStyle = .wheels
         $0.locale = Locale(identifier: "ko_KR")
-        $0.timeZone = TimeZone(identifier: "Asia/Seoul")
+        $0.timeZone = .current
         $0.maximumDate = Date()
     }
     private lazy var firstMetDateInputView = UIView(

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
@@ -242,13 +242,17 @@ final class PlantRegisterView: UIView {
         wateringGuideBannerView.configure(plantName: nil, springWaterCycle: nil)
     }
 
-    func setLastWateredDate(_ date: Date, text: String) {
-        lastWateredDatePicker.date = date
+    func updateLastWateredDate(_ date: Date?, text: String) {
+        if let date {
+            lastWateredDatePicker.date = date
+        }
         lastWateredDateTextField.text = text
     }
 
-    func setFirstMetDate(_ date: Date, text: String) {
-        firstMetDatePicker.date = date
+    func updateFirstMetDate(_ date: Date?, text: String) {
+        if let date {
+            firstMetDatePicker.date = date
+        }
         firstMetDateTextField.text = text
     }
 }

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterView.swift
@@ -99,8 +99,47 @@ final class PlantRegisterView: UIView {
             $0.horizontalEdges.bottom.equalToSuperview()
         }
     }
+    
+    private let firstMetDateTitleLabel = PlantRegisterView.makeRequiredSectionLabel(text: "식물을 키우기 시작한 날")
+    let firstMetDateTextField = PlantRegisterView.makeTextField(placeholder: "년 / 월 / 일").then {
+        $0.keyboardType = .numbersAndPunctuation
+    }
+    private let firstMetDatePicker = UIDatePicker().then {
+        $0.datePickerMode = .date
+        $0.preferredDatePickerStyle = .wheels
+        $0.locale = Locale(identifier: "ko_KR")
+        $0.timeZone = TimeZone(identifier: "Asia/Seoul")
+        $0.maximumDate = Date()
+    }
+    private lazy var firstMetDateInputView = UIView(
+        frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 304)
+    ).then {
+        $0.backgroundColor = .systemBackground
+        $0.autoresizingMask = [.flexibleWidth]
+
+        let toolbar = UIToolbar()
+        toolbar.items = [
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+            UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(didTapFirstMetDateDone))
+        ]
+
+        $0.addSubview(toolbar)
+        $0.addSubview(firstMetDatePicker)
+
+        toolbar.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(44)
+        }
+
+        firstMetDatePicker.snp.makeConstraints {
+            $0.top.equalTo(toolbar.snp.bottom)
+            $0.horizontalEdges.bottom.equalToSuperview()
+        }
+    }
+    
     let registerButton = BottomSaveButton(title: "등록하기")
     var onLastWateredDateDone: ((Date) -> Void)?
+    var onFirstMetDateDone: ((Date) -> Void)?
 
     private lazy var categoryStackView = makeSelectionGrid(buttons: categoryButtons)
     private lazy var locationStackView = makeSelectionGrid(buttons: locationButtons)
@@ -110,7 +149,7 @@ final class PlantRegisterView: UIView {
         backgroundColor = .white
         setupSelectionState()
         setupUI()
-        setupLastWateredDateInputView()
+        setupDateInputViews()
     }
 
     required init?(coder: NSCoder) {
@@ -178,6 +217,8 @@ final class PlantRegisterView: UIView {
         wateringCycleTextField.text = nil
         lastWateredDateTextField.text = nil
         lastWateredDatePicker.date = Date()
+        firstMetDateTextField.text = nil
+        firstMetDatePicker.date = Date()
 
         categoryButtons.forEach {
             $0.isSelected = false
@@ -194,6 +235,11 @@ final class PlantRegisterView: UIView {
     func setLastWateredDate(_ date: Date, text: String) {
         lastWateredDatePicker.date = date
         lastWateredDateTextField.text = text
+    }
+
+    func setFirstMetDate(_ date: Date, text: String) {
+        firstMetDatePicker.date = date
+        firstMetDateTextField.text = text
     }
 }
 
@@ -252,7 +298,9 @@ private extension PlantRegisterView {
             wateringCycleUnitLabel,
             wateringGuideBannerView,
             lastWateredTitleLabel,
-            lastWateredDateTextField
+            lastWateredDateTextField,
+            firstMetDateTitleLabel,
+            firstMetDateTextField
         ].forEach { contentView.addSubview($0) }
 
         cameraButton.snp.makeConstraints {
@@ -349,6 +397,18 @@ private extension PlantRegisterView {
             $0.leading.equalTo(plantTypeTitleLabel)
             $0.width.equalTo(126)
             $0.height.equalTo(48)
+        }
+
+        firstMetDateTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(lastWateredDateTextField.snp.bottom).offset(32)
+            $0.horizontalEdges.equalTo(plantTypeTitleLabel)
+        }
+
+        firstMetDateTextField.snp.makeConstraints {
+            $0.top.equalTo(firstMetDateTitleLabel.snp.bottom).offset(12)
+            $0.leading.equalTo(plantTypeTitleLabel)
+            $0.width.equalTo(126)
+            $0.height.equalTo(48)
             $0.bottom.equalToSuperview().inset(24)
         }
         categoryGuideView.snp.makeConstraints {
@@ -356,15 +416,23 @@ private extension PlantRegisterView {
         }
     }
 
-    func setupLastWateredDateInputView() {
+    func setupDateInputViews() {
         lastWateredDateTextField.inputView = lastWateredDateInputView
         lastWateredDateTextField.tintColor = .clear
+        firstMetDateTextField.inputView = firstMetDateInputView
+        firstMetDateTextField.tintColor = .clear
     }
 
     @objc func didTapLastWateredDateDone() {
         let selectedDate = lastWateredDatePicker.date
         onLastWateredDateDone?(selectedDate)
         lastWateredDateTextField.resignFirstResponder()
+    }
+
+    @objc func didTapFirstMetDateDone() {
+        let selectedDate = firstMetDatePicker.date
+        onFirstMetDateDone?(selectedDate)
+        firstMetDateTextField.resignFirstResponder()
     }
 
     // 버튼 그리드 배치하기

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -18,7 +18,7 @@ private struct PlantRegisterHeaderState: Equatable {
     let showsDeleteButton: Bool
 }
 
-private struct LastWateredDateViewState: Equatable {
+private struct DateFieldViewState: Equatable {
     let date: Date?
     let text: String
 }
@@ -158,12 +158,22 @@ final class PlantRegisterViewController: BaseViewController, View {
             .disposed(by: disposeBag)
 
         reactor.state
-            .map { LastWateredDateViewState(date: $0.lastWateredDate, text: $0.lastWateredDateText) }
+            .map { DateFieldViewState(date: $0.lastWateredDate, text: $0.lastWateredDateText) }
             .distinctUntilChanged()
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] viewState in
                 guard let self, let date = viewState.date else { return }
                 self.registerView.setLastWateredDate(date, text: viewState.text)
+            })
+            .disposed(by: disposeBag)
+
+        reactor.state
+            .map { DateFieldViewState(date: $0.firstMetDate, text: $0.firstMetDateText) }
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] viewState in
+                guard let self, let date = viewState.date else { return }
+                self.registerView.setFirstMetDate(date, text: viewState.text)
             })
             .disposed(by: disposeBag)
         
@@ -316,6 +326,12 @@ final class PlantRegisterViewController: BaseViewController, View {
                 self?.scrollToViewIfNeeded(self?.registerView.lastWateredDateTextField)
             })
             .disposed(by: disposeBag)
+
+        registerView.firstMetDateTextField.rx.controlEvent(.editingDidBegin)
+            .subscribe(onNext: { [weak self] in
+                self?.scrollToViewIfNeeded(self?.registerView.firstMetDateTextField)
+            })
+            .disposed(by: disposeBag)
         
         registerView.registerButton.rx.tap
             .subscribe(onNext: { [weak self] in
@@ -325,6 +341,10 @@ final class PlantRegisterViewController: BaseViewController, View {
 
         registerView.onLastWateredDateDone = { [weak reactor] date in
             reactor?.action.onNext(.updateLastWateredDate(date))
+        }
+
+        registerView.onFirstMetDateDone = { [weak reactor] date in
+            reactor?.action.onNext(.updateFirstMetDate(date))
         }
 
         syncInitialFormState()
@@ -387,10 +407,11 @@ final class PlantRegisterViewController: BaseViewController, View {
             .drive(onNext: { [weak self] keyboardHeight in
                 guard let self else { return }
 
-                let isShowingLastWateredDatePicker = self.registerView.lastWateredDateTextField.isFirstResponder
+                let isShowingDatePicker = self.registerView.lastWateredDateTextField.isFirstResponder
+                    || self.registerView.firstMetDateTextField.isFirstResponder
                 let bottomInset: CGFloat
 
-                if isShowingLastWateredDatePicker {
+                if isShowingDatePicker {
                     bottomInset = (keyboardHeight * 0.5) + 32
                 } else {
                     bottomInset = keyboardHeight > 0 ? keyboardHeight + 32 : 32
@@ -399,7 +420,7 @@ final class PlantRegisterViewController: BaseViewController, View {
                 self.registerView.scrollView.contentInset.bottom = bottomInset
                 self.registerView.scrollView.verticalScrollIndicatorInsets.bottom = bottomInset
 
-                if keyboardHeight > 0, !isShowingLastWateredDatePicker {
+                if keyboardHeight > 0, !isShowingDatePicker {
                     self.scrollToCurrentResponderIfNeeded()
                 }
             })

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -162,8 +162,8 @@ final class PlantRegisterViewController: BaseViewController, View {
             .distinctUntilChanged()
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] viewState in
-                guard let self, let date = viewState.date else { return }
-                self.registerView.setLastWateredDate(date, text: viewState.text)
+                guard let self else { return }
+                self.registerView.updateLastWateredDate(viewState.date, text: viewState.text)
             })
             .disposed(by: disposeBag)
 
@@ -172,8 +172,8 @@ final class PlantRegisterViewController: BaseViewController, View {
             .distinctUntilChanged()
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] viewState in
-                guard let self, let date = viewState.date else { return }
-                self.registerView.setFirstMetDate(date, text: viewState.text)
+                guard let self else { return }
+                self.registerView.updateFirstMetDate(viewState.date, text: viewState.text)
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #143

## 🛠 작업 내용 (What I did)
- PlantRegisterView에 데려온 날(firstMetDate) 입력 UI를 추가하고, 등록/수정 시 MyPlant.firstMetDate로 저장되도록 연결
- 등록 화면 레이아웃을 스택 기반으로 정리해 guide 뷰 표시 여부와 관계없이 간격이 자연스럽게 유지되도록 수정

## 💻 구현 상세 (Implementation Details)
- PlantRegisterView는 formStackView와 섹션별 UIStackView 구조로 재구성
- 식물 상세에도 반영되도록 연결함

## 📸 스크린샷 (Screenshots)
|가이드 뷰가 있을 때|가이드 뷰 없을 때|
|:---:|:---:|
|<img width="563" height="1218" alt="IMG_4686" src="https://github.com/user-attachments/assets/115001a7-d74c-4a67-bead-1d6f7cd2c555" />|<img width="563" height="1218" alt="IMG_4685" src="https://github.com/user-attachments/assets/422d0088-ad5a-4490-80ca-d86990654d2d" />|


## 🧐 리뷰 포인트 (Review Points)
- 시간되시면 실기기로 다른 오류 없는지 한번만 봐주시면 감사하겠습니다

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
