### PR TITLE
[Feat] 홈 화면 식물 정렬 기준 변경, 오늘 날짜 표시 색상 수정

### DIFF
--- a/LeafLog/LeafLog/Reactor/HomeReactor.swift
+++ b/LeafLog/LeafLog/Reactor/HomeReactor.swift
@@ -156,10 +156,21 @@ extension HomeReactor {
     private func plantConverToItem(plants: [MyPlant]) throws -> [HomeView.Item] {
         guard !plants.isEmpty else { return [] }
         
-        // 다음 급수일까지 남은 일수가 적은 순으로 정렬
+        // 물주기 버튼 활성화 기준 우선 정렬, 이후 다음 급수일까지 남은 일수가 적은 순으로 정렬
         let sortedPlants = try plants
-            .map { (plant: $0, remaining: try $0.wateringIntervalDays - daysFromLastWatering(from: $0.lastWateredAt)) }
-            .sorted { $0.remaining < $1.remaining }
+            .map {
+                let days = try daysFromLastWatering(from: $0.lastWateredAt)
+                return (plant: $0, excess: days, remaining: $0.wateringIntervalDays - days) }
+            .sorted(by: {
+                let lhsCanWater = $0.excess != 0
+                let rhsCanWater = $1.excess != 0
+                
+                if lhsCanWater != rhsCanWater {
+                    return lhsCanWater
+                }
+
+                return $0.remaining < $1.remaining
+            })
             .map { $0.plant }
         
         // 아이템 변환

--- a/LeafLog/LeafLog/View/CalendarView/CalendarDateCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarDateCell.swift
@@ -124,15 +124,15 @@ extension CalendarDateCell {
         
         selectedView.isHidden = !data.isSelected
         
+        let subColor = UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
+        
+        colorChip.isHidden = !data.isToday
+        colorChip.backgroundColor = (data.isToday && !data.isCurrentMonth) ? subColor : .primary700
+        
         if data.isToday && data.isCurrentMonth {
-            colorChip.isHidden = false
             dateLabel.textColor = .primary700
-        } else if data.isToday && !data.isCurrentMonth {
-            colorChip.isHidden = false
-            dateLabel.textColor = UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
-            colorChip.backgroundColor = UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
-        } else if !data.isCurrentMonth {
-            dateLabel.textColor = UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
+        } else {
+            dateLabel.textColor = data.isCurrentMonth ? .label : subColor
         }
     }
 }

--- a/LeafLog/LeafLog/View/CalendarView/CalendarDateCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarDateCell.swift
@@ -123,21 +123,16 @@ extension CalendarDateCell {
         }
         
         selectedView.isHidden = !data.isSelected
-        colorChip.isHidden = !data.isToday
         
-        dateLabel.textColor = data.isToday ? .primary700
-        : data.isCurrentMonth ? .label
-        : UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
-        
-//        if data.isToday && data.isCurrentMonth {
-//            colorChip.isHidden = false
-//            dateLabel.textColor = .primary700
-//        } else if data.isToday && !data.isCurrentMonth {
-//            colorChip.isHidden = false
-//            dateLabel.textColor = UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
-//            colorChip.backgroundColor = UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
-//        } else if !data.isCurrentMonth {
-//            dateLabel.textColor = UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
-//        }
+        if data.isToday && data.isCurrentMonth {
+            colorChip.isHidden = false
+            dateLabel.textColor = .primary700
+        } else if data.isToday && !data.isCurrentMonth {
+            colorChip.isHidden = false
+            dateLabel.textColor = UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
+            colorChip.backgroundColor = UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
+        } else if !data.isCurrentMonth {
+            dateLabel.textColor = UIColor(red: 0.76, green: 0.78, blue: 0.73, alpha: 1.00) // HEX #C3C8BB
+        }
     }
 }

--- a/LeafLog/LeafLog/View/CalendarView/CalendarDateCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarDateCell.swift
@@ -52,6 +52,7 @@ final class CalendarDateCell: UICollectionViewCell {
         dateLabel.textColor = .label
         selectedView.isHidden = true
         colorChip.isHidden = true
+        colorChip.backgroundColor = .primary700
     }
 }
 


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #148 #147 

## 🛠 작업 내용 (What I did)
- 홈 화면의 식물 정렬 기준 변경
- 오늘 날짜가 현재 표시 달과 상이할 시 표시 색상 수정

## 💻 구현 상세 (Implementation Details)
- 홈 화면의 식물 정렬 기준을 '물주기 버튼 활성화 여부' 우선, '다음 물주기까지 남은 일수' 기준으로 정렬하도록 수정했습니다.
- 오늘 날짜가 현재 표시 달과 상이할 시 표시되는 색상을 수정하였습니다.

## 📸 스크린샷 (Screenshots)
<p align=center>
<img width=40% src="https://github.com/user-attachments/assets/d5bc5dc5-cd3a-4636-8c03-945b953e7547" />
<img width=40% src="https://github.com/user-attachments/assets/2aa25629-16f5-4979-8d5b-6da26e8315e8" />
</p>

## 🧐 리뷰 포인트 (Review Points)
- 정렬이 의도대로 잘 되고 있는지 확인 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
