### PR TITLE
[FIX] 초기 빈 화면 및 알림 계정 전환 버그 수정

### DIFF
--- a/LeafLog/LeafLog/App/Notification/FCMManager.swift
+++ b/LeafLog/LeafLog/App/Notification/FCMManager.swift
@@ -50,6 +50,7 @@ final class FCMManager: NSObject {
 extension FCMManager: UNUserNotificationCenterDelegate {
     // Foreground에서 알림이 오는 설정
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        NotificationCenter.default.post(name: .leafLogRemoteNotificationReceived, object: nil)
         completionHandler([.list, .banner])
     }
 }

--- a/LeafLog/LeafLog/App/Notification/NotificationName+.swift
+++ b/LeafLog/LeafLog/App/Notification/NotificationName+.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationName+.swift
+//  LeafLog
+//
+//  Created by OpenAI Codex on 5/20/26.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let leafLogRemoteNotificationReceived = Notification.Name("leafLogRemoteNotificationReceived")
+}

--- a/LeafLog/LeafLog/App/SupabaseManager.swift
+++ b/LeafLog/LeafLog/App/SupabaseManager.swift
@@ -300,6 +300,13 @@ extension SupabaseManager {
                     lastSeenAt: Date(),
                     isActive: true
                 )
+
+                try await client
+                    .from("device_tokens")
+                    .update(["is_active": false])
+                    .eq("device_id", value: deviceID)
+                    .neq("user_id", value: currentUserId)
+                    .execute()
                 
                 try await client
                     .from("device_tokens")
@@ -309,6 +316,18 @@ extension SupabaseManager {
                 logger.error("⚠️ 디바이스 토큰 저장 보류(로그인 전이거나 네트워크 에러)\nerror: \(error.localizedDescription, privacy: .private)")
             }
         }
+    }
+
+    func deactivateCurrentDeviceToken() async throws {
+        guard let currentUserId = client.auth.currentUser?.id else { return }
+        guard let deviceID = UIDevice.current.identifierForVendor?.uuidString.lowercased() else { return }
+
+        try await client
+            .from("device_tokens")
+            .update(["is_active": false])
+            .eq("user_id", value: currentUserId)
+            .eq("device_id", value: deviceID)
+            .execute()
     }
     
     // 유저 알림 허용 여부 업데이트

