### PR TITLE
[Fix] AI 검색 후 검색어 검색 시 결과가 나오지 않는 현상 수정, 달력에서 회색 날짜 선택 시 상세목록이 나오지 않는 현상 수정

### DIFF
--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -91,6 +91,10 @@ final class MainFlow: Flow {
         case .alarmCenter:
             return navigateToAlarmCenter()
             
+        case .diaryImageSourceSheet:
+            presentDiaryImageSourceSheet()
+            return .none
+            
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
         }
@@ -325,5 +329,24 @@ extension MainFlow {
         let viewController = PlantRegisterViewController(reactor: reactor)
         viewController.hidesBottomBarWhenPushed = true
         return viewController
+    }
+}
+
+extension MainFlow {
+    private func presentDiaryImageSourceSheet() {
+        guard let navigationController = tabBarController.selectedViewController as? UINavigationController,
+              let viewController = navigationController.topViewController as? PlantCareViewController else {
+            return
+        }
+
+        ImageSourcePickerPresenter.present(
+            from: navigationController,
+            sourceView: viewController.diaryImagePickerSourceView,
+            delegate: viewController,
+            deleteTitle: viewController.hasDiaryPhoto ? "사진 삭제" : nil,
+            onDelete: { [weak viewController] in
+                viewController?.deleteDiaryPhoto()
+            }
+        )
     }
 }

