### PR TITLE
[Fix] AI 검색 시 네비게이션 스택이 계속 쌓이는 현상 해결, AI 검색 시 이미지 불러오기 기능 추가

### DIFF
--- a/LeafLog/LeafLog.xcodeproj/project.pbxproj
+++ b/LeafLog/LeafLog.xcodeproj/project.pbxproj
@@ -282,9 +282,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = LeafLog/LeafLog.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Q7HGK38S83;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Q7HGK38S83;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LeafLog/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -303,6 +305,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.jooslin.leaflog.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = jooslin;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -325,9 +328,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = LeafLog/LeafLog.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Q7HGK38S83;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Q7HGK38S83;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LeafLog/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -346,6 +351,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.jooslin.leaflog.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = jooslin;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/LeafLog/LeafLog.xcodeproj/xcshareddata/xcschemes/LeafLog.xcscheme
+++ b/LeafLog/LeafLog.xcodeproj/xcshareddata/xcschemes/LeafLog.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "16AD0E2C2F7FAFE200C98732"
+               BuildableName = "LeafLog.app"
+               BlueprintName = "LeafLog"
+               ReferencedContainer = "container:LeafLog.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "16AD0E2C2F7FAFE200C98732"
+            BuildableName = "LeafLog.app"
+            BlueprintName = "LeafLog"
+            ReferencedContainer = "container:LeafLog.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "16AD0E2C2F7FAFE200C98732"
+            BuildableName = "LeafLog.app"
+            BlueprintName = "LeafLog"
+            ReferencedContainer = "container:LeafLog.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -64,14 +64,8 @@ final class MainFlow: Flow {
         case .plantSearchDetail(let contentNumber):
             return navigateToPlantSearchDetail(contentNumber: contentNumber)
 
-        case .classificationResult(let result):
-            return navigateToClassificationResult(result)
-
         case .plantRegisterSelectedPlant(let selectedPlant):
             return updatePlantRegister(selectedPlant)
-
-        case .cameraRequired:
-            return navigateToCameraClassification()
 
         case .applicatoinSettingRequired:
             if let url = URL(string: UIApplication.openSettingsURLString) {
@@ -254,37 +248,6 @@ extension MainFlow {
                 withNextStepper: viewController
             )
         )
