### PR TITLE
[FEAT] 커뮤니티 글 작성 UI 구현

### DIFF
--- a/LeafLog/LeafLog/Util/Custom/CustomComponent.swift
+++ b/LeafLog/LeafLog/Util/Custom/CustomComponent.swift
@@ -1,7 +1,0 @@
-//
-//  CustomComponent.swift
-//  LeafLog
-//
-//  Created by t2025-m0143 on 4/3/26.
-//
-

--- a/LeafLog/LeafLog/Util/Custom/DesignTextField.swift
+++ b/LeafLog/LeafLog/Util/Custom/DesignTextField.swift
@@ -1,0 +1,52 @@
+//
+//  DesignTextField.swift
+//  LeafLog
+//
+//  Created by 변예린 on 7/2/26.
+//
+
+import UIKit
+
+class DesignTextField: UITextField {
+    private let contentInsets = UIEdgeInsets(top: 14, left: 12, bottom: 14, right: 12)
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        backgroundColor = .clear
+        textColor = .label
+        
+        layer.cornerRadius = 12
+        clipsToBounds = true
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: 48)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func textRect(forBounds bounds: CGRect) -> CGRect {
+        bounds.inset(by: contentInsets)
+    }
+    
+    override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        bounds.inset(by: contentInsets)
+    }
+    
+    override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+        bounds.inset(by: contentInsets)
+    }
+    
+    func setPlaceholder(text: String) {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 14, weight: .regular),
+            .foregroundColor: UIColor.grayScale300
+        ]
+        
+        attributedPlaceholder = NSAttributedString(string: text, attributes: attributes)
+    }
+}

--- a/LeafLog/LeafLog/Util/Custom/DesignTextField.swift
+++ b/LeafLog/LeafLog/Util/Custom/DesignTextField.swift
@@ -15,6 +15,8 @@ class DesignTextField: UITextField {
         
         backgroundColor = .clear
         textColor = .label
+        layer.borderWidth = 1
+        layer.borderColor = UIColor.grayScale100.cgColor
         
         layer.cornerRadius = 12
         clipsToBounds = true

--- a/LeafLog/LeafLog/Util/Extension/Extension.swift
+++ b/LeafLog/LeafLog/Util/Extension/Extension.swift
@@ -1,6 +1,0 @@
-//
-//  Extension.swift
-//  LeafLog
-//
-//  Created by t2025-m0143 on 4/3/26.
-//

--- a/LeafLog/LeafLog/Util/Extension/UILabel+.swift
+++ b/LeafLog/LeafLog/Util/Extension/UILabel+.swift
@@ -28,4 +28,27 @@ extension UILabel {
         self.text = text
         apply(config, color: color, lines: lines)
     }
+    
+    // 줄 간격 설정
+    func setTextWithLineHeight(text: String, height: CGFloat) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.minimumLineHeight = height
+        paragraphStyle.maximumLineHeight = height
+        
+        var attributes: [NSAttributedString.Key: Any] = [
+            .paragraphStyle: paragraphStyle
+        ]
+        
+        if let font = font {
+            attributes[.font] = font
+        }
+        if let textColor = textColor {
+            attributes[.foregroundColor] = textColor
+        }
+        
+        attributedText = NSAttributedString(
+            string: text,
+            attributes: attributes
+        )
+    }
 }

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -19,6 +19,8 @@ final class CommunityComposeView: UIView {
         $0.alwaysBounceVertical = true
     }
     