--- a/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
@@ -142,9 +142,7 @@ final class PlantTabFlow: Flow {
         case .photoSelect: // 사진 선택 분기
             return presentPhotoSelect()
 
-        case .diaryImageSourceSheet:
-            presentDiaryImageSourceSheet()
-            return .none
+        
             
         case .cameraRequired:
             let camera = CameraClassificationViewController()
@@ -190,22 +188,6 @@ extension PlantTabFlow {
         navigationController.present(alert, animated: true)
         
         return .none
-    }
-
-    private func presentDiaryImageSourceSheet() {
-        guard let viewController = navigationController.topViewController as? PlantCareViewController else {
-            return
-        }
-
-        ImageSourcePickerPresenter.present(
-            from: navigationController,
-            sourceView: viewController.diaryImagePickerSourceView,
-            delegate: viewController,
-            deleteTitle: viewController.hasDiaryPhoto ? "사진 삭제" : nil,
-            onDelete: { [weak viewController] in
-                viewController?.deleteDiaryPhoto()
-            }
-        )
     }
 
     private func updateAndRestorePlantRegister(

--- a/LeafLog/LeafLog/Reactor/CalendarReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CalendarReactor.swift
@@ -338,7 +338,7 @@ extension CalendarReactor {
         guard !dateRawValue.isEmpty else { return [:] }
         let targetDate = LocalDate(rawValue: dateRawValue)
         
-        let key = currentKeyMonth(of: date)
+        let key = currentKeyMonth(of: currentState.benchmarkDate)
         let monthlyRecords = monthlyRecordCache[key] ?? []
         
         var records: [MyPlant: CareRecord] = [:]

--- a/LeafLog/LeafLog/Reactor/CalendarReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CalendarReactor.swift
@@ -91,7 +91,10 @@ final class CalendarReactor: Reactor {
                 ])
             
         case .updateFilter(let tag):
-            return filterCalendar(tag: tag)
+            return Observable.concat([
+                filterCalendar(tag: tag),
+                detailItems(of: currentState.selectedDate ?? Date())
+                ])
             
         case .dateSelected(let date):
             return Observable.concat([

--- a/LeafLog/LeafLog/Reactor/CalendarReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CalendarReactor.swift
@@ -26,6 +26,7 @@ final class CalendarReactor: Reactor {
         case updateFilters(Set<Int>)
         case updateMonthlyData(MonthKey, [CareRecord])
         case updateSelectedDate(Date)
+        case updateMyPlants([MyPlant])
         
         case setCalendarHeader(Int, Int) // 년, 월
         case setCalendarItem([CalendarView.Item])
@@ -44,6 +45,7 @@ final class CalendarReactor: Reactor {
         var benchmarkDate: Date = Date() // 달력 표시 기준일
         var filters: Set<Int> = []
         var cacheData: [MonthKey: [CareRecord]] = [:]
+        var plants: [MyPlant] = []
         
         var selectedDate: Date? // 선택된 날짜
         var data: [CalendarView.Section: [CalendarView.Item]] = [
@@ -115,6 +117,9 @@ final class CalendarReactor: Reactor {
             
         case .updateSelectedDate(let date):
             newState.selectedDate = date
+            
+        case .updateMyPlants(let plants):
+            newState.plants = plants
             
         case .setCalendarHeader(let year, let month):
             newState.data[.header] = [CalendarView.Item.header(year, month)]

--- a/LeafLog/LeafLog/Reactor/CalendarReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CalendarReactor.swift
@@ -25,8 +25,8 @@ final class CalendarReactor: Reactor {
         case updateBenchmarkDate(Date)
         case updateFilters(Set<Int>)
         case updateMonthlyData(MonthKey, [CareRecord])
-        case updateSelectedDate(Date)
         case updateMyPlants([MyPlant])
+        case updateSelectedDate(Date)
         
         case setCalendarHeader(Int, Int) // 년, 월
         case setCalendarItem([CalendarView.Item])
@@ -46,6 +46,7 @@ final class CalendarReactor: Reactor {
         var filters: Set<Int> = []
         var cacheData: [MonthKey: [CareRecord]] = [:]
         var plants: [MyPlant] = []
+        var cacheOrder: [MonthKey] = []
         
         var selectedDate: Date? // 선택된 날짜
         var data: [CalendarView.Section: [CalendarView.Item]] = [
@@ -62,10 +63,7 @@ final class CalendarReactor: Reactor {
     @Dependency(\.careRecordDBManager) private var careRecordDBManager
     
     private let calendar = Calendar.current
-    private var monthlyRecordCache: [MonthKey: [CareRecord]] = [:]
-    private var monthlyRecordCacheOrder: [MonthKey] = []
     private let cacheLimit = 3
-    private var myPlants: [MyPlant] = []
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
@@ -113,13 +111,16 @@ final class CalendarReactor: Reactor {
             newState.filters = filters
             
         case .updateMonthlyData(let key, let data):
+            let newManagedCache = manageCache(state.cacheOrder, key: key, cache: state.cacheData)
+            newState.cacheOrder = newManagedCache.0
+            newState.cacheData = newManagedCache.1
             newState.cacheData[key] = data
-            
-        case .updateSelectedDate(let date):
-            newState.selectedDate = date
             
         case .updateMyPlants(let plants):
             newState.plants = plants
+            
+        case .updateSelectedDate(let date):
+            newState.selectedDate = date
             
         case .setCalendarHeader(let year, let month):
             newState.data[.header] = [CalendarView.Item.header(year, month)]
@@ -176,7 +177,7 @@ extension CalendarReactor {
                         // 월간 기록
                         let key = self.currentKeyMonth(of: benchmark)
                         
-                        let cache = try await self.updateCache(of: benchmark, key: key) // 캐시 업데이트 데이터
+                        let cache = try await self.updateCacheData(of: benchmark, key: key) // 캐시 업데이트 데이터
                         let plants = cache.0
                         let records = cache.1
                         
@@ -377,31 +378,29 @@ extension CalendarReactor {
 
 //MARK: Manage Record Cache
 extension CalendarReactor {
-    private func updateCache(of date: Date, key: MonthKey) async throws -> ([MyPlant], [CareRecord]) {
+    private func updateCacheData(of date: Date, key: MonthKey) async throws -> ([MyPlant], [CareRecord]) {
         let plants = try await plantDBManager.fetchMyPlants() // 유저가 등록한 모든 식물
-        
         let data = try await self.monthlyPlantRecords(of: date, plants: plants)
-        guard manageCacheOrder(key: key) else { return ([], []) } // 캐시 정리
         return (plants, data)
     }
     
-    private func manageCacheOrder(key: MonthKey) -> Bool {
-        if monthlyRecordCacheOrder.contains(key) { // Cache Hit
-            guard let index = monthlyRecordCacheOrder.firstIndex(of: key) else { return false }
-            monthlyRecordCacheOrder.append(monthlyRecordCacheOrder.remove(at: index)) // 가장 후순위로 순서 변경
-            return true
-        } else if monthlyRecordCacheOrder.count >= cacheLimit { // Cache Miss, Limit full
-            let target = monthlyRecordCacheOrder.removeFirst() // 가장 오래된 키를 지우면서 반환
-            monthlyRecordCache.removeValue(forKey: target) // 캐시에서 가장 오래된 데이터 삭제
-            return true
+    private func manageCache(_ order: [MonthKey], key: MonthKey, cache: [MonthKey: [CareRecord]]) -> ([MonthKey], [MonthKey: [CareRecord]]) {
+        var newOrder = order
+        var newCache = cache
+        
+        if newOrder.contains(key) { // Cache Hit
+            guard let index = newOrder.firstIndex(of: key) else { return (order, cache) }
+            newOrder.append(newOrder.remove(at: index)) // 가장 후순위로 순서 변경
+            return (newOrder, newCache)
+        } else if newOrder.count >= cacheLimit { // Cache Miss, Limit full
+            let target = newOrder.removeFirst() // 가장 오래된 키를 지우면서 반환
+            newOrder.append(key) // 신규 캐시 추가
+            newCache.removeValue(forKey: target) // 캐시에서 가장 오래된 데이터 삭제
+            return (newOrder, newCache)
         } else { // Cache Miss, Limit Enough
-            return true
+            newOrder.append(key) // 신규 캐시 추가
+            return (newOrder, newCache)
         }
-    }
-    
-    private func updateMyPlants() async throws {
-        let plants = try await plantDBManager.fetchMyPlants() // 유저가 등록한 모든 식물
-        myPlants = plants
     }
 }
 

--- a/LeafLog/LeafLog/Reactor/CalendarReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CalendarReactor.swift
@@ -175,13 +175,17 @@ extension CalendarReactor {
                     do {
                         // 월간 기록
                         let key = self.currentKeyMonth(of: benchmark)
-                        try await self.updateCache(of: benchmark, key: key) // 캐시 업데이트
-                        let records = self.monthlyRecordCache[key] ?? []
+                        
+                        let cache = try await self.updateCache(of: benchmark, key: key) // 캐시 업데이트 데이터
+                        let plants = cache.0
+                        let records = cache.1
                         
                         let dates = self.calculateDates(of: benchmark)
                         let items = self.datesConvertToItems(current: benchmark, dates, records: records, filters: filters)
                         
                         observer.onNext(.updateBenchmarkDate(benchmark))
+                        observer.onNext(.updateMonthlyData(key, records))
+                        observer.onNext(.updateMyPlants(plants))
                         observer.onNext(.setCalendarHeader(year, month))
                         observer.onNext(.setFilterItem([CalendarView.Item.filter(filters)]))
                         observer.onNext(.setCalendarItem(items))
@@ -208,7 +212,7 @@ extension CalendarReactor {
         let benchmark = currentState.benchmarkDate
         let newFilter = newFilters(tag: tag)
         let key = currentKeyMonth(of: benchmark)
-        let records = monthlyRecordCache[key] ?? []
+        let records = currentState.cacheData[key] ?? []
         
         let dates = calculateDates(of: benchmark)
         let items = datesConvertToItems(current: benchmark, dates, records: records, filters: newFilter)
@@ -344,10 +348,10 @@ extension CalendarReactor {
         let targetDate = LocalDate(rawValue: dateRawValue)
         
         let key = currentKeyMonth(of: currentState.benchmarkDate)
-        let monthlyRecords = monthlyRecordCache[key] ?? []
+        let monthlyRecords = currentState.cacheData[key] ?? []
         
         var records: [MyPlant: CareRecord] = [:]
-        for plant in myPlants {
+        for plant in  currentState.plants {
             let filtered = monthlyRecords.filter { $0.plantID == plant.id && $0.recordDate == targetDate }
             guard let record = filtered.first else { continue }
             records[plant] = record
@@ -373,13 +377,12 @@ extension CalendarReactor {
 
 //MARK: Manage Record Cache
 extension CalendarReactor {
-    private func updateCache(of date: Date, key: MonthKey) async throws {
-            let plants = try await plantDBManager.fetchMyPlants() // 유저가 등록한 모든 식물
-            myPlants = plants
+    private func updateCache(of date: Date, key: MonthKey) async throws -> ([MyPlant], [CareRecord]) {
+        let plants = try await plantDBManager.fetchMyPlants() // 유저가 등록한 모든 식물
         
-            let data = try await self.monthlyPlantRecords(of: date, plants: plants)
-            guard manageCacheOrder(key: key) else { return } // 캐시 정리
-            monthlyRecordCache[key] = data
+        let data = try await self.monthlyPlantRecords(of: date, plants: plants)
+        guard manageCacheOrder(key: key) else { return ([], []) } // 캐시 정리
+        return (plants, data)
     }
     
     private func manageCacheOrder(key: MonthKey) -> Bool {

--- a/LeafLog/LeafLog/Reactor/SearchReactor.swift
+++ b/LeafLog/LeafLog/Reactor/SearchReactor.swift
@@ -146,7 +146,8 @@ final class SearchReactor: Reactor {
                 .just(.setLoading(true)),
                 searchClassificationResult(classifications: classificationResult),
                 .just(.setLoading(false)),
-                .just(.setTitle("검색 결과"))
+                .just(.setTitle("검색 결과")),
+                .just(.setSearchType(.plantName))
             ])
 
         case .selectPlant(let item):


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #157 

## 🛠 작업 내용 (What I did)
- AI 검색 후 검색어 검색 시 결과가 나오지 않는 현상 수정
- 달력에서 회색 날짜(현재 달이 아닌 날짜) 선택 시 상세목록이 나오지 않는 현상 수정

## 💻 구현 상세 (Implementation Details)
- AI 검색 완료 시 검색 타입을 'plantName'으로 원복하는 로직을 추가하여 버그를 수정하였습니다.
- 달력에서 상세 목록을 찾는 기준을 선택한 날짜가 아닌 달력 표시 기준 날짜로 변경하여 버그를 수정하였습니다.

## 🧐 리뷰 포인트 (Review Points)
- 기존 의도대로 잘 작동하는지 확인 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
