### PR TITLE
[FIX] 알림 상태 표시 및 권한 처리 개선

### DIFF
--- a/LeafLog/LeafLog/App/Flows/AppStep.swift
+++ b/LeafLog/LeafLog/App/Flows/AppStep.swift
@@ -57,7 +57,7 @@ enum AppStep: Step {
         onConfirm: () -> Void
     )
     
+    // MyInfoTab
     case profileImageSourceSheet
-    // 예시용
-    case pushButtonTapped
+    case notificationAuthorizationRequired(onSettingsSelected: () -> Void)
 }

--- a/LeafLog/LeafLog/App/Flows/MyInfoTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MyInfoTabFlow.swift
@@ -55,6 +55,9 @@ final class MyInfoTabFlow: Flow {
         case .loginRequired:
             return .end(forwardToParentFlowWithStep: step)
             
+        case .notificationAuthorizationRequired(let onSettingsSelected):
+            return presentNotificationAuthorizationRequired(onSettingsSelected: onSettingsSelected)
+            
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
         }
@@ -78,5 +81,22 @@ private extension MyInfoTabFlow {
                 profileEditVC?.deleteProfileImage()
             }
         )
+    }
+    
+    func presentNotificationAuthorizationRequired(onSettingsSelected: @escaping () -> Void) -> RxFlow.FlowContributors {
+        let alert = UIAlertController(title: "알림 권한 필요", message: "푸시 알림을 활성화하기 위해서는 알림 권한이 필요합니다.", preferredStyle: .alert)
+        
+        let setting = UIAlertAction(title: "설정으로 이동", style: .default) { _ in
+            onSettingsSelected()
+        }
+        
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(setting)
+        alert.addAction(cancel)
+        
+        navigationController.present(alert, animated: true)
+        
+        return .none
     }
 }

--- a/LeafLog/LeafLog/App/Notification/NotificationManager.swift
+++ b/LeafLog/LeafLog/App/Notification/NotificationManager.swift
@@ -56,6 +56,7 @@ final class NotificationManager {
     }
     
     // 알림 허용 여부 업데이트