-    }
-
-    private func navigateToClassificationResult(_ result: [String: PlantClassificationService.Confidence]) -> FlowContributors {
-        let searchViewController = SearchViewController(classficationResult: result)
-        searchViewController.hidesBottomBarWhenPushed = true
-        navigate(to: searchViewController, animated: true)
-
-        return .one(
-            flowContributor: .contribute(
-                withNextPresentable: searchViewController,
-                withNextStepper: searchViewController
-            )
-        )
-    }
-
-    private func navigateToCameraClassification() -> FlowContributors {
-        if let navigationController = tabBarController.selectedViewController as? UINavigationController,
-           navigationController.viewControllers.contains(where: { $0 is CameraClassificationViewController }) {
-            navigationController.popViewController(animated: true)
-            return .none
-        } else {
-            let cameraViewController = CameraClassificationViewController()
-            navigate(to: cameraViewController, animated: true)
-            
-            return .one(
-                flowContributor: .contribute(
-                    withNextPresentable: cameraViewController,
-                    withNextStepper: cameraViewController
-                )
-            )
-        }
     }
 
     private func updatePlantRegister(_ selectedPlant: SelectedPlant) -> FlowContributors {

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -270,15 +270,21 @@ extension MainFlow {
     }
 
     private func navigateToCameraClassification() -> FlowContributors {
-        let cameraViewController = CameraClassificationViewController()
-        navigate(to: cameraViewController, animated: true)
-
-        return .one(
-            flowContributor: .contribute(
-                withNextPresentable: cameraViewController,
-                withNextStepper: cameraViewController
+        if let navigationController = tabBarController.selectedViewController as? UINavigationController,
+           navigationController.viewControllers.contains(where: { $0 is CameraClassificationViewController }) {
+            navigationController.popViewController(animated: true)
+            return .none
+        } else {
+            let cameraViewController = CameraClassificationViewController()
+            navigate(to: cameraViewController, animated: true)
+            
+            return .one(
+                flowContributor: .contribute(
+                    withNextPresentable: cameraViewController,
+                    withNextStepper: cameraViewController
+                )
             )
-        )
+        }
     }
 
     private func updatePlantRegister(_ selectedPlant: SelectedPlant) -> FlowContributors {

--- a/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
@@ -23,8 +23,6 @@ final class PlantTabFlow: Flow {
     @Dependency(\.cameraService) private var cameraService
     @Dependency(\.uiApplication) private var uiApplication
     private let navigationController = UINavigationController()
-    private let photoSelectStepper = PhotoSelectStepper()
-    private var imagePicker: PHPickerViewController?
     
     var root: any RxFlow.Presentable { navigationController }
     
@@ -74,11 +72,9 @@ final class PlantTabFlow: Flow {
             return .one(
                 flowContributor: .contribute(
                     withNextPresentable: plantRegisterViewController,
-                    withNextStepper: CompositeStepper(
-                        steppers: [plantRegisterViewController, photoSelectStepper]
+                    withNextStepper:  plantRegisterViewController
                     )
                 )
-            )
             
             // 검색, 상세 등에서 식물 정보 가지고 시작
         case .plantRegisterSelectedPlant(let selectedPlant):
@@ -99,9 +95,7 @@ final class PlantTabFlow: Flow {
             return .one(
                 flowContributor: .contribute(
                     withNextPresentable: plantRegisterViewController,
-                    withNextStepper: CompositeStepper(
-                        steppers: [plantRegisterViewController, photoSelectStepper]
-                    )
+                    withNextStepper: plantRegisterViewController
                 )
             )
 
@@ -136,11 +130,6 @@ final class PlantTabFlow: Flow {
             }
             return .none
             
-        case .photoSelect: // 사진 선택 분기
-            return presentPhotoSelect()
-
-        
-            
 //        case .cameraRequired:
 //            let camera = CameraClassificationViewController()
 //            navigationController.pushViewController(camera, animated: true)
@@ -154,39 +143,6 @@ final class PlantTabFlow: Flow {
 }
 
 extension PlantTabFlow {
-    // 사진 선택 alert에서 사용할 stepper
-    struct PhotoSelectStepper: Stepper {
-        let steps = PublishRelay<Step>()
-    }
-    
-    //TODO: 추후 수정 필요 - 등록 화면의 카메라 검색 버튼과 연동하여 수정 필요
-    private func presentPhotoSelect() -> FlowContributors {
-        let alert = UIAlertController()
-        let cameraAction = UIAlertAction(title: "촬영하기", style: .default) { [weak self] _ in
-            self?.photoSelectStepper.steps.accept(AppStep.cameraRequired)
-        }
-        
-//        let galleryAction = UIAlertAction(title: "이미지 불러오기", style: .default) { [weak self] _ in
-//            guard let self else { return }
-//            
-//           let imagePicker = imagePicker ?? makeImagePicker()
-//            
-//            alert.dismiss(animated: true) {
-//                self.navigationController.present(imagePicker, animated: true)
-//            }
-//        }
-        
-        let cancel = UIAlertAction(title: "취소", style: .cancel)
-        
-        alert.addAction(cameraAction)
-//        alert.addAction(galleryAction)
-        alert.addAction(cancel)
-        
-        navigationController.present(alert, animated: true)
-        
-        return .none
-    }
-
     private func updateAndRestorePlantRegister(
         registerViewController: PlantRegisterViewController,
         selectedPlant: SelectedPlant,

--- a/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
@@ -119,10 +119,7 @@ final class PlantTabFlow: Flow {
             return .one(flowContributor: .contribute(withNextPresentable: viewController, withNextStepper: viewController))
         
         case .classificationResult(let result): // AI 검색 결과 표시
-            let searchViewController = SearchViewController(classficationResult: result)
-            searchViewController.hidesBottomBarWhenPushed = true
-            navigationController.pushViewController(searchViewController, animated: true)
-            return .one(flowContributor: .contribute(withNextPresentable: searchViewController, withNextStepper: searchViewController))
+            return navigateToClassificationResult(result)
             
         case .applicatoinSettingRequired: // 휴대폰 앱 설정 화면 이동
             if let url = URL(string: UIApplication.openSettingsURLString) {
@@ -130,11 +127,8 @@ final class PlantTabFlow: Flow {
             }
             return .none
             
-//        case .cameraRequired:
-//            let camera = CameraClassificationViewController()
-//            navigationController.pushViewController(camera, animated: true)
-//            
-//            return .one(flowContributor: .contribute(withNextPresentable: camera, withNextStepper: camera))
+        case .cameraRequired:
+            return navigateToCameraClassification()
             
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
@@ -163,5 +157,35 @@ extension PlantTabFlow {
         let viewController = PlantRegisterViewController(reactor: reactor)
         viewController.hidesBottomBarWhenPushed = true
         return viewController
+    }
+    
+    private func navigateToCameraClassification() -> FlowContributors {
+        if navigationController.viewControllers.contains(where: { $0 is CameraClassificationViewController }) {
+            navigationController.popViewController(animated: true)
+            return .none
+        } else {
+            let cameraViewController = CameraClassificationViewController()
+            navigationController.pushViewController(cameraViewController, animated: true)
+            
+            return .one(
+                flowContributor: .contribute(
+                    withNextPresentable: cameraViewController,
+                    withNextStepper: cameraViewController
+                )
+            )
+        }
+    }
+    
+    private func navigateToClassificationResult(_ result: [String: PlantClassificationService.Confidence]) -> FlowContributors {
+        let searchViewController = SearchViewController(classficationResult: result)
+        searchViewController.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(searchViewController, animated: true)
+        
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: searchViewController,
+                withNextStepper: searchViewController
+            )
+        )
     }
 }

--- a/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
@@ -141,11 +141,11 @@ final class PlantTabFlow: Flow {
 
         
             
-        case .cameraRequired:
-            let camera = CameraClassificationViewController()
-            navigationController.pushViewController(camera, animated: true)
-            
-            return .one(flowContributor: .contribute(withNextPresentable: camera, withNextStepper: camera))
+//        case .cameraRequired:
+//            let camera = CameraClassificationViewController()
+//            navigationController.pushViewController(camera, animated: true)
+//            
+//            return .one(flowContributor: .contribute(withNextPresentable: camera, withNextStepper: camera))
             
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))

--- a/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/PlantTabFlow.swift
@@ -160,8 +160,8 @@ extension PlantTabFlow {
     }
     
     private func navigateToCameraClassification() -> FlowContributors {
-        if navigationController.viewControllers.contains(where: { $0 is CameraClassificationViewController }) {
-            navigationController.popViewController(animated: true)
+        if let cameraVC = navigationController.viewControllers.first(where: { $0 is CameraClassificationViewController }) {
+            navigationController.popToViewController(cameraVC, animated: true)
             return .none
         } else {
             let cameraViewController = CameraClassificationViewController()

--- a/LeafLog/LeafLog/Reactor/CalendarReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CalendarReactor.swift
@@ -259,7 +259,6 @@ extension CalendarReactor {
                 .just(.setDetailTreatItem(detailRecords[Badge.treat.rawValue]))
             ])
         }
-        
     }
     
     private func updateSelectedItem(date: Date) -> Observable<Mutation> {

--- a/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
@@ -136,7 +136,10 @@ extension CameraClassificationReactor {
 extension CameraClassificationReactor {
     private func analyzeImage(_ imageData: Data, normalizedRect: CGRect) -> Observable<Mutation> {
         Observable.create { [weak self] observer in
-            guard let self else { return Disposables.create() }
+            guard let self else {
+                observer.onCompleted()
+                return Disposables.create()
+            }
             
             let cropImage = self.plantClassificationService.cropCapturedImage(imageData, normalizedRect: normalizedRect)
             guard let cropImage else {
@@ -145,7 +148,7 @@ extension CameraClassificationReactor {
                 return Disposables.create()
             }
             
-            Task { [weak self] in
+            let task = Task { [weak self] in
                 guard let self else {
                     observer.onCompleted()
                     return
@@ -160,7 +163,9 @@ extension CameraClassificationReactor {
                     observer.onCompleted()
                 }
             }
-            return Disposables.create()
+            return Disposables.create() {
+                task.cancel()
+            }
         }
     }
 }

--- a/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
@@ -33,7 +33,7 @@ final class CameraClassificationReactor: Reactor {
         @Pulse var isAuthorized: Bool = false
         @Pulse var isCameraReady: Bool = false
     
-        var classificationResult: [String: PlantClassificationService.Confidence] = [:]
+        @Pulse var classificationResult: [String: PlantClassificationService.Confidence]? = nil
         
         @Pulse var errorMessage: String? = nil
     }

--- a/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
@@ -134,6 +134,7 @@ extension CameraClassificationReactor {
 }
 
 extension CameraClassificationReactor {
+    // 촬영한 이미지 분석
     private func analyzeImage(_ imageData: Data, normalizedRect: CGRect) -> Observable<Mutation> {
         Observable.create { [weak self] observer in
             guard let self else {
@@ -141,6 +142,7 @@ extension CameraClassificationReactor {
                 return Disposables.create()
             }
             
+            // 가이드 프레임에 맞추어 이미지 crop
             let cropImage = self.plantClassificationService.cropCapturedImage(imageData, normalizedRect: normalizedRect)
             guard let cropImage else {
                 observer.onNext(.analyzeResult([:]))

--- a/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
@@ -143,7 +143,7 @@ extension CameraClassificationReactor {
             }
             
             // 가이드 프레임에 맞추어 이미지 crop
-            let cropImage = self.plantClassificationService.cropCapturedImage(imageData, normalizedRect: normalizedRect)
+            let cropImage = self.plantClassificationService.cropGuideFrame(imageData, normalizedRect: normalizedRect)
             guard let cropImage else {
                 observer.onNext(.analyzeResult([:]))
                 observer.onCompleted()

--- a/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
@@ -542,9 +542,9 @@ extension PlantRegisterReactor {
                 }
                 
                 do {
-//                    let croppedImage = self.plantClassificationService.cropCenterSquare(image)
+                    let croppedImage = self.plantClassificationService.cropCenterSquare(image)
                     
-                    let classificationResult = try self.plantClassificationService.analyzeImage(image: image)
+                    let classificationResult = try self.plantClassificationService.analyzeImage(image: croppedImage)
                     observer.onNext(.analyzeResult(classificationResult))
                     observer.onCompleted()
                 } catch let error as PlantClassificationService.ClassificationError {

--- a/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
@@ -542,6 +542,8 @@ extension PlantRegisterReactor {
                 }
                 
                 do {
+//                    let croppedImage = self.plantClassificationService.cropCenterSquare(image)
+                    
                     let classificationResult = try self.plantClassificationService.analyzeImage(image: image)
                     observer.onNext(.analyzeResult(classificationResult))
                     observer.onCompleted()

--- a/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
@@ -534,7 +534,7 @@ final class PlantRegisterReactor: Reactor {
 extension PlantRegisterReactor {
     private func analyzeImage(_ image: UIImage) -> Observable<Mutation> {
         Observable.create { [weak self] observer in
-            Task { [weak self] in
+            let task = Task { [weak self] in
                 guard let self else {
                     observer.onCompleted()
                     return
@@ -554,7 +554,9 @@ extension PlantRegisterReactor {
                     observer.onCompleted()
                 }
             }
-            return Disposables.create()
+            return Disposables.create() {
+                task.cancel()
+            }
         }
     }
 }

--- a/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
@@ -532,6 +532,7 @@ final class PlantRegisterReactor: Reactor {
 }
 
 extension PlantRegisterReactor {
+    // 갤러리에서 가져온 이미지 분석
     private func analyzeImage(_ image: UIImage) -> Observable<Mutation> {
         Observable.create { [weak self] observer in
             let task = Task { [weak self] in

--- a/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
@@ -96,7 +96,7 @@ final class PlantRegisterReactor: Reactor {
         @Pulse var deleteCompleted = false
         @Pulse var errorMessage: String? = nil
         
-        var classificationResult: [String: PlantClassificationService.Confidence] = [:]
+        @Pulse var classificationResult: [String: PlantClassificationService.Confidence]? = nil
     }
 
     let initialState: State

--- a/LeafLog/LeafLog/Service/PlantClassificationService/PlantClassificationService.swift
+++ b/LeafLog/LeafLog/Service/PlantClassificationService/PlantClassificationService.swift
@@ -151,35 +151,6 @@ extension PlantClassificationService {
 
 //MARK: Preprocess to run model
 extension PlantClassificationService {
-    // 이미지 중앙 crop 함수 - 이미지 검색 시 카메라 preview의 aspectFill + guideFrame과 비슷한 비율로 사용
-    func cropCenterSquare(_ image: UIImage) -> UIImage {
-        guard image.size.width > 0, image.size.height > 0 else { return image }
-
-        let screenSize = UIScreen.main.bounds.size
-        let guideSide: CGFloat = 280
-        let previewScale = max(
-            screenSize.width / image.size.width,
-            screenSize.height / image.size.height
-        )
-        let cropPaddingScale: CGFloat = 1.12
-        let side = min((guideSide / previewScale) * cropPaddingScale, min(image.size.width, image.size.height))
-
-        let format = UIGraphicsImageRendererFormat.default()
-        format.scale = 1
-        let verticalOffset = side * 0.08
-
-        return UIGraphicsImageRenderer(size: CGSize(width: side, height: side), format: format).image { _ in
-            image.draw(
-                in: CGRect(
-                    x: (side - image.size.width) / 2.0,
-                    y: ((side - image.size.height) / 2.0) + verticalOffset,
-                    width: image.size.width,
-                    height: image.size.height
-                )
-            )
-        }
-    }
-
     // 이미지 전처리 함수
     private func preprocessImage(_ image: UIImage, width: Int, height: Int) -> Data? {
         // 1. 비율에 맞춰 리사이징 할 크기 계산 (Aspect Fill 방식)
@@ -243,29 +214,46 @@ extension PlantClassificationService {
     }
 }
 
-// MARK: Added - Capture Image Crop & Preprocess
+//MARK: Crop Image
 extension PlantClassificationService {
-    // 모델 입력용 데이터로 전처리
-    func preprocessCapturedImageData(
-        _ imageData: Data,
-        normalizedRect: CGRect
-    ) -> Data? {
-        guard let croppedImage = cropCapturedImage(imageData, normalizedRect: normalizedRect) else {
-            return nil
-        }
+    // 이미지 중앙 crop 함수 - 이미지 검색 시 카메라 preview의 aspectFill + guideFrame과 비슷한 비율로 사용
+    func cropCenterSquare(_ image: UIImage) -> UIImage {
+        guard let orientedImage = normalizedImage(from: image) else { return image }
+        let cropRect = makeCenterGuideRect(for: orientedImage)
+        return cropImage(orientedImage, cropRect: cropRect) ?? orientedImage
+    }
 
-        return preprocessImage(croppedImage, width: inputWidth, height: inputHeight)
+    // 이미지 중앙 가이드 Rect 생성 함수 - 이미지 검색 시 crop할 이미지 범위를 구함
+    private func makeCenterGuideRect(for image: UIImage) -> CGRect {
+        guard image.size.width > 0, image.size.height > 0 else { return .zero }
+
+        let screenSize = UIScreen.main.bounds.size
+        let guideSide: CGFloat = 280
+        let previewScale = max(
+            screenSize.width / image.size.width,
+            screenSize.height / image.size.height
+        )
+        let cropPaddingScale: CGFloat = 1.12
+        let side = min((guideSide / previewScale) * cropPaddingScale, min(image.size.width, image.size.height))
+        let verticalOffset = side * 0.08
+
+        return CGRect(
+            x: ((image.size.width - side) / 2.0),
+            y: ((image.size.height - side) / 2.0) - verticalOffset,
+            width: side,
+            height: side
+        )
     }
     
-    // normalized rect 기준으로 캡처 데이터에서 guideFrame 영역만 잘라낸 이미지를 반환
-    func cropCapturedImage(
+    // 이미지 guidFrame crop 함수 - 촬영하기 시 normalized rect 기준으로 캡처 데이터에서 guideFrame 영역만 잘라낸 이미지를 반환
+    func cropGuideFrame(
         _ imageData: Data,
         normalizedRect: CGRect
     ) -> UIImage? {
         guard let image = UIImage(data: imageData) else { return nil }
         guard !normalizedRect.isEmpty else { return image }
 
-        // capturePhoto로 얻은 UIImage는 데이터가 나타내느 방향(orientation)과 실제 cgImage 픽셀 방향이 다를 수 있음
+        // capturePhoto로 얻은 UIImage는 데이터가 나타내는 방향(orientation)과 실제 cgImage 픽셀 방향이 다를 수 있음
         // 캡처 이미지의 사이즈만큼 세로 캔버스에 다시 그려서 crop 좌표 계산을 "사용자가 보는 방향"으로 맞춤
         let orientedSize = image.size
         let format = UIGraphicsImageRendererFormat.default()
@@ -280,7 +268,7 @@ extension PlantClassificationService {
         }
 
         let imageSize = CGSize(width: cgImage.width, height: cgImage.height)
-
+        
         // normalized rect는 프리뷰 좌표계를 기준으로 축이 바뀐 형태
         // -> 세로 이미지 기준 crop에서는 x/y와 width/height를 서로 바꿔 적용해야 guideFrame에 보였던 정사각형 영역과 같은 크기로 잘림
         let cropRect = CGRect(
@@ -288,28 +276,42 @@ extension PlantClassificationService {
             y: normalizedRect.minX * imageSize.height,
             width: normalizedRect.height * imageSize.width,
             height: normalizedRect.width * imageSize.height
-        ).intersection(CGRect(origin: .zero, size: imageSize))
+        )
 
+        return cropImage(orientedImage, cropRect: cropRect) ?? orientedImage
+    }
+    
+    // 이미지를 잘라내는 함수
+    private func cropImage(_ image: UIImage, cropRect: CGRect) -> UIImage? {
+        guard let cgImage = image.cgImage else { return nil }
+
+        let imageBounds = CGRect(x: 0, y: 0, width: cgImage.width, height: cgImage.height)
+        let cropRect = cropRect.intersection(imageBounds).integral
 
         guard !cropRect.isEmpty,
-              let croppedCGImage = cgImage.cropping(to: cropRect.integral) else {
-            return orientedImage
+              let croppedCGImage = cgImage.cropping(to: cropRect) else {
+            return nil
         }
 
         return UIImage(cgImage: croppedCGImage)
     }
 
+}
+
+
+// MARK: Normalize Image
+extension PlantClassificationService {
     // UIImage의 방향을 실제 픽셀에 반영하여 crop 좌표 계산이 어긋나지 않도록 정방향 이미지로 다시 그림
     private func normalizedImage(from image: UIImage) -> UIImage? {
         guard let cgImage = image.cgImage else { return image }
 
-        let pixelSize = CGSize(width: cgImage.width, height: cgImage.height)
+        let imageSize = image.size
         let format = UIGraphicsImageRendererFormat.default()
         format.scale = 1
 
-        return UIGraphicsImageRenderer(size: pixelSize, format: format).image { _ in
+        return UIGraphicsImageRenderer(size: imageSize, format: format).image { _ in
             UIImage(cgImage: cgImage, scale: 1, orientation: image.imageOrientation)
-                .draw(in: CGRect(origin: .zero, size: pixelSize))
+                .draw(in: CGRect(origin: .zero, size: imageSize))
         }
     }
 }

--- a/LeafLog/LeafLog/Service/PlantClassificationService/PlantClassificationService.swift
+++ b/LeafLog/LeafLog/Service/PlantClassificationService/PlantClassificationService.swift
@@ -135,6 +135,9 @@ extension PlantClassificationService {
                 let name = labels[target.offset]
                 let confidence = Confidence.from(value: target.element)
                 
+                let approx = Double(target.element) / 255.0 * 100.0
+                print("index=\(target.offset) raw=\(target.element) approx=\(String(format: "%.2f%%", approx)) label=\(name)")
+                
                 guard confidence != .unknown else { continue }
                 result[name] = confidence
             }
@@ -148,6 +151,35 @@ extension PlantClassificationService {
 
 //MARK: Preprocess to run model
 extension PlantClassificationService {
+    // 이미지 중앙 crop 함수 - 이미지 검색 시 카메라 preview의 aspectFill + guideFrame과 비슷한 비율로 사용
+    func cropCenterSquare(_ image: UIImage) -> UIImage {
+        guard image.size.width > 0, image.size.height > 0 else { return image }
+
+        let screenSize = UIScreen.main.bounds.size
+        let guideSide: CGFloat = 280
+        let previewScale = max(
+            screenSize.width / image.size.width,
+            screenSize.height / image.size.height
+        )
+        let cropPaddingScale: CGFloat = 1.12
+        let side = min((guideSide / previewScale) * cropPaddingScale, min(image.size.width, image.size.height))
+
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        let verticalOffset = side * 0.08
+
+        return UIGraphicsImageRenderer(size: CGSize(width: side, height: side), format: format).image { _ in
+            image.draw(
+                in: CGRect(
+                    x: (side - image.size.width) / 2.0,
+                    y: ((side - image.size.height) / 2.0) + verticalOffset,
+                    width: image.size.width,
+                    height: image.size.height
+                )
+            )
+        }
+    }
+
     // 이미지 전처리 함수
     private func preprocessImage(_ image: UIImage, width: Int, height: Int) -> Data? {
         // 1. 비율에 맞춰 리사이징 할 크기 계산 (Aspect Fill 방식)

--- a/LeafLog/LeafLog/View/CameraClassificationView/CameraClassificationViewController.swift
+++ b/LeafLog/LeafLog/View/CameraClassificationView/CameraClassificationViewController.swift
@@ -86,9 +86,10 @@ class CameraClassificationViewController: BaseViewController, View {
     }
     
     private func bindState(reactor: CameraClassificationReactor) {
-        reactor.state
-            .map { AppStep.classificationResult($0.classificationResult)
-            }
+        reactor.pulse(\.$classificationResult)
+            .compactMap { $0 }
+            .observe(on: MainScheduler.instance)
+            .map { AppStep.classificationResult($0) }
             .bind(to: steps)
             .disposed(by: disposeBag)
         

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -11,6 +11,8 @@ import RxKeyboard
 import RxSwift
 import UIKit
 import RxCocoa
+import Dependencies
+import SnapKit
 
 private struct PlantRegisterHeaderState: Equatable {
     let title: String
@@ -39,6 +41,7 @@ private func makePlantRegisterHeaderState(_ state: PlantRegisterReactor.State) -
 }
 
 final class PlantRegisterViewController: BaseViewController, View {
+    @Dependency(\.plantClassificationService) private var plantClassificationService
     private let registerView = PlantRegisterView()
     private var selectedImage: UIImage?
     
@@ -309,8 +312,16 @@ final class PlantRegisterViewController: BaseViewController, View {
             }
             .withUnretained(self)
             .do(onNext: { $0.present($1, animated: true) })
-            .flatMap { $1.rx.selectedImages.take(1) }
+            .flatMap { $1.rx.selectedImages }
             .compactMap(\.first)
+            .withUnretained(self)
+            .map { `self`, image in
+                self.plantClassificationService.cropCenterSquare(image)
+            }
+            .withUnretained(self)
+            .flatMap { `self`, croppedImage in
+                self.presentDebugCroppedImage(croppedImage)
+            }
             .map { PlantRegisterReactor.Action.classificationImageSelected($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -524,6 +535,75 @@ extension PlantRegisterViewController {
         
         let imagePicker = PHPickerViewController(configuration: config)
         return imagePicker
+    }
+
+    private func presentDebugCroppedImage(_ image: UIImage) -> Observable<UIImage> {
+        #if DEBUG
+        Observable.create { [weak self] observer in
+            func presentIfReady(retryCount: Int) {
+                guard let self else {
+                    observer.onNext(image)
+                    observer.onCompleted()
+                    return
+                }
+
+                guard self.presentedViewController == nil else {
+                    if retryCount < 10 {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                            presentIfReady(retryCount: retryCount + 1)
+                        }
+                    } else {
+                        observer.onNext(image)
+                        observer.onCompleted()
+                    }
+                    return
+                }
+
+                let previewController = UIViewController()
+                previewController.modalPresentationStyle = .overFullScreen
+                previewController.view.backgroundColor = .black
+
+                let imageView = UIImageView(image: image)
+                imageView.contentMode = .scaleAspectFit
+                imageView.backgroundColor = .black
+
+                let closeButton = UIButton(type: .system)
+                closeButton.setTitle("닫기", for: .normal)
+                closeButton.setTitleColor(.white, for: .normal)
+                closeButton.addAction(
+                    UIAction { [weak previewController] _ in
+                        previewController?.dismiss(animated: true) {
+                            observer.onNext(image)
+                            observer.onCompleted()
+                        }
+                    },
+                    for: .touchUpInside
+                )
+
+                previewController.view.addSubview(imageView)
+                previewController.view.addSubview(closeButton)
+
+                imageView.snp.makeConstraints {
+                    $0.edges.equalToSuperview()
+                }
+
+                closeButton.snp.makeConstraints {
+                    $0.top.equalTo(previewController.view.safeAreaLayoutGuide).offset(16)
+                    $0.trailing.equalToSuperview().inset(24)
+                }
+
+                self.present(previewController, animated: true)
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                presentIfReady(retryCount: 0)
+            }
+
+            return Disposables.create()
+        }
+        #else
+        Observable.just(image)
+        #endif
     }
 }
 

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -224,6 +224,13 @@ final class PlantRegisterViewController: BaseViewController, View {
             })
             .disposed(by: disposeBag)
 
+        reactor.pulse(\.$classificationResult)
+            .compactMap { $0 }
+            .observe(on: MainScheduler.instance)
+            .map { AppStep.classificationResult($0) }
+            .bind(to: steps)
+            .disposed(by: disposeBag)
+
         Observable.just(PlantRegisterReactor.Action.viewDidLoad)
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -277,9 +284,36 @@ final class PlantRegisterViewController: BaseViewController, View {
             for: .touchUpInside
         )
         
-        registerView.plantTypeSearchBar.cameraButton.rx.tap
-            .map { AppStep.cameraRequired }
+        // 카메라 검색 버튼
+        let cameraSearchButtonSelected = registerView.plantTypeSearchBar.cameraButton.rx.tap
+            .withUnretained(self)
+            .flatMap({ `self`, _ in
+                self.selectedPlantTypeImageSourceAlert()
+            })
+            .share()
+        
+        // 카메라 검색 버튼 - 촬영하기 선택 시
+        cameraSearchButtonSelected
+            .compactMap { result in
+                guard case .camera = result else { return nil }
+                
+                return AppStep.cameraRequired
+            }
             .bind(to: steps)
+            .disposed(by: disposeBag)
+   
+        // 카메라 검색 버튼 - 이미지 불러오기 선택 시
+        cameraSearchButtonSelected
+            .compactMap { [weak self] result -> PHPickerViewController? in
+                guard case .photoLibrary = result else { return nil }
+                return self?.makeImagePicker()
+            }
+            .withUnretained(self)
+            .do(onNext: { $0.present($1, animated: true) })
+            .flatMap { $1.rx.selectedImages }
+            .compactMap(\.first)
+            .map { PlantRegisterReactor.Action.classificationImageSelected($0) }
+            .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
         registerView.categoryButtons.forEach { button in
@@ -507,5 +541,39 @@ private extension UIView {
         }
 
         return nil
+    }
+}
+
+extension PlantRegisterViewController {
+    private enum PlantTypeImageSource {
+        case camera
+        case photoLibrary
+        case none
+    }
+    
+    private func selectedPlantTypeImageSourceAlert() -> Observable<PlantTypeImageSource> {
+        Observable.create { [weak self] observer in
+            guard let self else {
+                observer.onCompleted()
+                return Disposables.create()
+            }
+            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
+            
+            alert.addAction(UIAlertAction(title: "촬영하기", style: .default) { _ in
+                observer.onNext(.camera)
+                observer.onCompleted()
+            })
+            alert.addAction(UIAlertAction(title: "이미지 불러오기", style: .default) { _ in
+                observer.onNext(.photoLibrary)
+                observer.onCompleted()
+            })
+            alert.addAction(UIAlertAction(title: "취소", style: .cancel) { _ in
+                observer.onCompleted()
+            })
+
+            self.present(alert, animated: true)
+            return Disposables.create()
+        }
+        
     }
 }

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -11,8 +11,6 @@ import RxKeyboard
 import RxSwift
 import UIKit
 import RxCocoa
-import Dependencies
-import SnapKit
 
 private struct PlantRegisterHeaderState: Equatable {
     let title: String
@@ -41,7 +39,6 @@ private func makePlantRegisterHeaderState(_ state: PlantRegisterReactor.State) -
 }
 
 final class PlantRegisterViewController: BaseViewController, View {
-    @Dependency(\.plantClassificationService) private var plantClassificationService
     private let registerView = PlantRegisterView()
     private var selectedImage: UIImage?
     
@@ -314,14 +311,6 @@ final class PlantRegisterViewController: BaseViewController, View {
             .do(onNext: { $0.present($1, animated: true) })
             .flatMap { $1.rx.selectedImages.take(1) }
             .compactMap(\.first)
-            .withUnretained(self)
-            .map { `self`, image in
-                self.plantClassificationService.cropCenterSquare(image)
-            }
-            .withUnretained(self)
-            .flatMap { `self`, croppedImage in
-                self.presentDebugCroppedImage(croppedImage)
-            }
             .map { PlantRegisterReactor.Action.classificationImageSelected($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -537,74 +526,6 @@ extension PlantRegisterViewController {
         return imagePicker
     }
 
-    private func presentDebugCroppedImage(_ image: UIImage) -> Observable<UIImage> {
-        #if DEBUG
-        Observable.create { [weak self] observer in
-            func presentIfReady(retryCount: Int) {
-                guard let self else {
-                    observer.onNext(image)
-                    observer.onCompleted()
-                    return
-                }
-
-                guard self.presentedViewController == nil else {
-                    if retryCount < 10 {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                            presentIfReady(retryCount: retryCount + 1)
-                        }
-                    } else {
-                        observer.onNext(image)
-                        observer.onCompleted()
-                    }
-                    return
-                }
-
-                let previewController = UIViewController()
-                previewController.modalPresentationStyle = .overFullScreen
-                previewController.view.backgroundColor = .black
-
-                let imageView = UIImageView(image: image)
-                imageView.contentMode = .scaleAspectFit
-                imageView.backgroundColor = .black
-
-                let closeButton = UIButton(type: .system)
-                closeButton.setTitle("닫기", for: .normal)
-                closeButton.setTitleColor(.white, for: .normal)
-                closeButton.addAction(
-                    UIAction { [weak previewController] _ in
-                        previewController?.dismiss(animated: true) {
-                            observer.onNext(image)
-                            observer.onCompleted()
-                        }
-                    },
-                    for: .touchUpInside
-                )
-
-                previewController.view.addSubview(imageView)
-                previewController.view.addSubview(closeButton)
-
-                imageView.snp.makeConstraints {
-                    $0.edges.equalToSuperview()
-                }
-
-                closeButton.snp.makeConstraints {
-                    $0.top.equalTo(previewController.view.safeAreaLayoutGuide).offset(16)
-                    $0.trailing.equalToSuperview().inset(24)
-                }
-
-                self.present(previewController, animated: true)
-            }
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                presentIfReady(retryCount: 0)
-            }
-
-            return Disposables.create()
-        }
-        #else
-        Observable.just(image)
-        #endif
-    }
 }
 
 private extension UIView {

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -547,7 +547,6 @@ extension PlantRegisterViewController {
     private enum PlantTypeImageSource {
         case camera
         case photoLibrary
-        case none
     }
     
     private func selectedPlantTypeImageSourceAlert() -> Observable<PlantTypeImageSource> {

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -296,7 +296,6 @@ final class PlantRegisterViewController: BaseViewController, View {
         cameraSearchButtonSelected
             .compactMap { result in
                 guard case .camera = result else { return nil }
-                
                 return AppStep.cameraRequired
             }
             .bind(to: steps)
@@ -310,7 +309,7 @@ final class PlantRegisterViewController: BaseViewController, View {
             }
             .withUnretained(self)
             .do(onNext: { $0.present($1, animated: true) })
-            .flatMap { $1.rx.selectedImages }
+            .flatMap { $1.rx.selectedImages.take(1) }
             .compactMap(\.first)
             .map { PlantRegisterReactor.Action.classificationImageSelected($0) }
             .bind(to: reactor.action)

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -312,7 +312,7 @@ final class PlantRegisterViewController: BaseViewController, View {
             }
             .withUnretained(self)
             .do(onNext: { $0.present($1, animated: true) })
-            .flatMap { $1.rx.selectedImages }
+            .flatMap { $1.rx.selectedImages.take(1) }
             .compactMap(\.first)
             .withUnretained(self)
             .map { `self`, image in

--- a/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
+++ b/LeafLog/LeafLog/View/PlantRegisterView/PlantRegisterViewController.swift
@@ -286,6 +286,7 @@ final class PlantRegisterViewController: BaseViewController, View {
         
         // 카메라 검색 버튼
         let cameraSearchButtonSelected = registerView.plantTypeSearchBar.cameraButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
             .withUnretained(self)
             .flatMap({ `self`, _ in
                 self.selectedPlantTypeImageSourceAlert()


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #160

## 🛠 작업 내용 (What I did)
- AI 검색 후 검색 결과화면에서 카메라 버튼 선택 시 네비게이션 스택이 계속 쌓이는 현상 해결
- AI 검색 시 촬영하기 / 이미지 불러오기 선택지 추가

## 💻 구현 상세 (Implementation Details)
- AI 검색 후 검색 결과화면에서 카메라 버튼 선택 시 네비게이션 스택이 계속 쌓이는 현상 해결
->  "촬영하기"로 결과 화면 진입 시 pop, 일반 검색으로 진입 시 push
- AI 검색 시 이미지 불러오기 선택지 추가: 갤러리에서 이미지 선택 가능

## 📸 스크린샷 (Screenshots)
<p align=center>
<img width=40% src="https://github.com/user-attachments/assets/649f849e-5f75-4692-b769-7ebf387aaa4a" />
<img width=40% src="https://github.com/user-attachments/assets/359ac918-c66b-4f40-9616-e0e314c6ee8c" />
</p>

## 🧐 리뷰 포인트 (Review Points)
- 네비게이션 스택이 쌓이는 현상이 정상적으로 수정되었는지 확인 부탁드립니다.
- 추가 버그가 발생하진 않았을지 확인 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