+    private let contentView = UIView()
+    
     //MARK: init
     init(mode: Mode) {
         super.init(frame: .zero)
@@ -38,7 +40,24 @@ final class CommunityComposeView: UIView {
     }
     
     private func setLayout() {
+        addSubview(titleView)
+        addSubview(scrollView)
+        scrollView.addSubview(contentView)
         
+        titleView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        scrollView.snp.makeConstraints {
+            $0.top.equalTo(titleView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalTo(scrollView.contentLayoutGuide)
+            $0.width.equalTo(scrollView.snp.width)
+        }
     }
  
 }

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -29,6 +29,8 @@ final class CommunityComposeView: UIView {
     let categoryPlanetButton = UIButton(config: .lSize, title: "초록별 여행").then {
         $0.layer.cornerRadius = 8
     }
+    
+    
     let saveButton = BottomSaveButton(title: "")
     
     //MARK: init

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -1,0 +1,53 @@
+//
+//  CommunityComposeView.swift
+//  LeafLog
+//
+//  Created by 변예린 on 7/1/26.
+//
+
+import UIKit
+import Kingfisher
+import SnapKit
+import Then
+
+final class CommunityComposeView: UIView {
+    // MARK: - UI Components
+    let titleView = TitleHeaderView(text: "", hasBackButton: true, rightButtonImage: "helpCircle")
+    
+    private let scrollView = UIScrollView().then {
+        $0.showsVerticalScrollIndicator = false
+        $0.alwaysBounceVertical = true
+    }
+    
+    //MARK: init
+    init(mode: Mode) {
+        super.init(frame: .zero)
+        
+        switch mode {
+        case .create:
+            titleView.titleLabel.text = "게시글 작성"
+        case .edit:
+            titleView.titleLabel.text = "게시글 수정"
+        }
+        
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setLayout() {
+        
+    }
+ 
+}
+
+
+//MARK: Types
+extension CommunityComposeView {
+    enum Mode {
+        case create
+        case edit
+    }
+}

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -30,6 +30,32 @@ final class CommunityComposeView: UIView {
         $0.layer.cornerRadius = 8
     }
     
+    let titleTextField = DesignTextField().then {
+        $0.placeholder = "제목을 입력해주세요."
+    }
+    
+    let bodyTextView = UITextView().then {
+        $0.font = .systemFont(ofSize: 14, weight: .regular)
+        $0.textColor = .label
+        $0.backgroundColor = .grayScale50
+        $0.layer.borderColor = UIColor.grayScale100.cgColor
+        $0.layer.borderWidth = 1
+        
+        $0.layer.cornerRadius = 12
+        $0.clipsToBounds = true
+
+        $0.isScrollEnabled = true
+        $0.showsVerticalScrollIndicator = false
+        $0.textContainerInset = UIEdgeInsets(
+            top: 12,
+            left: 12,
+            bottom: 12,
+            right: 12
+        )
+        $0.textContainer.lineFragmentPadding = 0
+    }
+    
+    private let bodyPlaceholderLabel = UILabel(text: "게시글 내용을 입력해주세요.", config: .body14, color: .grayScale300)
     
     let saveButton = BottomSaveButton(title: "")
     
@@ -63,7 +89,10 @@ final class CommunityComposeView: UIView {
         addSubview(titleView)
         addSubview(scrollView)
         addSubview(saveButton)
+        
         scrollView.addSubview(contentView)
+        
+        bodyTextView.addSubview(bodyPlaceholderLabel)
         
         titleView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
@@ -83,6 +112,14 @@ final class CommunityComposeView: UIView {
         contentView.snp.makeConstraints {
             $0.edges.equalTo(scrollView.contentLayoutGuide)
             $0.width.equalTo(scrollView.snp.width)
+        }
+        
+        bodyTextView.snp.makeConstraints {
+            $0.height.equalTo(140)
+        }
+        
+        bodyPlaceholderLabel.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview().inset(12)
         }
     }
  

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -20,7 +20,6 @@ final class CommunityComposeView: UIView {
     }
     private let contentView = UIView()
     
-    private lazy var categoryTitleLabel = makeAttributedTitle(text: "카테고리*")
     let categoryDailyButton = UIButton(config: .lSize, title: "식물 일상").then {
         $0.layer.cornerRadius = 8
     }
@@ -31,14 +30,10 @@ final class CommunityComposeView: UIView {
         $0.layer.cornerRadius = 8
     }
     
-    private lazy var titleTitleLabel = makeAttributedTitle(text: "제목*")
     let titleTextField = DesignTextField().then {
         $0.placeholder = "제목을 입력해주세요."
     }
 
-    private lazy var pictureTitleLabel = makeAttributedTitle(text: "사진 첨부 (선택)")
-    
-    private lazy var bodyTitleLabel = makeAttributedTitle(text: "내용*")
     let bodyTextView = UITextView().then {
         $0.font = .systemFont(ofSize: 14, weight: .regular)
         $0.textColor = .label
@@ -93,6 +88,7 @@ final class CommunityComposeView: UIView {
         
         let categoryStack = makeVerticalStackView(title: "카테고리*", style: .attributed, views: [buttonStack])
         let titleStack = makeVerticalStackView(title: "제목*", style: .attributed, views: [titleTextField])
+        //TODO: custom comp 만들기
         let pictureStack = makeVerticalStackView(title: "사진 첨부 (선택)", style: .plain, views: [])
         let bodyStack = makeVerticalStackView(title: "내용*", style: .attributed, views: [bodyTextView])
         

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -88,7 +88,32 @@ final class CommunityComposeView: UIView {
 
 //MARK: Components
 extension CommunityComposeView {
-    
+    private func makeAttributedTitle(text: String) -> UILabel {
+        let label = UILabel(config: .title14)
+        let attributedString = NSMutableAttributedString(string: text)
+        
+        if let starRange = text.range(of: "*") {
+            let nsRange = NSRange(starRange, in: text)
+            
+            // 별 색상 설정
+            attributedString.addAttribute(
+                .foregroundColor,
+                value: UIColor.subRed,
+                range: nsRange
+            )
+            
+            // 폰트 설정
+            attributedString.addAttribute(
+                .font,
+                value: label.font as Any,
+                range: NSRange(location: 0, length: attributedString.length)
+            )
+        }
+        
+        label.attributedText = attributedString
+        
+        return label
+    }
 }
 
 //MARK: Types

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -20,6 +20,7 @@ final class CommunityComposeView: UIView {
     }
     private let contentView = UIView()
     
+    private lazy var categoryTitleLabel = makeAttributedTitle(text: "카테고리*")
     let categoryDailyButton = UIButton(config: .lSize, title: "식물 일상").then {
         $0.layer.cornerRadius = 8
     }
@@ -30,10 +31,14 @@ final class CommunityComposeView: UIView {
         $0.layer.cornerRadius = 8
     }
     
+    private lazy var titleTitleLabel = makeAttributedTitle(text: "제목*")
     let titleTextField = DesignTextField().then {
         $0.placeholder = "제목을 입력해주세요."
     }
+
+    private lazy var pictureTitleLabel = makeAttributedTitle(text: "사진 첨부 (선택)")
     
+    private lazy var bodyTitleLabel = makeAttributedTitle(text: "내용*")
     let bodyTextView = UITextView().then {
         $0.font = .systemFont(ofSize: 14, weight: .regular)
         $0.textColor = .label
@@ -83,16 +88,23 @@ final class CommunityComposeView: UIView {
         let buttonStack = UIStackView(arrangedSubviews: [categoryDailyButton, categoryQuestionButton, categoryPlanetButton]).then {
             $0.axis = .horizontal
             $0.spacing = 8
-            $0.alignment = .center
+            $0.alignment = .fill
+        }
+        
+        let categoryStack = makeVerticalStackView(title: "카테고리*", style: .attributed, views: [buttonStack])
+        let titleStack = makeVerticalStackView(title: "제목*", style: .attributed, views: [titleTextField])
+        let pictureStack = makeVerticalStackView(title: "사진 첨부 (선택)", style: .plain, views: [])
+        let bodyStack = makeVerticalStackView(title: "내용*", style: .attributed, views: [bodyTextView])
+        
+        let stackView = UIStackView(arrangedSubviews: [categoryStack, titleStack, pictureStack, bodyStack]).then {
+            $0.axis = .vertical
+            $0.spacing = 32
+            $0.alignment = .leading
         }
         
         addSubview(titleView)
         addSubview(scrollView)
         addSubview(saveButton)
-        
-        scrollView.addSubview(contentView)
-        
-        bodyTextView.addSubview(bodyPlaceholderLabel)
         
         titleView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
@@ -102,17 +114,45 @@ final class CommunityComposeView: UIView {
         scrollView.snp.makeConstraints {
             $0.top.equalTo(titleView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
+            $0.bottom.greaterThanOrEqualTo(saveButton.snp.top).inset(24)
         }
         
         saveButton.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(24)
             $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(24)
+            $0.height.equalTo(48)
         }
+        
+        scrollView.addSubview(contentView)
+        contentView.addSubview(stackView)
         
         contentView.snp.makeConstraints {
             $0.edges.equalTo(scrollView.contentLayoutGuide)
             $0.width.equalTo(scrollView.snp.width)
         }
+        
+        stackView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.verticalEdges.equalToSuperview().inset(32)
+        }
+        
+        categoryStack.snp.makeConstraints {
+            $0.width.equalToSuperview()
+        }
+        
+        buttonStack.snp.makeConstraints {
+            $0.height.equalTo(36)
+        }
+        
+        titleStack.snp.makeConstraints {
+            $0.width.equalToSuperview()
+        }
+        
+        bodyStack.snp.makeConstraints {
+            $0.width.equalToSuperview()
+        }
+        
+        bodyTextView.addSubview(bodyPlaceholderLabel)
         
         bodyTextView.snp.makeConstraints {
             $0.height.equalTo(140)

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -21,6 +21,8 @@ final class CommunityComposeView: UIView {
     
     private let contentView = UIView()
     
+    let saveButton = BottomSaveButton(title: "")
+    
     //MARK: init
     init(mode: Mode) {
         super.init(frame: .zero)
@@ -28,8 +30,10 @@ final class CommunityComposeView: UIView {
         switch mode {
         case .create:
             titleView.titleLabel.text = "게시글 작성"
+            saveButton.setTitle("등록하기")
         case .edit:
             titleView.titleLabel.text = "게시글 수정"
+            saveButton.setTitle("수정하기")
         }
         
         setLayout()
@@ -42,6 +46,7 @@ final class CommunityComposeView: UIView {
     private func setLayout() {
         addSubview(titleView)
         addSubview(scrollView)
+        addSubview(saveButton)
         scrollView.addSubview(contentView)
         
         titleView.snp.makeConstraints {
@@ -52,6 +57,11 @@ final class CommunityComposeView: UIView {
         scrollView.snp.makeConstraints {
             $0.top.equalTo(titleView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
+        }
+        
+        saveButton.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(24)
+            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(24)
         }
         
         contentView.snp.makeConstraints {

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -110,7 +110,7 @@ final class CommunityComposeView: UIView {
         scrollView.snp.makeConstraints {
             $0.top.equalTo(titleView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.greaterThanOrEqualTo(saveButton.snp.top).inset(24)
+            $0.bottom.equalTo(saveButton.snp.top).inset(24)
         }
         
         saveButton.snp.makeConstraints {

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -18,9 +18,17 @@ final class CommunityComposeView: UIView {
         $0.showsVerticalScrollIndicator = false
         $0.alwaysBounceVertical = true
     }
-    
     private let contentView = UIView()
     
+    let categoryDailyButton = UIButton(config: .lSize, title: "식물 일상").then {
+        $0.layer.cornerRadius = 8
+    }
+    let categoryQuestionButton = UIButton(config: .lSize, title: "식물 고민").then {
+        $0.layer.cornerRadius = 8
+    }
+    let categoryPlanetButton = UIButton(config: .lSize, title: "초록별 여행").then {
+        $0.layer.cornerRadius = 8
+    }
     let saveButton = BottomSaveButton(title: "")
     
     //MARK: init
@@ -44,6 +52,12 @@ final class CommunityComposeView: UIView {
     }
     
     private func setLayout() {
+        let buttonStack = UIStackView(arrangedSubviews: [categoryDailyButton, categoryQuestionButton, categoryPlanetButton]).then {
+            $0.axis = .horizontal
+            $0.spacing = 8
+            $0.alignment = .center
+        }
+        
         addSubview(titleView)
         addSubview(scrollView)
         addSubview(saveButton)
@@ -72,6 +86,10 @@ final class CommunityComposeView: UIView {
  
 }
 
+//MARK: Components
+extension CommunityComposeView {
+    
+}
 
 //MARK: Types
 extension CommunityComposeView {

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeView.swift
@@ -114,6 +114,25 @@ extension CommunityComposeView {
         
         return label
     }
+    
+    private func makeVerticalStackView(title: String, style: TitleStyle, views: [UIView]) -> UIStackView {
+        let titleLabel = switch style {
+        case .plain:
+            UILabel(text: title, config: .title14)
+        case .attributed:
+            makeAttributedTitle(text: title)
+        }
+        
+        let stackView = UIStackView(arrangedSubviews: [titleLabel] + views).then {
+            $0.axis = .vertical
+            $0.spacing = 16
+            
+            titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+            titleLabel.setContentHuggingPriority(.required, for: .vertical)
+        }
+        
+        return stackView
+    }
 }
 
 //MARK: Types
@@ -121,5 +140,10 @@ extension CommunityComposeView {
     enum Mode {
         case create
         case edit
+    }
+    
+    enum TitleStyle {
+        case plain
+        case attributed
     }
 }

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeViewController.swift
@@ -24,6 +24,8 @@ final class CommunityComposeViewController: BaseViewController, View {
         self.reactor = CameraClassificationReactor()
         tabBarController?.tabBar.isHidden = true
         navigationController?.navigationBar.isHidden = true
+        
+        
     }
     
     //MARK: Bind

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeViewController.swift
@@ -1,0 +1,52 @@
+//
+//  CommunityComposeViewController.swift
+//  LeafLog
+//
+//  Created by 변예린 on 7/5/26.
+//
+
+import UIKit
+import Dependencies
+import ReactorKit
+import RxCocoa
+
+final class CommunityComposeViewController: BaseViewController, View {
+    //MARK: properties
+    let composeView = CommunityComposeView(mode: .create)
+    
+    //MARK: Lifecycle
+    override func loadView() {
+        view = composeView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.reactor = CameraClassificationReactor()
+        tabBarController?.tabBar.isHidden = true
+        navigationController?.navigationBar.isHidden = true
+    }
+    
+    //MARK: Bind
+    func bind(reactor: CameraClassificationReactor) {
+        bindAction(reactor: reactor)
+        bindState(reactor: reactor)
+    }
+    
+    private func bindAction(reactor: CameraClassificationReactor) {
+        // 뒤로가기
+        composeView.titleView.rx.backButtonTap
+            .subscribe(onNext: { [weak self] _ in
+                self?.steps.accept(AppStep.pageBack)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func bindState(reactor: CameraClassificationReactor) {
+        
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+  CommunityComposeViewController()
+}

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityComposeViewController.swift
@@ -22,7 +22,7 @@ final class CommunityComposeViewController: BaseViewController, View {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.reactor = CameraClassificationReactor()
-        tabBarController?.tabBar.isHidden = true
+        hidesBottomBarWhenPushed = true
         navigationController?.navigationBar.isHidden = true
         
         

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityInfoView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityInfoView.swift
@@ -27,7 +27,9 @@ final class CommunityInfoView: UIView {
         config: .label12,
         color: .grayScale700,
         lines: 1
-    )
+    ).then {
+        $0.setTextWithLineHeight(text: $0.text ?? "", height: 18)
+    }
     
     private let ruleBackgroundView = UIView().then {
         $0.backgroundColor = .white
@@ -50,7 +52,9 @@ final class CommunityInfoView: UIView {
         config: .label12,
         color: .grayScale600,
         lines: 0
-    )
+    ).then {
+        $0.setTextWithLineHeight(text: $0.text ?? "", height: 18)
+    }
     
     //MARK: init
     override init(frame: CGRect) {
@@ -124,6 +128,7 @@ extension CommunityInfoView {
         let title = UILabel(text: rule.title, config: .label12, lines: 1)
         let description = UILabel(text: rule.description, config: .body12, lines: 0).then {
             $0.lineBreakMode = .byWordWrapping
+            $0.setTextWithLineHeight(text: $0.text ?? "", height: 18)
         }
         
         let stackView = UIStackView(arrangedSubviews: [title, description]).then {

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityInfoView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityInfoView.swift
@@ -29,7 +29,7 @@ final class CommunityInfoView: UIView {
         lines: 1
     )
     
-    private let backgroundView = UIView().then {
+    private let ruleBackgroundView = UIView().then {
         $0.backgroundColor = .white
         $0.layer.cornerRadius = 12
         $0.clipsToBounds = true
@@ -51,8 +51,74 @@ final class CommunityInfoView: UIView {
         color: .grayScale600,
         lines: 0
     )
+    
+    //MARK: init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        backgroundColor = .grayScale50
+        layer.cornerRadius = 12
+        clipsToBounds = true
+        
+        setLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 }
 
+//MARK: layout
+extension CommunityInfoView {
+    private func setLayout()  {
+        let titleStack = UIStackView(arrangedSubviews: [titleLabel, subTitleLabel]).then {
+            $0.axis = .vertical
+            $0.alignment = .leading
+            $0.spacing = 0
+        }
+        
+        let ruleStack = UIStackView(arrangedSubviews: [firstRule, secondRule, thirdRule]).then {
+            $0.axis = .vertical
+            $0.alignment = .leading
+            $0.spacing = 8
+        }
+        
+        let noticeStack = UIStackView(arrangedSubviews: [noticeTitleLabel, noticeBodyLabel]).then {
+            $0.axis = .vertical
+            $0.alignment = .leading
+            $0.spacing = 0
+        }
+        
+        let stackView = UIStackView(arrangedSubviews: [titleStack, ruleBackgroundView, noticeStack]).then {
+            $0.axis = .vertical
+            $0.spacing = 8
+            $0.alignment = .leading
+        }
+        
+        ruleBackgroundView.addSubview(ruleStack)
+        
+        ruleStack.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(12)
+        }
+        
+        addSubview(closeButton)
+        addSubview(stackView)
+        
+        closeButton.snp.makeConstraints {
+            $0.width.height.equalTo(24)
+            $0.top.equalToSuperview().inset(12)
+            $0.trailing.equalToSuperview().inset(24)
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.top.equalTo(closeButton.snp.bottom).offset(8)
+            $0.horizontalEdges.bottom.equalToSuperview().inset(24)
+        }
+    }
+}
+
+//MARK: helper
 extension CommunityInfoView {
     private func makeRuleStack(of rule: Rule) -> UIStackView {
         let title = UILabel(text: rule.title, config: .label12, lines: 1)
@@ -70,6 +136,7 @@ extension CommunityInfoView {
     }
 }
 
+//MARK: Types
 extension CommunityInfoView {
     enum Rule {
         case first, second, third

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityInfoView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityInfoView.swift
@@ -1,0 +1,99 @@
+//
+//  CommunityInfoView.swift
+//  LeafLog
+//
+//  Created by 변예린 on 7/4/26.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class CommunityInfoView: UIView {
+    let closeButton = UIButton(configuration: .plain()).then {
+        $0.configuration?.baseForegroundColor = .grayScale600
+        $0.setImage(.x, for: .normal)
+    }
+    
+    private let titleLabel = UILabel(
+        text: "🌿 잎로그 커뮤니티 이용 가이드",
+        config: .label14,
+        color: .black,
+        lines: 1
+    )
+    
+    private let subTitleLabel = UILabel(
+        text: "모두가 즐거운 식물 생활을 위해 아래 수칙을 지켜주세요!",
+        config: .label12,
+        color: .grayScale700,
+        lines: 1
+    )
+    
+    private let backgroundView = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 12
+        $0.clipsToBounds = true
+    }
+    
+    private lazy var firstRule = makeRuleStack(of: .first)
+    private lazy var secondRule = makeRuleStack(of: .second)
+    private lazy var thirdRule = makeRuleStack(of: .third)
+    
+    private let noticeTitleLabel = UILabel(
+        text: "💡 신고 안내",
+        config: .label12,
+        lines: 1
+    )
+    
+    private let noticeBodyLabel = UILabel(
+        text: "가이드라인에 어긋나는 게시글을 발견하시면 [신고] 버튼을 눌러주세요. 운영진이 신속히 확인하겠습니다.",
+        config: .label12,
+        color: .grayScale600,
+        lines: 0
+    )
+}
+
+extension CommunityInfoView {
+    private func makeRuleStack(of rule: Rule) -> UIStackView {
+        let title = UILabel(text: rule.title, config: .label12, lines: 1)
+        let description = UILabel(text: rule.description, config: .body12, lines: 0).then {
+            $0.lineBreakMode = .byWordWrapping
+        }
+        
+        let stackView = UIStackView(arrangedSubviews: [title, description]).then {
+            $0.axis = .vertical
+            $0.spacing = 0
+            $0.alignment = .leading
+        }
+        
+        return stackView
+    }
+}
+
+extension CommunityInfoView {
+    enum Rule {
+        case first, second, third
+        
+        var title: String {
+            switch self {
+            case .first:
+                "1. 서로를 존중해주세요"
+            case .second:
+                "2. 식물과 관련된 정보만 공유해요"
+            case .third:
+                "3. 소중한 정보를 보호하세요"
+            }
+        }
+        
+        var description: String {
+            switch self {
+            case .first:
+                "비방, 욕설, 차별적 발언은 예고없이 삭제되며 이용이 제한될 수 있습니다. 식물 초보의 질문에도 따뜻하게 답해주세요."
+            case .second:
+                "주제와 무관한 정치, 종교, 홍보성 게시글은 지양해 주세요. 깨끗한 피드는 우리 모두가 만듭니다."
+            case .third:
+                "타인의 사진을 무단 도용하거나, 개인정보(연락처, 주소 등)가 노출되지 않도록 주의해 주세요."
+            }
+        }
+    }
+}

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityInfoViewController.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityInfoViewController.swift
@@ -1,0 +1,32 @@
+//
+//  CommunityInfoViewController.swift
+//  LeafLog
+//
+//  Created by 변예린 on 7/5/26.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class CommunityInfoViewController: BaseViewController {
+    private let infoView = CommunityInfoView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .clear
+        
+        view.addSubview(infoView)
+        
+        infoView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+  CommunityInfoViewController()
+}

--- a/LeafLog/LeafLog/View/CommunityComposeView/CommunityPictureComposeView.swift
+++ b/LeafLog/LeafLog/View/CommunityComposeView/CommunityPictureComposeView.swift
@@ -1,0 +1,7 @@
+//
+//  CommunityPictureComposeView.swift
+//  LeafLog
+//
+//  Created by 변예린 on 7/5/26.
+//
+


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #173

## 🛠 작업 내용 (What I did)
- 커뮤니티 게시글 작성 화면 UI를 구현했습니다.
- 카테고리 선택, 제목 입력, 본문 입력, 등록 버튼 영역을 배치했습니다.
- 커뮤니티 이용 가이드 안내 화면 UI를 추가했습니다.
- 제목 입력용 `DesignTextField` 컴포넌트와 UILabel 행간 설정 확장을 추가했습니다.

## 💻 구현 상세 (Implementation Details)
- `CommunityComposeView`에서 `UIScrollView` 기반 입력 화면을 구성하고, 필수 입력 항목은 별표 색상으로 구분했습니다.
- `CommunityComposeViewController`에서 뒤로가기 액션을 `AppStep.pageBack`으로 연결했습니다.
- `CommunityInfoView`/`CommunityInfoViewController`를 추가해 커뮤니티 이용 가이드 안내 UI를 구성했습니다.
- 사진 첨부 영역은 섹션 타이틀만 배치되어 있으며, custom component 생성 및 실제 배치는 아직 완료되지 않았습니다.

## 📸 스크린샷 (Screenshots)
<img width="300" height="620" alt="image" src="https://github.com/user-attachments/assets/2bef1b0b-f6e6-4ef3-9988-7269d2f0d828" />
<img width="300" height="620" alt="image" src="https://github.com/user-attachments/assets/68392ed2-5dc1-4018-8854-16ba326e2d40" />


## 🧐 리뷰 포인트 (Review Points)
- 사진 첨부 custom component 생성 및 배치가 미완성 상태입니다. 폴더 정리 후 구현 예정입니다.
- 작성 화면의 카테고리/제목/내용 영역 간격과 입력 UX가 디자인 의도에 맞는지 확인 부탁드립니다.
- 커뮤니티 이용 가이드 안내 문구와 레이아웃이 적절한지 확인 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?