+    @discardableResult
     func updateIsNotificationEnabled(to isEnabled: Bool?) async throws -> Bool {
         guard let userId = self.supabaseManager.client.auth.currentUser?.id else {
             throw NotificationError.userIDNotFound
@@ -66,6 +67,9 @@ final class NotificationManager {
         var target: Bool = false
         
         if let isEnabled {
+            if isEnabled && !isAuthorized {
+                throw NotificationError.authorizationDenied
+            }
             target = isEnabled && isAuthorized
         } else {
             target = isAuthorized
@@ -106,6 +110,7 @@ final class NotificationManager {
 extension NotificationManager {
     enum NotificationError: Error {
         case userIDNotFound
+        case authorizationDenied
     }
 }
 

--- a/LeafLog/LeafLog/App/Notification/NotificationManager.swift
+++ b/LeafLog/LeafLog/App/Notification/NotificationManager.swift
@@ -56,24 +56,28 @@ final class NotificationManager {
     }
     
     // 알림 허용 여부 업데이트
-    func updateIsNotificationEnabled(to isEnabled: Bool?) async throws {
+    func updateIsNotificationEnabled(to isEnabled: Bool?) async throws -> Bool {
         guard let userId = self.supabaseManager.client.auth.currentUser?.id else {
             throw NotificationError.userIDNotFound
         }
         
+        let isAuthorized = await self.checkNotificationEnabled()
+        
         var target: Bool = false
         
         if let isEnabled {
-            target = isEnabled
+            target = isEnabled && isAuthorized
         } else {
-            target = await self.checkNotificationEnabled()
+            target = isAuthorized
         }
         
         let willUpdate = checkUserDefaultsWouldUpdate(to: target, user: userId)
-        guard willUpdate else { return } // UserDefaults가 업데이트될 경우
+        guard willUpdate else { return target } // UserDefaults가 업데이트될 경우
         
         try await supabaseManager.updateIsNotificationEnabled(target) // DB 업데이트
         updateUserDefaultsIsNotificationEnabled(to: target, user: userId) // UserDefaults 업데이트
+        
+        return target
     }
     
     // UserDefaults 업데이트 여부

--- a/LeafLog/LeafLog/App/Notification/NotificationName+.swift
+++ b/LeafLog/LeafLog/App/Notification/NotificationName+.swift
@@ -9,4 +9,5 @@ import Foundation
 
 extension Notification.Name {
     static let leafLogRemoteNotificationReceived = Notification.Name("leafLogRemoteNotificationReceived")
+    static let leafLogNotificationReadStateChanged = Notification.Name("leafLogNotificationReadStateChanged")
 }

--- a/LeafLog/LeafLog/App/SupabaseManager.swift
+++ b/LeafLog/LeafLog/App/SupabaseManager.swift
@@ -290,27 +290,16 @@ extension SupabaseManager {
     func updateFCMToken(_ validToken: String) {
         Task {
             do {
-                guard let currentUserId = client.auth.currentUser?.id else { return } // 현재 로그인 된 유저 정보
+                guard client.auth.currentUser?.id != nil else { return } // 현재 로그인 된 유저 정보
                 guard let deviceID = UIDevice.current.identifierForVendor?.uuidString.lowercased() else { return } // 기기 정보
                 
-                let payload = DeviceTokenPayload(
-                    userID: currentUserId,
-                    fcmToken: validToken,
-                    deviceID: deviceID,
-                    lastSeenAt: Date(),
-                    isActive: true
-                )
+                let payload = [
+                    "p_fcm_token": validToken,
+                    "p_device_id": deviceID,
+                ]
 
                 try await client
-                    .from("device_tokens")
-                    .update(["is_active": false])
-                    .eq("device_id", value: deviceID)
-                    .neq("user_id", value: currentUserId)
-                    .execute()
-                
-                try await client
-                    .from("device_tokens")
-                    .upsert(payload, onConflict: "user_id,device_id")
+                    .rpc("activate_current_device_token", params: payload)
                     .execute()
             } catch {
                 logger.error("⚠️ 디바이스 토큰 저장 보류(로그인 전이거나 네트워크 에러)\nerror: \(error.localizedDescription, privacy: .private)")
@@ -343,21 +332,6 @@ extension SupabaseManager {
             .execute()
     }
     
-    private struct DeviceTokenPayload: Encodable {
-        let userID: UUID
-        let fcmToken: String
-        let deviceID: String
-        let lastSeenAt: Date
-        let isActive: Bool
-        
-        enum CodingKeys: String, CodingKey {
-            case userID = "user_id"
-            case fcmToken = "fcm_token"
-            case deviceID = "device_id"
-            case lastSeenAt = "last_seen_at"
-            case isActive = "is_active"
-        }
-    }
 }
 
 

--- a/LeafLog/LeafLog/Assets.xcassets/lineIcon/bellOn.imageset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/lineIcon/bellOn.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "Property 1=new-bell.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/lineIcon/bellOn.imageset/Property 1=new-bell.svg
+++ b/LeafLog/LeafLog/Assets.xcassets/lineIcon/bellOn.imageset/Property 1=new-bell.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 8C18 6.4087 17.3679 4.88258 16.2426 3.75736C15.1174 2.63214 13.5913 2 12 2C10.4087 2 8.88258 2.63214 7.75736 3.75736C6.63214 4.88258 6 6.4087 6 8C6 15 3 17 3 17H21C21 17 18 15 18 8Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.7295 21C13.5537 21.3031 13.3014 21.5547 12.9978 21.7295C12.6941 21.9044 12.3499 21.9965 11.9995 21.9965C11.6492 21.9965 11.3049 21.9044 11.0013 21.7295C10.6977 21.5547 10.4453 21.3031 10.2695 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="21.5" cy="2.5" r="2.5" fill="#9FC423"/>
+</svg>

--- a/LeafLog/LeafLog/Network/NotificationDBManager.swift
+++ b/LeafLog/LeafLog/Network/NotificationDBManager.swift
@@ -34,6 +34,30 @@ final class NotificationDBManager {
         }
     }
 
+    func hasUnreadNotifications() async throws -> Bool {
+        struct NotificationID: Decodable {
+            let id: UUID
+        }
+
+        let user = try await supabaseManager.client.auth.user()
+
+        do {
+            let notifications: [NotificationID] = try await supabaseManager.client
+                .from("notifications")
+                .select("id")
+                .eq("user_id", value: user.id)
+                .not("sent_at", operator: .is, value: "null")
+                .is("read_at", value: nil)
+                .limit(1)
+                .execute()
+                .value
+
+            return !notifications.isEmpty
+        } catch {
+            throw AuthError.notificationFailed("미확인 알림 상태를 불러오지 못했어요. 잠시 후 다시 시도해주세요.")
+        }
+    }
+
     func markAsRead(notificationID: UUID) async throws {
         let user = try await supabaseManager.client.auth.user()
 

--- a/LeafLog/LeafLog/Reactor/CalendarReactor.swift
+++ b/LeafLog/LeafLog/Reactor/CalendarReactor.swift
@@ -13,6 +13,8 @@ import Dependencies
 final class CalendarReactor: Reactor {
     enum Action {
         case viewWillAppear
+        case refreshUnreadNotificationState
+        case remoteNotificationReceived
         case previousMonth
         case nextMonth
         case backToToday
@@ -37,6 +39,7 @@ final class CalendarReactor: Reactor {
         case setDetailGrowItem([CalendarView.Item])
         case setDetailSproutItem([CalendarView.Item])
         case setDetailTreatItem([CalendarView.Item])
+        case setHasUnreadNotification(Bool)
         
         case error(String)
     }
@@ -47,10 +50,11 @@ final class CalendarReactor: Reactor {
         var cacheData: [MonthKey: [CareRecord]] = [:]
         var plants: [MyPlant] = []
         var cacheOrder: [MonthKey] = []
+        var hasUnreadNotification: Bool = false
         
         var selectedDate: Date? // 선택된 날짜
         var data: [CalendarView.Section: [CalendarView.Item]] = [
-            .title: [.title],
+            .title: [.title(false)],
             .filter: [.filter([])]
         ]
         @Pulse var errorMessage: String? = nil
@@ -61,6 +65,7 @@ final class CalendarReactor: Reactor {
     //MARK: properties
     @Dependency(\.plantDBManager) private var plantDBManager
     @Dependency(\.careRecordDBManager) private var careRecordDBManager
+    @Dependency(\.notificationDBManager) private var notificationDBManager
     
     private let calendar = Calendar.current
     private let cacheLimit = 3
@@ -72,8 +77,15 @@ final class CalendarReactor: Reactor {
             return Observable.concat([
                 reloadCalendar(moveBenchmark: .none),
                 .just(.updateSelectedDate(date)),
-                detailItems(of: date)
+                detailItems(of: date),
+                refreshUnreadNotificationState()
                 ])
+
+        case .refreshUnreadNotificationState:
+            return refreshUnreadNotificationState()
+
+        case .remoteNotificationReceived:
+            return .just(.setHasUnreadNotification(true))
             
         case .previousMonth:
             return reloadCalendar(moveBenchmark: .previous)
@@ -148,6 +160,10 @@ final class CalendarReactor: Reactor {
             
         case .setDetailTreatItem(let items):
             newState.data[.treat] = items
+
+        case .setHasUnreadNotification(let hasUnreadNotification):
+            newState.hasUnreadNotification = hasUnreadNotification
+            newState.data[.title] = [.title(hasUnreadNotification)]
             
         case .error(let message):
             newState.errorMessage = message
@@ -258,6 +274,29 @@ extension CalendarReactor {
                 .just(.setDetailSproutItem(detailRecords[Badge.sprout.rawValue])),
                 .just(.setDetailTreatItem(detailRecords[Badge.treat.rawValue]))
             ])
+        }
+    }
+
+    private func refreshUnreadNotificationState() -> Observable<Mutation> {
+        Observable.create { [weak self] observer in
+            let task = Task { [weak self] in
+                guard let self else {
+                    observer.onCompleted()
+                    return
+                }
+
+                do {
+                    let hasUnreadNotification = try await self.notificationDBManager.hasUnreadNotifications()
+                    observer.onNext(.setHasUnreadNotification(hasUnreadNotification))
+                    observer.onCompleted()
+                } catch {
+                    observer.onCompleted()
+                }
+            }
+
+            return Disposables.create {
+                task.cancel()
+            }
         }
     }
     

--- a/LeafLog/LeafLog/Reactor/HomeReactor.swift
+++ b/LeafLog/LeafLog/Reactor/HomeReactor.swift
@@ -13,6 +13,8 @@ import Dependencies
 final class HomeReactor: Reactor {
     enum Action {
         case viewWillAppear
+        case refreshUnreadNotificationState
+        case remoteNotificationReceived
         case waterButtonTap(UUID)
     }
     
@@ -20,6 +22,7 @@ final class HomeReactor: Reactor {
         case setEmpty(Bool)
         case setTotalCard(Int, Int)
         case setPlants([HomeView.Item])
+        case setHasUnreadNotification(Bool)
         case error(String)
     }
     
@@ -27,6 +30,7 @@ final class HomeReactor: Reactor {
         var isEmpty: Bool = true
         var totalPlants: Int = 0
         var totalWater: Int = 0
+        var hasUnreadNotification: Bool = false
         var data: [HomeView.Section: [HomeView.Item]] = [:]
         @Pulse var errorMessage: String? = nil
     }
@@ -36,12 +40,19 @@ final class HomeReactor: Reactor {
     //MARK: Properties
     @Dependency(\.plantDBManager) private var plantDBManger
     @Dependency(\.careRecordDBManager) private var careRecordDBManager
+    @Dependency(\.notificationDBManager) private var notificationDBManager
     private let calendar = Calendar.current
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewWillAppear:
-            return loadPlants()
+            return Observable.merge(loadPlants(), refreshUnreadNotificationState())
+
+        case .refreshUnreadNotificationState:
+            return refreshUnreadNotificationState()
+
+        case .remoteNotificationReceived:
+            return .just(.setHasUnreadNotification(true))
             
         case .waterButtonTap(let id):
             return Observable.concat(
@@ -63,6 +74,9 @@ final class HomeReactor: Reactor {
             
         case .setPlants(let items):
             newState.data[.plant] = items
+
+        case .setHasUnreadNotification(let hasUnreadNotification):
+            newState.hasUnreadNotification = hasUnreadNotification
             
         case .error(let message):
             newState.errorMessage = message
@@ -150,6 +164,29 @@ extension HomeReactor {
                     observer.onCompleted()
                 }
             }
+            return Disposables.create {
+                task.cancel()
+            }
+        }
+    }
+
+    private func refreshUnreadNotificationState() -> Observable<Mutation> {
+        Observable.create { [weak self] observer in
+            let task = Task { [weak self] in
+                guard let self else {
+                    observer.onCompleted()
+                    return
+                }
+
+                do {
+                    let hasUnreadNotification = try await self.notificationDBManager.hasUnreadNotifications()
+                    observer.onNext(.setHasUnreadNotification(hasUnreadNotification))
+                    observer.onCompleted()
+                } catch {
+                    observer.onCompleted()
+                }
+            }
+
             return Disposables.create {
                 task.cancel()
             }

--- a/LeafLog/LeafLog/Reactor/MyPageReactor.swift
+++ b/LeafLog/LeafLog/Reactor/MyPageReactor.swift
@@ -185,10 +185,10 @@ final class MyPageReactor: Reactor {
                 }
                 
                 do {
-                    try await self.notificationManager.updateIsNotificationEnabled(to: isOn)
+                    let actualIsOn = try await self.notificationManager.updateIsNotificationEnabled(to: isOn)
                     self.logger.log("✅ Supabase DB에 알림 허용 여부가 성공적으로 저장되었습니다.")
                     
-                    observer.onNext(.setPushAlert(isOn))
+                    observer.onNext(.setPushAlert(actualIsOn))
                     observer.onCompleted()
                 } catch {
                     self.logger.error("알림 허용 여부 저장 시 오류 발생: \(error.localizedDescription, privacy: .private)")

--- a/LeafLog/LeafLog/Reactor/MyPageReactor.swift
+++ b/LeafLog/LeafLog/Reactor/MyPageReactor.swift
@@ -37,6 +37,7 @@ final class MyPageReactor: Reactor {
         case setErrorMessage(String?)
         case setRouteToMail(isError: Bool)
         case setPushAlert(Bool)
+        case setNotificationAuthorizationRequired(Bool)
     }
     
     struct State {
@@ -48,6 +49,7 @@ final class MyPageReactor: Reactor {
         @Pulse var errorMessage: String?
         @Pulse var routeToMail: Bool? // true면 오류 신고, false면 일반 문의 버전
         @Pulse var pushAlertIsOn: Bool = true
+        @Pulse var notificationAuthorizationRequired: Bool = false
     }
     
     let initialState = State()
@@ -115,6 +117,9 @@ final class MyPageReactor: Reactor {
             
         case .setPushAlert(let isOn):
             newState.pushAlertIsOn = isOn
+            
+        case .setNotificationAuthorizationRequired(let isRequired):
+            newState.notificationAuthorizationRequired = isRequired
         }
         
         return newState
@@ -189,6 +194,12 @@ final class MyPageReactor: Reactor {
                     self.logger.log("✅ Supabase DB에 알림 허용 여부가 성공적으로 저장되었습니다.")
                     
                     observer.onNext(.setPushAlert(actualIsOn))
+                    observer.onNext(.setNotificationAuthorizationRequired(false))
+                    observer.onCompleted()
+                } catch NotificationManager.NotificationError.authorizationDenied {
+                    self.logger.log("⚠️알림 권한 허용 필요")
+                    observer.onNext(.setPushAlert(false))
+                    observer.onNext(.setNotificationAuthorizationRequired(true))
                     observer.onCompleted()
                 } catch {
                     self.logger.error("알림 허용 여부 저장 시 오류 발생: \(error.localizedDescription, privacy: .private)")

--- a/LeafLog/LeafLog/Reactor/NotificationCenterReactor.swift
+++ b/LeafLog/LeafLog/Reactor/NotificationCenterReactor.swift
@@ -90,6 +90,14 @@ extension NotificationCenterReactor {
                     }
                     
                     observer.onNext(.setAlarm(items))
+
+                    do {
+                        try await self.notificationDBManager.markAllAsRead()
+                        NotificationCenter.default.post(name: .leafLogNotificationReadStateChanged, object: nil)
+                    } catch {
+                        self.logger.error("알림 전체 읽음 처리 실패: \(error.localizedDescription, privacy: .private)")
+                    }
+
                     observer.onCompleted()
                 } catch let error as AuthError {
                     observer.onNext(.error(error.userMessage))

--- a/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
+++ b/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
@@ -84,6 +84,10 @@ extension TitleHeaderView {
         backButton.configuration?.baseForegroundColor = color
         rightButton.configuration?.baseForegroundColor = color
     }
+
+    func setRightButtonImage(_ imageName: String) {
+        rightButton.setImage(UIImage(named: imageName), for: .normal)
+    }
 }
 
 extension TitleHeaderView {

--- a/LeafLog/LeafLog/View/CalendarView/CalendarTitleCell.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarTitleCell.swift
@@ -32,6 +32,10 @@ final class CalendarTitleCell: UICollectionViewCell {
         super.prepareForReuse()
         disposeBag = DisposeBag()
     }
+
+    func configure(hasUnreadNotification: Bool) {
+        titleView.setRightButtonImage(hasUnreadNotification ? "bellOn" : "bell")
+    }
 }
 
 extension Reactive where Base: CalendarTitleCell {

--- a/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarView.swift
@@ -68,6 +68,14 @@ extension CalendarView {
         
         let titleCellRegistration = UICollectionView.CellRegistration<CalendarTitleCell, Item> { [weak self] cell,indexPath,item in
             guard let self else { return }
+
+            switch item {
+            case .title(let hasUnreadNotification):
+                cell.configure(hasUnreadNotification: hasUnreadNotification)
+            default:
+                break
+            }
+
             cell.rx.alarmButtonTap
                 .bind(to: self.alarmButtonTap)
                 .disposed(by: cell.disposeBag)
@@ -223,7 +231,7 @@ extension CalendarView {
     
     nonisolated
     enum Item: Hashable {
-        case title
+        case title(Bool)
         case header(Int, Int) // 년, 월
         case filter(Set<Int>)
         case calendar(ManageInfoByDate)

--- a/LeafLog/LeafLog/View/CalendarView/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarViewController.swift
@@ -104,7 +104,8 @@ class CalendarViewController: BaseViewController, View {
     private func bindState(reactor: CalendarReactor) {
         reactor.state
             .map { $0.data }
-            .subscribe(onNext: { [weak self] data in
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(onNext: { [weak self] data in
                 self?.calendarView.setSnapshot(data)
             })
             .disposed(by: disposeBag)

--- a/LeafLog/LeafLog/View/CalendarView/CalendarViewController.swift
+++ b/LeafLog/LeafLog/View/CalendarView/CalendarViewController.swift
@@ -38,6 +38,16 @@ class CalendarViewController: BaseViewController, View {
             .map { _ in CalendarReactor.Action.viewWillAppear}
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+
+        NotificationCenter.default.rx.notification(.leafLogRemoteNotificationReceived)
+            .map { _ in CalendarReactor.Action.remoteNotificationReceived }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        NotificationCenter.default.rx.notification(.leafLogNotificationReadStateChanged)
+            .map { _ in CalendarReactor.Action.refreshUnreadNotificationState }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         
         calendarView.rx.alarmButtonTap
             .map { _ in AppStep.alarmCenter }

--- a/LeafLog/LeafLog/View/HomeView/HomeView.swift
+++ b/LeafLog/LeafLog/View/HomeView/HomeView.swift
@@ -160,6 +160,10 @@ extension HomeView {
         totalWideCard.plantLabel.text = "내 식물 \(total)개"
         totalWideCard.waterLabel.text = "물 필요 \(needWater)개"
     }
+
+    func configureAlarmButton(hasUnreadNotification: Bool) {
+        titleView.setRightButtonImage(hasUnreadNotification ? "bellOn" : "bell")
+    }
 }
 
 //MARK: CollectionView - Section, Item

--- a/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
+++ b/LeafLog/LeafLog/View/HomeView/HomeViewController.swift
@@ -38,6 +38,16 @@ extension HomeViewController {
             .map { HomeReactor.Action.viewWillAppear }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+
+        NotificationCenter.default.rx.notification(.leafLogRemoteNotificationReceived)
+            .map { _ in HomeReactor.Action.remoteNotificationReceived }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        NotificationCenter.default.rx.notification(.leafLogNotificationReadStateChanged)
+            .map { _ in HomeReactor.Action.refreshUnreadNotificationState }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         
         // 컬렉션뷰 아이템 선택시
         homeView.rx.itemSelected
@@ -107,6 +117,13 @@ extension HomeViewController {
         state.map(\.data)
             .drive { [weak self] data in
                 self?.homeView.setSnapshot(data)
+            }
+            .disposed(by: disposeBag)
+
+        state.map(\.hasUnreadNotification)
+            .distinctUntilChanged()
+            .drive { [weak self] hasUnreadNotification in
+                self?.homeView.configureAlarmButton(hasUnreadNotification: hasUnreadNotification)
             }
             .disposed(by: disposeBag)
     }

--- a/LeafLog/LeafLog/View/MyPageView/MyPageViewController.swift
+++ b/LeafLog/LeafLog/View/MyPageView/MyPageViewController.swift
@@ -157,6 +157,22 @@ final class MyPageViewController: BaseViewController, View {
             })
             .disposed(by: disposeBag)
         
+        // 알림 권한 허용 필요
+        reactor.pulse(\.$notificationAuthorizationRequired)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] isRequired in
+                if isRequired {
+                    self?.steps.accept(
+                        AppStep.notificationAuthorizationRequired(
+                            onSettingsSelected: { [weak self] in
+                                self?.steps.accept(AppStep.applicatoinSettingRequired)
+                            }
+                        )
+                    )
+                }
+            })
+            .disposed(by: disposeBag)
+        
         // 에러 메세지
         reactor.pulse(\.$errorMessage)
             .compactMap { $0 }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #170

## 🛠 작업 내용 (What I did)
- 같은 기기에서 계정 전환 시 이전 계정의 푸시 토큰이 활성 상태로 남지 않도록 FCM 토큰 동기화 흐름을 수정했습니다.
- 알림 권한이 미허용된 상태에서 마이페이지 푸시 알림을 켤 때 시스템 설정 이동 안내가 뜨도록 보완했습니다.
- 홈/캘린더 알림센터 아이콘이 미확인 알림 존재 여부에 따라 `bell` 또는 `bellOn`으로 표시되도록 구현했습니다.
- 알림센터 진입 시 현재 사용자의 미확인 알림(`read_at == null`)만 읽음 처리하도록 연결했습니다.

## 💻 구현 상세 (Implementation Details)
- `NotificationDBManager.hasUnreadNotifications()`를 추가해 `user_id == 현재 사용자`, `sent_at != null`, `read_at == null` 조건의 알림 존재 여부만 조회합니다.
- `HomeReactor`와 `CalendarReactor`에서 화면 진입 시 미확인 알림 상태를 DB에서 조회하고, FCM 수신 이벤트가 오면 즉시 `bellOn` 상태로 갱신합니다.
- 알림센터에서 목록 조회 후 `markAllAsRead()`를 호출하고, 읽음 상태 변경 이벤트를 발행해 홈/캘린더 아이콘이 최신 상태를 다시 조회하도록 했습니다.
- `TitleHeaderView`에 오른쪽 버튼 이미지를 교체하는 메서드를 추가해 기존 헤더 구조를 유지했습니다.

## 📸 스크린샷 (Screenshots)
|기능 실행 전|기능 실행 후|
|:---:|:---:|
|미확인 알림 상태 표시 없음|미확인 알림이 있으면 홈/캘린더 알림센터 아이콘이 `bellOn`으로 표시|

## 🧐 리뷰 포인트 (Review Points)
- 알림센터 진입 시 목록 조회 후 미확인 알림만 읽음 처리하는 순서가 의도와 맞는지 확인 부탁드립니다.
- 푸시 수신 이벤트에서 즉시 `bellOn`으로 바꾸고, 읽음 상태 변경 이벤트에서 DB 재조회하는 흐름이 적절한지 봐주세요.
- 계정 전환 시 FCM 토큰 활성화 처리 변경이 현재 로그인 사용자 기준 알림 수신만 보장하는지 확인 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?