--- a/LeafLog/LeafLog/Auth/AuthService.swift
+++ b/LeafLog/LeafLog/Auth/AuthService.swift
@@ -184,6 +184,11 @@ final class AuthService {
     // MARK: - Sign Out
     func signOut() async throws {
         let user = try await supabase.auth.user()
+        do {
+            try await supabaseManager.deactivateCurrentDeviceToken()
+        } catch {
+            throw AuthError.notificationFailed("기기 알림 연결을 해제하지 못했어요. 잠시 후 다시 시도해주세요.")
+        }
         try await supabase.auth.signOut()
         await signOutProvider(for: user)
     }

--- a/LeafLog/LeafLog/Auth/AuthService.swift
+++ b/LeafLog/LeafLog/Auth/AuthService.swift
@@ -187,7 +187,7 @@ final class AuthService {
         do {
             try await supabaseManager.deactivateCurrentDeviceToken()
         } catch {
-            throw AuthError.notificationFailed("기기 알림 연결을 해제하지 못했어요. 잠시 후 다시 시도해주세요.")
+            logger.error("기기 토큰 비활성화 실패: \(error.localizedDescription)")
         }
         try await supabase.auth.signOut()
         await signOutProvider(for: user)

--- a/LeafLog/LeafLog/Network/NotificationDBManager.swift
+++ b/LeafLog/LeafLog/Network/NotificationDBManager.swift
@@ -35,11 +35,14 @@ final class NotificationDBManager {
     }
 
     func markAsRead(notificationID: UUID) async throws {
+        let user = try await supabaseManager.client.auth.user()
+
         do {
             try await supabaseManager.client
                 .from("notifications")
                 .update(["read_at": dateFormatter.string(from: Date())])
                 .eq("id", value: notificationID)
+                .eq("user_id", value: user.id)
                 .execute()
         } catch {
             throw AuthError.notificationFailed("알림 상태를 업데이트하지 못했어요. 잠시 후 다시 시도해주세요.")

--- a/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
@@ -151,24 +151,17 @@ extension CameraClassificationReactor {
                 return Disposables.create()
             }
             
-            let task = Task { [weak self] in
-                guard let self else {
-                    observer.onCompleted()
-                    return
-                }
-                do {
-                    let classificationResult = try self.plantClassificationService.analyzeImage(image: cropImage)
-                    observer.onNext(.analyzeResult(classificationResult))
-                    observer.onCompleted()
-                } catch {
-                    self.logger.error("이미지 분석 실패: \(error.localizedDescription)")
-                    observer.onNext(.analyzeResult([:]))
-                    observer.onCompleted()
-                }
+            do {
+                let classificationResult = try self.plantClassificationService.analyzeImage(image: cropImage)
+                observer.onNext(.analyzeResult(classificationResult))
+                observer.onCompleted()
+            } catch {
+                self.logger.error("이미지 분석 실패: \(error.localizedDescription)")
+                observer.onNext(.analyzeResult([:]))
+                observer.onCompleted()
             }
-            return Disposables.create() {
-                task.cancel()
-            }
+            
+            return Disposables.create()
         }
     }
 }

--- a/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CameraClassificationReactor.swift
@@ -83,6 +83,7 @@ final class CameraClassificationReactor: Reactor {
             newState.isCameraReady = true
             
         case .cameraNotReady:
+            newState.isAuthorized = true
             newState.isCameraReady = false
 
         case .analyzeResult(let results):

--- a/LeafLog/LeafLog/Reactor/NotificationCenterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/NotificationCenterReactor.swift
@@ -14,6 +14,7 @@ import OSLog
 final class NotificationCenterReactor: Reactor {
     enum Action {
         case viewWillAppear
+        case refresh
     }
     
     enum Mutation {
@@ -36,6 +37,9 @@ final class NotificationCenterReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewWillAppear:
+            return notifications()
+            
+        case .refresh:
             return notifications()
         }
     }

--- a/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/PlantRegisterReactor.swift
@@ -535,31 +535,28 @@ extension PlantRegisterReactor {
     // 갤러리에서 가져온 이미지 분석
     private func analyzeImage(_ image: UIImage) -> Observable<Mutation> {
         Observable.create { [weak self] observer in
-            let task = Task { [weak self] in
-                guard let self else {
-                    observer.onCompleted()
-                    return
-                }
+            guard let self else {
+                observer.onCompleted()
+                return Disposables.create()
+            }
+            
+            do {
+                let croppedImage = self.plantClassificationService.cropCenterSquare(image)
                 
-                do {
-                    let croppedImage = self.plantClassificationService.cropCenterSquare(image)
-                    
-                    let classificationResult = try self.plantClassificationService.analyzeImage(image: croppedImage)
-                    observer.onNext(.analyzeResult(classificationResult))
-                    observer.onCompleted()
-                } catch let error as PlantClassificationService.ClassificationError {
-                    self.logger.error("PlantClassificationError: \(error.localizedDescription)")
-                    observer.onNext(.analyzeResult([:]))
-                    observer.onCompleted()
-                } catch {
-                    self.logger.error("알 수 없는 에러: \(error.localizedDescription)")
-                    observer.onNext(.analyzeResult([:]))
-                    observer.onCompleted()
-                }
+                let classificationResult = try self.plantClassificationService.analyzeImage(image: croppedImage)
+                observer.onNext(.analyzeResult(classificationResult))
+                observer.onCompleted()
+            } catch let error as PlantClassificationService.ClassificationError {
+                self.logger.error("PlantClassificationError: \(error.localizedDescription)")
+                observer.onNext(.analyzeResult([:]))
+                observer.onCompleted()
+            } catch {
+                self.logger.error("알 수 없는 에러: \(error.localizedDescription)")
+                observer.onNext(.analyzeResult([:]))
+                observer.onCompleted()
             }
-            return Disposables.create() {
-                task.cancel()
-            }
+            
+            return Disposables.create()
         }
     }
 }

--- a/LeafLog/LeafLog/View/CameraClassificationView/CameraClassificationViewController.swift
+++ b/LeafLog/LeafLog/View/CameraClassificationView/CameraClassificationViewController.swift
@@ -94,9 +94,11 @@ class CameraClassificationViewController: BaseViewController, View {
             .disposed(by: disposeBag)
         
         let isAuthorized = reactor.pulse(\.$isAuthorized)
+            .skip(1)
             .asDriver(onErrorDriveWith: .empty())
         
         let isCameraReady = reactor.pulse(\.$isCameraReady)
+            .skip(1)
             .asDriver(onErrorDriveWith: .empty())
         
         Driver

--- a/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
+++ b/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
@@ -87,6 +87,7 @@ extension HomeViewController {
         
         // 등록 식물이 없을 경우
         state.map(\.isEmpty)
+            .skip(1)
             .drive { [weak self] isEmpty in
                 self?.homeView.showEmpty(isEmpty)
             }

--- a/LeafLog/LeafLog/View/NotificationCenterView/NotificationCenterViewController.swift
+++ b/LeafLog/LeafLog/View/NotificationCenterView/NotificationCenterViewController.swift
@@ -69,7 +69,6 @@ final class NotificationCenterViewController: BaseViewController, View {
         reactor.state
             .map(\.alarmItem)
             .skip(1)
-            .distinctUntilChanged()
             .subscribe(onNext: { [weak self] items in
                 self?.notificationCenterView.emptyView.isHidden = !items.isEmpty
                 self?.notificationCenterView.setSnapshot(items)

--- a/LeafLog/LeafLog/View/NotificationCenterView/NotificationCenterViewController.swift
+++ b/LeafLog/LeafLog/View/NotificationCenterView/NotificationCenterViewController.swift
@@ -42,6 +42,23 @@ final class NotificationCenterViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        Observable.merge(
+            // 앱이 백그라운드 상태에서 다시 foreground로 진입했을 경우
+            NotificationCenter.default.rx.notification(
+                UIApplication.didBecomeActiveNotification
+            )
+            .map { _ in },
+            // FCM을 통해 푸시 알림을 받았을 경우
+            NotificationCenter.default.rx.notification(
+                .leafLogRemoteNotificationReceived
+            )
+            .map { _ in }
+        )
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .map { NotificationCenterReactor.Action.refresh }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         notificationCenterView.rx.backButtonTap
             .map { _ in AppStep.pageBack }
             .bind(to: steps)

--- a/LeafLog/LeafLog/View/NotificationCenterView/NotificationCenterViewController.swift
+++ b/LeafLog/LeafLog/View/NotificationCenterView/NotificationCenterViewController.swift
@@ -51,6 +51,8 @@ final class NotificationCenterViewController: BaseViewController, View {
     private func bindState(reactor: NotificationCenterReactor) {        
         reactor.state
             .map(\.alarmItem)
+            .skip(1)
+            .distinctUntilChanged()
             .subscribe(onNext: { [weak self] items in
                 self?.notificationCenterView.emptyView.isHidden = !items.isEmpty
                 self?.notificationCenterView.setSnapshot(items)


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #165
Closes #166

## 🛠 작업 내용 (What I did)
- 홈 화면 초기 진입 시 데이터 로딩 전 빈 상태 화면이 먼저 노출되는 현상을 수정했습니다.
- 알림 센터 초기 진입 시 알림 목록 확인 전 빈 알림 화면이 먼저 노출되는 현상을 수정했습니다.
- 카메라 검색 화면 초기 진입 시 권한/카메라 준비 상태 확인 전 권한 요청 화면이 노출되는 현상을 수정했습니다.
- 같은 기기에서 계정 전환 시 이전 계정의 푸시 알림이 수신되지 않도록 기기 토큰 비활성화 흐름을 추가했습니다.
- 알림 센터에 머무는 동안 푸시 알림을 수신하거나 앱이 다시 활성화되면 알림 목록을 갱신하도록 수정했습니다.

## 💻 구현 상세 (Implementation Details)
- Reactor 초기 상태가 실제 데이터 확인 전 UI에 반영되지 않도록 홈, 알림 센터, 카메라 검색 화면의 초기 상태 방출을 건너뛰었습니다.
- 카메라 준비 실패 상태에서는 권한 확인이 이미 완료된 상태이므로 `isAuthorized`를 `true`로 유지하도록 보정했습니다.
- FCM foreground 수신 시 앱 내부 notification을 발행하고, 알림 센터에서 해당 이벤트와 앱 활성화 이벤트를 받아 목록을 새로 조회하도록 했습니다.
- 로그아웃 시 현재 사용자/기기 조합의 device token을 비활성화하고, 같은 기기에서 다른 사용자 토큰이 활성 상태로 남지 않도록 저장 로직을 보강했습니다.
- 알림 읽음 처리 시 현재 사용자 조건을 함께 적용해 다른 사용자의 알림 상태가 변경되지 않도록 제한했습니다.

## 🧐 리뷰 포인트 (Review Points)
- `skip(1)` 적용 위치가 각 화면의 초기 로딩 상태 노출을 막는 데 충분한지 확인 부탁드립니다.
- 계정 전환 시 device token 비활성화 조건이 실제 운영 DB의 `device_tokens` 정책과 맞는지 확인 부탁드립니다.
- 알림 센터 refresh 트리거가 foreground 수신/앱 활성화 상황에서 중복 호출을 과하게 만들지 않는지 확인 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요? (미실행)
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #165, Closes #166)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
