### PR TITLE
[FEAT] 커뮤니티 게시글 작성 및 수정 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ LeafLog/LeafLog/Configuration/GoogleService-Info.plist
 service-account.json
 LeafLog/supabase/
 LeafLog/.vscode/
+AGENTS.md
+domain.md
+docs

--- a/LeafLog/LeafLog/App/Flows/AppStep.swift
+++ b/LeafLog/LeafLog/App/Flows/AppStep.swift
@@ -59,6 +59,8 @@ enum AppStep: Step {
     )
     
     //CommunityTab
+    case communityComposeCreate
+    case communityComposeEdit(CommunityPost)
     case composeNotice
     
     // MyInfoTab

--- a/LeafLog/LeafLog/App/Flows/AppStep.swift
+++ b/LeafLog/LeafLog/App/Flows/AppStep.swift
@@ -29,6 +29,7 @@ enum AppStep: Step {
     case endPlantRegisterEdit
     case endPlantDelete
     case calendarTab
+    case communityTab
     case myInfoTab
     case profileEdit // 프로필 수정 화면
     case record(plantID: UUID, date: Date = Date())

--- a/LeafLog/LeafLog/App/Flows/AppStep.swift
+++ b/LeafLog/LeafLog/App/Flows/AppStep.swift
@@ -58,6 +58,9 @@ enum AppStep: Step {
         onConfirm: () -> Void
     )
     
+    //CommunityTab
+    case composeNotice
+    
     // MyInfoTab
     case profileImageSourceSheet
     case notificationAuthorizationRequired(onSettingsSelected: () -> Void)

--- a/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
@@ -31,7 +31,7 @@ final class CommunityTabFlow: Flow {
         case .communityTab:
             //TODO: Community Main VC로 변경 필요
             let viewController = CommunityComposeViewController()
-//            viewController.reactor = CommunityComposeReactor()
+            viewController.reactor = CommunityComposeReactor()
             navigationController.setViewControllers([viewController], animated: false)
 
             return .one(

--- a/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
@@ -30,9 +30,8 @@ final class CommunityTabFlow: Flow {
         switch step {
         case .communityTab:
             //TODO: Community Main VC로 변경 필요
-            let mode = CommunityComposeMode.create
-            let viewController = CommunityComposeViewController(mode: mode)
-            viewController.reactor = CommunityComposeReactor(mode: mode)
+            let viewController = CommunityTempViewController()
+            viewController.reactor = CommunityTempReactor()
             navigationController.setViewControllers([viewController], animated: false)
 
             return .one(
@@ -41,6 +40,12 @@ final class CommunityTabFlow: Flow {
                     withNextStepper: viewController
                 )
             )
+
+        case .communityComposeCreate:
+            return navigateToCompose(mode: .create)
+
+        case .communityComposeEdit(let post):
+            return navigateToCompose(mode: .edit(post))
             
         case .composeNotice:
             let notice = CommunityInfoViewController()
@@ -48,9 +53,30 @@ final class CommunityTabFlow: Flow {
             navigationController.present(notice, animated: false)
         
             return .none
+
+        case .pageBack:
+            navigationController.popViewController(animated: true)
+            return .none
             
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
         }
+    }
+}
+
+private extension CommunityTabFlow {
+    func navigateToCompose(
+        mode: CommunityComposeMode
+    ) -> FlowContributors {
+        let viewController = CommunityComposeViewController(mode: mode)
+        viewController.reactor = CommunityComposeReactor(mode: mode)
+        navigationController.pushViewController(viewController, animated: true)
+
+        return .one(
+            flowContributor: .contribute(
+                withNextPresentable: viewController,
+                withNextStepper: viewController
+            )
+        )
     }
 }

--- a/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
@@ -31,7 +31,6 @@ final class CommunityTabFlow: Flow {
         case .communityTab:
             //TODO: Community Main VC로 변경 필요
             let viewController = CommunityComposeViewController()
-            viewController.reactor = CommunityComposeReactor()
             navigationController.setViewControllers([viewController], animated: false)
 
             return .one(

--- a/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
@@ -30,7 +30,9 @@ final class CommunityTabFlow: Flow {
         switch step {
         case .communityTab:
             //TODO: Community Main VC로 변경 필요
-            let viewController = CommunityComposeViewController()
+            let mode = CommunityComposeMode.create
+            let viewController = CommunityComposeViewController(mode: mode)
+            viewController.reactor = CommunityComposeReactor(mode: mode)
             navigationController.setViewControllers([viewController], animated: false)
 
             return .one(

--- a/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
@@ -1,0 +1,48 @@
+//
+//  CommunityTabFlow.swift
+//  LeafLog
+//
+//  Created by 변예린 on 7/9/26.
+//
+
+import UIKit
+import RxFlow
+import Dependencies
+import RxRelay
+import ReactorKit
+
+/*
+ RxFlow 사용 예시입니다. - 추후 해당 탭 구현 시 변경 예정입니다.
+ switch문으로 step에 따라 실행할 동작을 정의해주시면 됩니다.
+ PlantTabFlow에서만 step에 따른 동작을 정의해놓았으므로 다른 탭(Calendar, MyInfo)에서는 push버튼을 눌러도 아무 동작이 실행되지 않습니다.
+ */
+
+final class CommunityTabFlow: Flow {
+    private let navigationController = UINavigationController()
+    
+    var root: any RxFlow.Presentable { navigationController }
+    
+    func navigate(to step: any RxFlow.Step) -> RxFlow.FlowContributors {
+        guard let step = step as? AppStep else {
+            return .none
+        }
+        
+        switch step {
+        case .communityTab:
+            //TODO: Community Main VC로 변경 필요
+            let viewController = CommunityComposeViewController()
+//            viewController.reactor = CommunityComposeReactor()
+            navigationController.setViewControllers([viewController], animated: false)
+
+            return .one(
+                flowContributor: .contribute(
+                    withNextPresentable: viewController,
+                    withNextStepper: viewController
+                )
+            )
+        
+        default:
+            return .one(flowContributor: .forwardToParentFlow(withStep: step))
+        }
+    }
+}

--- a/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/CommunityTabFlow.swift
@@ -40,7 +40,14 @@ final class CommunityTabFlow: Flow {
                     withNextStepper: viewController
                 )
             )
+            
+        case .composeNotice:
+            let notice = CommunityInfoViewController()
+            notice.modalPresentationStyle = .overCurrentContext
+            navigationController.present(notice, animated: false)
         
+            return .none
+            
         default:
             return .one(flowContributor: .forwardToParentFlow(withStep: step))
         }

--- a/LeafLog/LeafLog/App/Flows/MainFlow.swift
+++ b/LeafLog/LeafLog/App/Flows/MainFlow.swift
@@ -144,11 +144,12 @@ extension MainFlow {
         
         let plantTabFlow = PlantTabFlow()
         let calendarTabFlow = CalendarTabFlow()
+        let communityTabFlow = CommunityTabFlow()
         let myInfoTabFlow = MyInfoTabFlow()
         
         // Flow를 준비 - 클로저는 Flow가 배치될 준비가 되었을 때(Flow의 첫 번째 화면이 선택되었을 때) 실행될 동작
         // Flow.use는 내부에서 Single 이벤트를 drive로 구독을 소비하므로 소비 완료 후 자동으로 구독이 해제되어 메모리 누수가 발생하지 않음
-        Flows.use(plantTabFlow, calendarTabFlow, myInfoTabFlow, when: .created) { plant, calendar, my in
+        Flows.use(plantTabFlow, calendarTabFlow, communityTabFlow, myInfoTabFlow, when: .created) { plant, calendar, community, my in
             
             plant.tabBarItem = UITabBarItem(
                 title: "홈",
@@ -162,19 +163,25 @@ extension MainFlow {
                 selectedImage: .calendarFill,
             )
             
+            community.tabBarItem = UITabBarItem(
+                title: "커뮤니티",
+                image: .chat,
+                selectedImage: .chatFill)
+            
             my.tabBarItem = UITabBarItem(
                 title: "마이",
                 image: .userEmpty,
                 selectedImage: .userFill
             )
             
-            self.tabBarController.setViewControllers([plant, calendar, my], animated: true)
+            self.tabBarController.setViewControllers([plant, calendar, community, my], animated: true)
             self.tabBarController.tabBar.tintColor = .primary700
         }
         
         return .multiple(flowContributors: [
             .contribute(withNextPresentable: plantTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.plantTab)),
             .contribute(withNextPresentable: calendarTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.calendarTab)),
+            .contribute(withNextPresentable: communityTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.communityTab)),
             .contribute(withNextPresentable: myInfoTabFlow, withNextStepper: OneStepper(withSingleStep: AppStep.myInfoTab))
         ])
     }

--- a/LeafLog/LeafLog/Assets.xcassets/icon/chatFill.imageset/Contents.json
+++ b/LeafLog/LeafLog/Assets.xcassets/icon/chatFill.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "Property 1=pressed.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/LeafLog/LeafLog/Assets.xcassets/icon/chatFill.imageset/Property 1=pressed.svg
+++ b/LeafLog/LeafLog/Assets.xcassets/icon/chatFill.imageset/Property 1=pressed.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 15C21 15.5304 20.7893 16.0391 20.4142 16.4142C20.0391 16.7893 19.5304 17 19 17H7L3 21V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H19C19.5304 3 20.0391 3.21071 20.4142 3.58579C20.7893 3.96086 21 4.46957 21 5V15Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/LeafLog/LeafLog/Model/CommunityPost.swift
+++ b/LeafLog/LeafLog/Model/CommunityPost.swift
@@ -1,0 +1,52 @@
+//
+//  CommunityPost.swift
+//  LeafLog
+//
+//  Created by OpenAI Codex on 7/29/26.
+//
+
+import Foundation
+
+struct CommunityPost: Hashable {
+    let id: UUID
+    let authorID: UUID
+    let category: PostCategory
+    let title: String
+    let content: String
+    let legacyImagePath: String?
+    let createdAt: Date
+    let updatedAt: Date
+    let deletedAt: Date?
+    let likeCount: Int
+    let images: [CommunityPostImage]
+
+}
+
+struct CommunityPostImage: Codable, Hashable {
+    let id: UUID
+    let postID: UUID
+    let imagePath: String
+    let sortOrder: Int
+    let createdAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case postID = "post_id"
+        case imagePath = "image_path"
+        case sortOrder = "sort_order"
+        case createdAt = "created_at"
+    }
+}
+
+struct CommunityPostImageInput: Hashable {
+    let id: UUID
+    let imagePath: String
+}
+
+struct CommunityPostSaveInput {
+    let id: UUID
+    let category: PostCategory
+    let title: String
+    let content: String
+    let images: [CommunityPostImageInput]
+}

--- a/LeafLog/LeafLog/Model/CommunityPost.swift
+++ b/LeafLog/LeafLog/Model/CommunityPost.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CommunityPost: Hashable {
+struct CommunityPost: Codable, Hashable {
     let id: UUID
     let authorID: UUID
     let category: PostCategory
@@ -20,6 +20,19 @@ struct CommunityPost: Hashable {
     let likeCount: Int
     let images: [CommunityPostImage]
 
+    enum CodingKeys: String, CodingKey {
+        case id
+        case authorID = "author_id"
+        case category
+        case title
+        case content
+        case legacyImagePath = "image_path"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case deletedAt = "deleted_at"
+        case likeCount = "like_count"
+        case images
+    }
 }
 
 struct CommunityPostImage: Codable, Hashable {

--- a/LeafLog/LeafLog/Model/CommunityPostValidation.swift
+++ b/LeafLog/LeafLog/Model/CommunityPostValidation.swift
@@ -1,0 +1,57 @@
+//
+//  CommunityPostValidation.swift
+//  LeafLog
+//
+//  Created by OpenAI Codex on 8/3/26.
+//
+
+import Foundation
+
+enum CommunityPostValidation {
+    static let titleMaxCount = 50
+    static let contentMaxCount = 1_000
+
+    enum ValidationResult {
+        case valid(title: String, content: String)
+        case invalid(message: String)
+
+        var isValid: Bool {
+            if case .valid = self { return true }
+            return false
+        }
+    }
+
+    static func validate(
+        title: String,
+        content: String
+    ) -> ValidationResult {
+        let normalizedTitle = title.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        let isContentEmpty = content
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+
+        guard !normalizedTitle.isEmpty else {
+            return .invalid(message: "제목을 입력해주세요.")
+        }
+
+        guard normalizedTitle.count <= titleMaxCount else {
+            return .invalid(
+                message: "제목은 최대 50자까지 입력할 수 있어요."
+            )
+        }
+
+        guard !isContentEmpty else {
+            return .invalid(message: "내용을 입력해주세요.")
+        }
+
+        guard content.count <= contentMaxCount else {
+            return .invalid(
+                message: "내용은 최대 1,000자까지 입력할 수 있어요."
+            )
+        }
+
+        return .valid(title: normalizedTitle, content: content)
+    }
+}

--- a/LeafLog/LeafLog/Model/PostCategory.swift
+++ b/LeafLog/LeafLog/Model/PostCategory.swift
@@ -5,7 +5,9 @@
 //  Created by 변예린 on 7/9/26.
 //
 
-enum PostCategory: Int {
+import Foundation
+
+enum PostCategory: Int, Codable {
     case plantLife = 0
     case plantHelp
     case greenTrip
@@ -37,5 +39,26 @@ enum PostCategory: Int {
         case .plantHelp: "식물 고민"
         case .greenTrip: "초록별 여행"
         }
+    }
+}
+
+extension PostCategory {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let databaseValue = try container.decode(String.self)
+
+        guard let category = PostCategory(databaseValue: databaseValue) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "지원하지 않는 게시글 카테고리입니다."
+            )
+        }
+
+        self = category
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(databaseValue)
     }
 }

--- a/LeafLog/LeafLog/Model/PostCategory.swift
+++ b/LeafLog/LeafLog/Model/PostCategory.swift
@@ -1,0 +1,20 @@
+//
+//  PostCategory.swift
+//  LeafLog
+//
+//  Created by 변예린 on 7/9/26.
+//
+
+enum PostCategory: Int {
+    case plantLife = 0
+    case plantHelp
+    case greenTrip
+    
+    var title: String {
+        switch self {
+        case .plantLife: "식물 일상"
+        case .plantHelp: "식물 고민"
+        case .greenTrip: "초록별 여행"
+        }
+    }
+}

--- a/LeafLog/LeafLog/Model/PostCategory.swift
+++ b/LeafLog/LeafLog/Model/PostCategory.swift
@@ -9,6 +9,27 @@ enum PostCategory: Int {
     case plantLife = 0
     case plantHelp
     case greenTrip
+
+    var databaseValue: String {
+        switch self {
+        case .plantLife: "plant_life"
+        case .plantHelp: "plant_help"
+        case .greenTrip: "green_trip"
+        }
+    }
+
+    init?(databaseValue: String) {
+        switch databaseValue {
+        case "plant_life":
+            self = .plantLife
+        case "plant_help":
+            self = .plantHelp
+        case "green_trip":
+            self = .greenTrip
+        default:
+            return nil
+        }
+    }
     
     var title: String {
         switch self {

--- a/LeafLog/LeafLog/Network/Supabase/CommunityPostDBManager.swift
+++ b/LeafLog/LeafLog/Network/Supabase/CommunityPostDBManager.swift
@@ -29,12 +29,10 @@ final class CommunityPostDBManager {
         let parameters = try makeParameters(input: input)
 
         do {
-            let response: CommunityPostRPCResponse = try await supabaseManager.client
+            return try await supabaseManager.client
                 .rpc(function, params: parameters)
                 .execute()
                 .value
-
-            return try makeCommunityPost(response: response)
         } catch let error as AuthError {
             throw error
         } catch {
@@ -68,10 +66,6 @@ final class CommunityPostDBManager {
             throw AuthError.communityFailed("내용은 최대 1,000자까지 입력할 수 있어요.")
         }
 
-        guard input.images.count <= 3 else {
-            throw AuthError.communityFailed("사진은 최대 3장까지 첨부할 수 있어요.")
-        }
-
         let uniqueImageIDs = Set(input.images.map(\.id))
         let uniqueImagePaths = Set(input.images.map(\.imagePath))
         guard
@@ -99,63 +93,6 @@ final class CommunityPostDBManager {
         )
     }
 
-    private func makeCommunityPost(
-        response: CommunityPostRPCResponse
-    ) throws -> CommunityPost {
-        guard let category = PostCategory(
-            databaseValue: response.post.category
-        ) else {
-            throw AuthError.communityFailed(
-                "게시글 카테고리 정보를 확인해주세요."
-            )
-        }
-
-        return CommunityPost(
-            id: response.post.id,
-            authorID: response.post.authorID,
-            category: category,
-            title: response.post.title,
-            content: response.post.content,
-            legacyImagePath: response.post.legacyImagePath,
-            createdAt: response.post.createdAt,
-            updatedAt: response.post.updatedAt,
-            deletedAt: response.post.deletedAt,
-            likeCount: response.post.likeCount,
-            images: response.images
-        )
-    }
-
-}
-
-nonisolated private struct CommunityPostRPCResponse: Decodable, Sendable {
-    let post: StoredCommunityPost
-    let images: [CommunityPostImage]
-}
-
-nonisolated private struct StoredCommunityPost: Decodable, Sendable {
-    let id: UUID
-    let authorID: UUID
-    let category: String
-    let title: String
-    let content: String
-    let legacyImagePath: String?
-    let createdAt: Date
-    let updatedAt: Date
-    let deletedAt: Date?
-    let likeCount: Int
-
-    enum CodingKeys: String, CodingKey {
-        case id
-        case authorID = "author_id"
-        case category
-        case title
-        case content
-        case legacyImagePath = "image_path"
-        case createdAt = "created_at"
-        case updatedAt = "updated_at"
-        case deletedAt = "deleted_at"
-        case likeCount = "like_count"
-    }
 }
 
 nonisolated private struct CommunityPostRPCParameters: Encodable, Sendable {

--- a/LeafLog/LeafLog/Network/Supabase/CommunityPostDBManager.swift
+++ b/LeafLog/LeafLog/Network/Supabase/CommunityPostDBManager.swift
@@ -77,25 +77,15 @@ final class CommunityPostDBManager {
     private func makeParameters(
         input: CommunityPostSaveInput
     ) throws -> CommunityPostRPCParameters {
-        let title = input.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        let isContentEmpty = input.content
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .isEmpty
-
-        guard !title.isEmpty else {
-            throw AuthError.communityFailed("제목을 입력해주세요.")
-        }
-
-        guard title.count <= 50 else {
-            throw AuthError.communityFailed("제목은 최대 50자까지 입력할 수 있어요.")
-        }
-
-        guard !isContentEmpty else {
-            throw AuthError.communityFailed("내용을 입력해주세요.")
-        }
-
-        guard input.content.count <= 1_000 else {
-            throw AuthError.communityFailed("내용은 최대 1,000자까지 입력할 수 있어요.")
+        let validatedText: (title: String, content: String)
+        switch CommunityPostValidation.validate(
+            title: input.title,
+            content: input.content
+        ) {
+        case let .valid(title, content):
+            validatedText = (title, content)
+        case let .invalid(message):
+            throw AuthError.communityFailed(message)
         }
 
         let uniqueImageIDs = Set(input.images.map(\.id))
@@ -119,8 +109,8 @@ final class CommunityPostDBManager {
         return CommunityPostRPCParameters(
             postID: input.id,
             category: input.category.databaseValue,
-            title: title,
-            content: input.content,
+            title: validatedText.title,
+            content: validatedText.content,
             images: imagePayloads
         )
     }

--- a/LeafLog/LeafLog/Network/Supabase/CommunityPostDBManager.swift
+++ b/LeafLog/LeafLog/Network/Supabase/CommunityPostDBManager.swift
@@ -22,6 +22,40 @@ final class CommunityPostDBManager {
         try await savePost(function: "update_community_post", input: input)
     }
 
+    func fetchMyPosts(
+        limit: Int = 20,
+        offset: Int = 0
+    ) async throws -> [CommunityPost] {
+        guard limit > 0, offset >= 0 else {
+            throw AuthError.communityFailed("게시글 조회 범위를 확인해주세요.")
+        }
+
+        do {
+            let user = try await supabaseManager.client.auth.user()
+
+            return try await supabaseManager.client
+                .from("community_posts")
+                .select("*, images:community_post_images(*)")
+                .eq("author_id", value: user.id)
+                .is("deleted_at", value: nil)
+                .order("created_at", ascending: false)
+                .order(
+                    "sort_order",
+                    ascending: true,
+                    referencedTable: "images"
+                )
+                .range(from: offset, to: offset + limit - 1)
+                .execute()
+                .value
+        } catch let error as AuthError {
+            throw error
+        } catch {
+            throw AuthError.communityFailed(
+                "작성한 게시글을 불러오지 못했어요. 잠시 후 다시 시도해주세요."
+            )
+        }
+    }
+
     private func savePost(
         function: String,
         input: CommunityPostSaveInput

--- a/LeafLog/LeafLog/Network/Supabase/CommunityPostDBManager.swift
+++ b/LeafLog/LeafLog/Network/Supabase/CommunityPostDBManager.swift
@@ -1,0 +1,200 @@
+//
+//  CommunityPostDBManager.swift
+//  LeafLog
+//
+//  Created by OpenAI Codex on 7/29/26.
+//
+
+import Dependencies
+import Foundation
+import Supabase
+
+final class CommunityPostDBManager {
+    @Dependency(\.supabaseManager) private var supabaseManager
+
+    private init() {}
+
+    func createPost(input: CommunityPostSaveInput) async throws -> CommunityPost {
+        try await savePost(function: "create_community_post", input: input)
+    }
+
+    func updatePost(input: CommunityPostSaveInput) async throws -> CommunityPost {
+        try await savePost(function: "update_community_post", input: input)
+    }
+
+    private func savePost(
+        function: String,
+        input: CommunityPostSaveInput
+    ) async throws -> CommunityPost {
+        let parameters = try makeParameters(input: input)
+
+        do {
+            let response: CommunityPostRPCResponse = try await supabaseManager.client
+                .rpc(function, params: parameters)
+                .execute()
+                .value
+
+            return try makeCommunityPost(response: response)
+        } catch let error as AuthError {
+            throw error
+        } catch {
+            throw AuthError.communityFailed(
+                "게시글을 저장하지 못했어요. 잠시 후 다시 시도해주세요."
+            )
+        }
+    }
+
+    private func makeParameters(
+        input: CommunityPostSaveInput
+    ) throws -> CommunityPostRPCParameters {
+        let title = input.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isContentEmpty = input.content
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+
+        guard !title.isEmpty else {
+            throw AuthError.communityFailed("제목을 입력해주세요.")
+        }
+
+        guard title.count <= 50 else {
+            throw AuthError.communityFailed("제목은 최대 50자까지 입력할 수 있어요.")
+        }
+
+        guard !isContentEmpty else {
+            throw AuthError.communityFailed("내용을 입력해주세요.")
+        }
+
+        guard input.content.count <= 1_000 else {
+            throw AuthError.communityFailed("내용은 최대 1,000자까지 입력할 수 있어요.")
+        }
+
+        guard input.images.count <= 3 else {
+            throw AuthError.communityFailed("사진은 최대 3장까지 첨부할 수 있어요.")
+        }
+
+        let uniqueImageIDs = Set(input.images.map(\.id))
+        let uniqueImagePaths = Set(input.images.map(\.imagePath))
+        guard
+            uniqueImageIDs.count == input.images.count,
+            uniqueImagePaths.count == input.images.count,
+            input.images.allSatisfy({ !$0.imagePath.isEmpty })
+        else {
+            throw AuthError.communityFailed("첨부한 사진 정보를 확인해주세요.")
+        }
+
+        let imagePayloads = input.images.enumerated().map { index, image in
+            CommunityPostImagePayload(
+                id: image.id,
+                imagePath: image.imagePath,
+                sortOrder: index
+            )
+        }
+
+        return CommunityPostRPCParameters(
+            postID: input.id,
+            category: input.category.databaseValue,
+            title: title,
+            content: input.content,
+            images: imagePayloads
+        )
+    }
+
+    private func makeCommunityPost(
+        response: CommunityPostRPCResponse
+    ) throws -> CommunityPost {
+        guard let category = PostCategory(
+            databaseValue: response.post.category
+        ) else {
+            throw AuthError.communityFailed(
+                "게시글 카테고리 정보를 확인해주세요."
+            )
+        }
+
+        return CommunityPost(
+            id: response.post.id,
+            authorID: response.post.authorID,
+            category: category,
+            title: response.post.title,
+            content: response.post.content,
+            legacyImagePath: response.post.legacyImagePath,
+            createdAt: response.post.createdAt,
+            updatedAt: response.post.updatedAt,
+            deletedAt: response.post.deletedAt,
+            likeCount: response.post.likeCount,
+            images: response.images
+        )
+    }
+
+}
+
+nonisolated private struct CommunityPostRPCResponse: Decodable, Sendable {
+    let post: StoredCommunityPost
+    let images: [CommunityPostImage]
+}
+
+nonisolated private struct StoredCommunityPost: Decodable, Sendable {
+    let id: UUID
+    let authorID: UUID
+    let category: String
+    let title: String
+    let content: String
+    let legacyImagePath: String?
+    let createdAt: Date
+    let updatedAt: Date
+    let deletedAt: Date?
+    let likeCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case authorID = "author_id"
+        case category
+        case title
+        case content
+        case legacyImagePath = "image_path"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case deletedAt = "deleted_at"
+        case likeCount = "like_count"
+    }
+}
+
+nonisolated private struct CommunityPostRPCParameters: Encodable, Sendable {
+    let postID: UUID
+    let category: String
+    let title: String
+    let content: String
+    let images: [CommunityPostImagePayload]
+
+    enum CodingKeys: String, CodingKey {
+        case postID = "p_post_id"
+        case category = "p_category"
+        case title = "p_title"
+        case content = "p_content"
+        case images = "p_images"
+    }
+}
+
+nonisolated private struct CommunityPostImagePayload: Encodable, Sendable {
+    let id: UUID
+    let imagePath: String
+    let sortOrder: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case imagePath = "image_path"
+        case sortOrder = "sort_order"
+    }
+}
+
+extension CommunityPostDBManager: DependencyKey {
+    static var liveValue: CommunityPostDBManager {
+        CommunityPostDBManager()
+    }
+}
+
+extension DependencyValues {
+    var communityPostDBManager: CommunityPostDBManager {
+        get { self[CommunityPostDBManager.self] }
+        set { self[CommunityPostDBManager.self] = newValue }
+    }
+}

--- a/LeafLog/LeafLog/Network/Supabase/CommunityPostDBManager.swift
+++ b/LeafLog/LeafLog/Network/Supabase/CommunityPostDBManager.swift
@@ -12,8 +12,6 @@ import Supabase
 final class CommunityPostDBManager {
     @Dependency(\.supabaseManager) private var supabaseManager
 
-    private init() {}
-
     func createPost(input: CommunityPostSaveInput) async throws -> CommunityPost {
         try await savePost(function: "create_community_post", input: input)
     }

--- a/LeafLog/LeafLog/Network/Supabase/SupabaseManager.swift
+++ b/LeafLog/LeafLog/Network/Supabase/SupabaseManager.swift
@@ -65,6 +65,7 @@ extension SupabaseManager {
     private enum StorageBucket {
         static let profileImages = "profile-images"
         static let plantImages = "plant-images"
+        static let communityImages = "community-images"
     }
 
     // 엣지케이스 방지
@@ -81,6 +82,14 @@ extension SupabaseManager {
     private enum ImageUploadCompression {
         static let maxPixelLength: CGFloat = 1280 // 긴쪽이 1280 넘으면 1280으로
         static let jpegQuality: CGFloat = 0.75 // 75% 품질로 압축
+    }
+
+    private enum CommunityImageUpload {
+        static let maxByteCount = 5 * 1024 * 1024
+        static let maxPixelLength: CGFloat = 2048
+        static let minPixelLength: CGFloat = 640
+        static let resizeRatio: CGFloat = 0.8
+        static let jpegQualities: [CGFloat] = [0.82, 0.75, 0.68, 0.61, 0.55]
     }
 
     // 프로필 이미지를 private bucket에 업로드하고, DB에는 storage path만 저장
@@ -123,6 +132,37 @@ extension SupabaseManager {
             sizeLimitError: .careFailed(ImageUploadLimit.exceededMessage)
         )
     }
+
+    func uploadCommunityPostImage(
+        _ image: UIImage,
+        userID: UUID,
+        postID: UUID,
+        imageID: UUID
+    ) async throws -> String {
+        let objectPath = [
+            "users",
+            userID.uuidString.lowercased(),
+            "posts",
+            postID.uuidString.lowercased(),
+            "\(imageID.uuidString.lowercased()).jpg"
+        ].joined(separator: "/")
+
+        let fileData = try optimizedCommunityImageData(from: image)
+
+        _ = try await client.storage
+            .from(StorageBucket.communityImages)
+            .upload(
+                objectPath,
+                data: fileData,
+                options: FileOptions(
+                    cacheControl: "3600",
+                    contentType: "image/jpeg",
+                    upsert: true
+                )
+            )
+
+        return objectPath
+    }
     
     // DB에 저장된 프로필 이미지 값을 실제 접근 가능한 URL로 변환
     // private bucket path면 signed URL을 만들고, 기존 외부 URL은 그대로 사용
@@ -147,6 +187,17 @@ extension SupabaseManager {
         try await resolveStoredImageURL(
             from: storedValue,
             bucket: StorageBucket.plantImages,
+            cacheKey: cacheKey
+        )
+    }
+
+    func resolveCommunityPostImageURL(
+        from storedValue: String?,
+        cacheKey: String? = nil
+    ) async throws -> URL? {
+        try await resolveStoredImageURL(
+            from: storedValue,
+            bucket: StorageBucket.communityImages,
             cacheKey: cacheKey
         )
     }
@@ -225,6 +276,86 @@ extension SupabaseManager {
         }
     }
 
+    private func optimizedCommunityImageData(from image: UIImage) throws -> Data {
+        let originalPixelSize = CGSize(
+            width: image.size.width * image.scale,
+            height: image.size.height * image.scale
+        )
+        let originalLongestSide = max(
+            originalPixelSize.width,
+            originalPixelSize.height
+        )
+
+        guard originalLongestSide > 0 else {
+            throw AuthError.communityFailed("사진을 변환하지 못했어요.")
+        }
+
+        var targetLongestSide = min(
+            originalLongestSide,
+            CommunityImageUpload.maxPixelLength
+        )
+
+        while true {
+            let renderedImage = renderCommunityImage(
+                image,
+                originalPixelSize: originalPixelSize,
+                targetLongestSide: targetLongestSide
+            )
+
+            for quality in CommunityImageUpload.jpegQualities {
+                guard let data = renderedImage.jpegData(
+                    compressionQuality: quality
+                ) else {
+                    continue
+                }
+
+                if data.count <= CommunityImageUpload.maxByteCount {
+                    return data
+                }
+            }
+
+            guard targetLongestSide > CommunityImageUpload.minPixelLength else {
+                break
+            }
+
+            targetLongestSide = max(
+                targetLongestSide * CommunityImageUpload.resizeRatio,
+                CommunityImageUpload.minPixelLength
+            )
+        }
+
+        throw AuthError.communityFailed("사진을 최적화하지 못했어요.")
+    }
+
+    private func renderCommunityImage(
+        _ image: UIImage,
+        originalPixelSize: CGSize,
+        targetLongestSide: CGFloat
+    ) -> UIImage {
+        let originalLongestSide = max(
+            originalPixelSize.width,
+            originalPixelSize.height
+        )
+        let ratio = min(1, targetLongestSide / originalLongestSide)
+        let targetSize = CGSize(
+            width: originalPixelSize.width * ratio,
+            height: originalPixelSize.height * ratio
+        )
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+
+        return UIGraphicsImageRenderer(
+            size: targetSize,
+            format: format
+        ).image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(origin: .zero, size: targetSize))
+            image.draw(in: CGRect(origin: .zero, size: targetSize))
+        }
+    }
+
     private static func isStorageSizeLimitError(_ error: Error) -> Bool {
         let message = (String(describing: error)).lowercased()
         return message.contains("maximum allowed size")
@@ -281,6 +412,14 @@ extension SupabaseManager {
         try await client.storage
             .from(StorageBucket.plantImages)
             .remove(paths: [path])
+    }
+
+    func deleteCommunityPostImages(paths: [String]) async throws {
+        guard !paths.isEmpty else { return }
+
+        try await client.storage
+            .from(StorageBucket.communityImages)
+            .remove(paths: paths)
     }
 }
 

--- a/LeafLog/LeafLog/Network/Supabase/SupabaseManager.swift
+++ b/LeafLog/LeafLog/Network/Supabase/SupabaseManager.swift
@@ -38,6 +38,11 @@ private actor SignedImageURLMemoryCache {
     }
 }
 
+private enum CommunityImageProcessingError: Error {
+    case invalidImage
+    case optimizationFailed
+}
+
 final class SupabaseManager {
     private let logger = Logger(subsystem: "LeafLog", category: "SupabaseManager")
     
@@ -147,19 +152,29 @@ extension SupabaseManager {
             "\(imageID.uuidString.lowercased()).jpg"
         ].joined(separator: "/")
 
-        let fileData = try optimizedCommunityImageData(from: image)
+        do {
+            let fileData = try optimizedCommunityImageData(from: image)
 
-        _ = try await client.storage
-            .from(StorageBucket.communityImages)
-            .upload(
-                objectPath,
-                data: fileData,
-                options: FileOptions(
-                    cacheControl: "3600",
-                    contentType: "image/jpeg",
-                    upsert: true
+            _ = try await client.storage
+                .from(StorageBucket.communityImages)
+                .upload(
+                    objectPath,
+                    data: fileData,
+                    options: FileOptions(
+                        cacheControl: "3600",
+                        contentType: "image/jpeg",
+                        upsert: true
+                    )
                 )
+        } catch {
+            logger.error(
+                "Community image upload failed. postID: \(postID.uuidString, privacy: .public), imageID: \(imageID.uuidString, privacy: .public), error: \(String(describing: error), privacy: .private)"
             )
+
+            throw AuthError.communityFailed(
+                "사진을 업로드하지 못했어요. 잠시 후 다시 시도해주세요."
+            )
+        }
 
         return objectPath
     }
@@ -287,7 +302,7 @@ extension SupabaseManager {
         )
 
         guard originalLongestSide > 0 else {
-            throw AuthError.communityFailed("사진을 변환하지 못했어요.")
+            throw CommunityImageProcessingError.invalidImage
         }
 
         var targetLongestSide = min(
@@ -324,7 +339,7 @@ extension SupabaseManager {
             )
         }
 
-        throw AuthError.communityFailed("사진을 최적화하지 못했어요.")
+        throw CommunityImageProcessingError.optimizationFailed
     }
 
     private func renderCommunityImage(

--- a/LeafLog/LeafLog/Scenes/Community/CommunityTempViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/CommunityTempViewController.swift
@@ -1,0 +1,191 @@
+//
+//  CommunityTempViewController.swift
+//  LeafLog
+//
+//  Created by OpenAI Codex on 7/30/26.
+//
+
+import Dependencies
+import ReactorKit
+import RxCocoa
+import SnapKit
+import UIKit
+
+final class CommunityTempReactor: Reactor {
+    @Dependency(\.communityPostDBManager)
+    private var communityPostDBManager
+
+    enum Action {
+        case editLatestPostTapped
+    }
+
+    enum Mutation {
+        case setLoading(Bool)
+        case setLatestPost(CommunityPost)
+        case setNoticeMessage(String)
+        case setErrorMessage(String)
+    }
+
+    struct State {
+        var isLoading = false
+        @Pulse var latestPost: CommunityPost?
+        @Pulse var noticeMessage: String?
+        @Pulse var errorMessage: String?
+    }
+
+    let initialState = State()
+
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .editLatestPostTapped:
+            return fetchLatestPost()
+        }
+    }
+
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+
+        switch mutation {
+        case .setLoading(let isLoading):
+            newState.isLoading = isLoading
+        case .setLatestPost(let post):
+            newState.latestPost = post
+        case .setNoticeMessage(let message):
+            newState.noticeMessage = message
+        case .setErrorMessage(let message):
+            newState.errorMessage = message
+        }
+
+        return newState
+    }
+
+    private func fetchLatestPost() -> Observable<Mutation> {
+        guard !currentState.isLoading else { return .empty() }
+
+        let fetchPost = Single<CommunityPost?>.create {
+            [communityPostDBManager] in
+            try await communityPostDBManager
+                .fetchMyPosts(limit: 1, offset: 0)
+                .first
+        }
+        .asObservable()
+        .flatMap { post -> Observable<Mutation> in
+            guard let post else {
+                return .from([
+                    .setLoading(false),
+                    .setNoticeMessage("작성한 게시글이 없어요.")
+                ])
+            }
+
+            return .from([
+                .setLoading(false),
+                .setLatestPost(post)
+            ])
+        }
+        .catch { error in
+            let message = (error as? AuthError)?.userMessage
+                ?? "작성한 게시글을 불러오지 못했어요. 잠시 후 다시 시도해주세요."
+
+            return .from([
+                .setLoading(false),
+                .setErrorMessage(message)
+            ])
+        }
+
+        return .concat(
+            .just(.setLoading(true)),
+            fetchPost
+        )
+    }
+}
+
+final class CommunityTempViewController: BaseViewController, View {
+    private let createButton = BottomSaveButton(title: "게시글 작성")
+    private let editButton = BottomSaveButton(title: "최근 게시글 수정")
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .grayScale50
+        setLayout()
+    }
+
+    func bind(reactor: CommunityTempReactor) {
+        createButton.rx.tap
+            .subscribe(with: self) { viewController, _ in
+                viewController.steps.accept(AppStep.communityComposeCreate)
+            }
+            .disposed(by: disposeBag)
+
+        editButton.rx.tap
+            .map { CommunityTempReactor.Action.editLatestPostTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        reactor.state
+            .map(\.isLoading)
+            .distinctUntilChanged()
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: editButton) { button, isLoading in
+                button.isEnabled = !isLoading
+                button.setTitle(
+                    isLoading ? "게시글 불러오는 중" : "최근 게시글 수정"
+                )
+            }
+            .disposed(by: disposeBag)
+
+        reactor.pulse(\.$latestPost)
+            .compactMap { $0 }
+            .subscribe(with: self) { viewController, post in
+                viewController.steps.accept(
+                    AppStep.communityComposeEdit(post)
+                )
+            }
+            .disposed(by: disposeBag)
+
+        reactor.pulse(\.$noticeMessage)
+            .compactMap { $0 }
+            .subscribe(with: self) { viewController, message in
+                viewController.steps.accept(
+                    AppStep.alert("안내", message)
+                )
+            }
+            .disposed(by: disposeBag)
+
+        reactor.pulse(\.$errorMessage)
+            .compactMap { $0 }
+            .subscribe(with: self) { viewController, message in
+                viewController.steps.accept(
+                    AppStep.alert("오류", message)
+                )
+            }
+            .disposed(by: disposeBag)
+    }
+
+    private func setLayout() {
+        let stackView = UIStackView(
+            arrangedSubviews: [createButton, editButton]
+        )
+        stackView.axis = .vertical
+        stackView.spacing = 12
+
+        view.addSubview(stackView)
+
+        stackView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(24)
+            $0.centerY.equalToSuperview()
+        }
+
+        [createButton, editButton].forEach {
+            $0.snp.makeConstraints {
+                $0.height.equalTo(48)
+            }
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    let viewController = CommunityTempViewController()
+    viewController.reactor = CommunityTempReactor()
+    return viewController
+}

--- a/LeafLog/LeafLog/Scenes/Community/CommunityTempViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/CommunityTempViewController.swift
@@ -114,11 +114,6 @@ final class CommunityTempViewController: BaseViewController, View {
         tabBarController?.tabBar.isHidden = false
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        tabBarController?.tabBar.isHidden = true
-    }
-    
     func bind(reactor: CommunityTempReactor) {
         createButton.rx.tap
             .subscribe(with: self) { viewController, _ in

--- a/LeafLog/LeafLog/Scenes/Community/CommunityTempViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/CommunityTempViewController.swift
@@ -109,6 +109,16 @@ final class CommunityTempViewController: BaseViewController, View {
         setLayout()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        tabBarController?.tabBar.isHidden = false
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        tabBarController?.tabBar.isHidden = true
+    }
+    
     func bind(reactor: CommunityTempReactor) {
         createButton.rx.tap
             .subscribe(with: self) { viewController, _ in

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -15,19 +15,22 @@ final class CommunityComposeReactor: Reactor {
         case viewWillAppear
         case selectCategory(Int)
         case enterTitle(String)
+        case enterBody(String)
     }
     
     enum Mutation {
         case setCategory(PostCategory)
         case setTitle(String)
+        case setBody(String)
     }
     
     struct State {
         var category: PostCategory
         var title: String = ""
+        var body: String = ""
         
         var isButtonActive: Bool {
-            !title.isEmpty
+            !title.isEmpty && !body.isEmpty
         }
     }
     
@@ -45,6 +48,8 @@ final class CommunityComposeReactor: Reactor {
                 .just(.setCategory(PostCategory(rawValue: tag) ?? .plantLife))
         case .enterTitle(let title):
             return .just(.setTitle(title))
+        case .enterBody(let body):
+            return .just(.setBody(body))
         }
     }
     
@@ -55,6 +60,8 @@ final class CommunityComposeReactor: Reactor {
             newState.category = category
         case .setTitle(let title):
             newState.title = title
+        case .setBody(let body):
+            newState.body = body
         }
         return newState
     }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -33,7 +33,8 @@ final class CommunityComposeReactor: Reactor {
         switch action {
         case .viewWillAppear:
             return .empty()
-
+        case .selectCategory:
+            return .empty()
         }
     }
     

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -15,48 +15,20 @@ enum CommunityComposeMode {
     case edit(CommunityPost)
 }
 
-struct CommunityComposePicture {
-    let existingImage: CommunityPostImage?
-    let localImageID: UUID?
-    let displayImage: UIImage?
-
-    init(existingImage: CommunityPostImage, displayImage: UIImage? = nil) {
-        self.existingImage = existingImage
-        self.localImageID = nil
-        self.displayImage = displayImage
-    }
-
-    init(localImageID: UUID = UUID(), image: UIImage) {
-        self.existingImage = nil
-        self.localImageID = localImageID
-        self.displayImage = image
-    }
-
-    func replacing(with image: UIImage) -> CommunityComposePicture {
-        CommunityComposePicture(
-            existingImage: existingImage,
-            localImageID: UUID(),
-            displayImage: image
-        )
-    }
-
-    func settingPreview(_ image: UIImage) -> CommunityComposePicture {
-        CommunityComposePicture(
-            existingImage: existingImage,
-            localImageID: localImageID,
-            displayImage: image
-        )
-    }
-
-    private init(
-        existingImage: CommunityPostImage?,
-        localImageID: UUID?,
-        displayImage: UIImage?
-    ) {
-        self.existingImage = existingImage
-        self.localImageID = localImageID
-        self.displayImage = displayImage
-    }
+enum CommunityComposePicture {
+    case existing(
+        image: CommunityPostImage,
+        displayURL: URL?
+    )
+    case added(
+        imageID: UUID,
+        displayImage: UIImage
+    )
+    case replacement(
+        existingImage: CommunityPostImage,
+        imageID: UUID,
+        displayImage: UIImage
+    )
 }
 
 final class CommunityComposeReactor: Reactor {
@@ -85,7 +57,7 @@ final class CommunityComposeReactor: Reactor {
         case replacePicture(index: Int, image: UIImage)
         case removePicture(index: Int)
         case movePicture(from: Int, to: Int)
-        case setExistingPicturePreview(id: UUID, image: UIImage)
+        case setExistingPictureURL(id: UUID, url: URL)
         case setSaving(Bool)
         case setSaveCompleted
         case setWarningMessage(String)
@@ -144,7 +116,12 @@ final class CommunityComposeReactor: Reactor {
                 title: post.title,
                 pictures: post.images
                     .sorted { $0.sortOrder < $1.sortOrder }
-                    .map { CommunityComposePicture(existingImage: $0) },
+                    .map {
+                        CommunityComposePicture.existing(
+                            image: $0,
+                            displayURL: nil
+                        )
+                    },
                 body: post.content
             )
         }
@@ -153,7 +130,7 @@ final class CommunityComposeReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewWillAppear:
-            return loadExistingPicturePreviews(state: currentState)
+            return loadExistingPictureURLs(state: currentState)
         case .selectCategory(let tag):
             return
                 .just(.setCategory(PostCategory(rawValue: tag) ?? .plantLife))
@@ -184,21 +161,49 @@ final class CommunityComposeReactor: Reactor {
         case .appendPictures(let pictures):
             newState.pictures.append(
                 contentsOf: pictures.map {
-                    CommunityComposePicture(image: $0)
+                    CommunityComposePicture.added(
+                        imageID: UUID(),
+                        displayImage: $0
+                    )
                 }
             )
         case let .replacePicture(index, image):
             guard newState.pictures.indices.contains(index) else {
                 return state
             }
-            newState.pictures[index] = newState.pictures[index]
-                .replacing(with: image)
+            newState.pictures[index] = switch newState.pictures[index] {
+            case .existing(let existingImage, _):
+                .replacement(
+                    existingImage: existingImage,
+                    imageID: UUID(),
+                    displayImage: image
+                )
+            case .added:
+                .added(
+                    imageID: UUID(),
+                    displayImage: image
+                )
+            case .replacement(let existingImage, _, _):
+                .replacement(
+                    existingImage: existingImage,
+                    imageID: UUID(),
+                    displayImage: image
+                )
+            }
         case .removePicture(let index):
             guard newState.pictures.indices.contains(index) else {
                 return state
             }
             let removedPicture = newState.pictures.remove(at: index)
-            if let imagePath = removedPicture.existingImage?.imagePath {
+            let existingImage: CommunityPostImage? = switch removedPicture {
+            case .existing(let image, _):
+                image
+            case .replacement(let image, _, _):
+                image
+            case .added:
+                nil
+            }
+            if let imagePath = existingImage?.imagePath {
                 newState.removedExistingImagePaths.append(imagePath)
             }
         case let .movePicture(from, to):
@@ -210,14 +215,22 @@ final class CommunityComposeReactor: Reactor {
             }
             let picture = newState.pictures.remove(at: from)
             newState.pictures.insert(picture, at: to)
-        case let .setExistingPicturePreview(id, image):
+        case let .setExistingPictureURL(id, url):
             guard let index = newState.pictures.firstIndex(where: {
-                $0.existingImage?.id == id && $0.localImageID == nil
+                guard case .existing(let image, _) = $0 else {
+                    return false
+                }
+                return image.id == id
             }) else {
                 return state
             }
-            newState.pictures[index] = newState.pictures[index]
-                .settingPreview(image)
+            guard case .existing(let image, _) = newState.pictures[index] else {
+                return state
+            }
+            newState.pictures[index] = .existing(
+                image: image,
+                displayURL: url
+            )
         case .setBody(let body):
             newState.body = body
         case .setSaving(let isSaving):
@@ -234,41 +247,32 @@ final class CommunityComposeReactor: Reactor {
         return newState
     }
 
-    private func loadExistingPicturePreviews(
+    private func loadExistingPictureURLs(
         state: State
     ) -> Observable<Mutation> {
-        let existingImages = state.pictures.compactMap(\.existingImage)
+        let existingImages = state.pictures.compactMap {
+            picture -> CommunityPostImage? in
+            guard case .existing(let image, _) = picture else {
+                return nil
+            }
+            return image
+        }
 
         return Observable.from(existingImages)
             .concatMap { [supabaseManager] image in
-                Single<UIImage?>.create {
-                    guard let url = try await supabaseManager
+                Single<URL?>.create {
+                    try await supabaseManager
                         .resolveCommunityPostImageURL(
                             from: image.imagePath,
                             cacheKey: image.id.uuidString
                         )
-                    else {
-                        return nil
-                    }
-
-                    let (data, response) = try await URLSession.shared.data(
-                        from: url
-                    )
-                    guard
-                        let response = response as? HTTPURLResponse,
-                        (200..<300).contains(response.statusCode)
-                    else {
-                        return nil
-                    }
-
-                    return UIImage(data: data)
                 }
                 .asObservable()
-                .compactMap { preview in
-                    preview.map {
-                        Mutation.setExistingPicturePreview(
+                .compactMap { url in
+                    url.map {
+                        Mutation.setExistingPictureURL(
                             id: image.id,
-                            image: $0
+                            url: $0
                         )
                     }
                 }
@@ -369,42 +373,54 @@ final class CommunityComposeReactor: Reactor {
         for picture in pictures {
             try Task.checkCancellation()
 
-            guard
-                let localImageID = picture.localImageID,
-                let localImage = picture.displayImage
-            else {
-                if let existingImage = picture.existingImage {
-                    imageInputs.append(
-                        CommunityPostImageInput(
-                            id: existingImage.id,
-                            imagePath: existingImage.imagePath
-                        )
-                    )
-                }
-                continue
-            }
-
-            if let imagePath = try await uploadPicture(
-                localImage,
-                userID: userID,
-                postID: postID,
-                imageID: localImageID,
-                supabaseManager: supabaseManager
-            ) {
+            switch picture {
+            case .existing(let image, _):
                 imageInputs.append(
                     CommunityPostImageInput(
-                        id: localImageID,
-                        imagePath: imagePath
+                        id: image.id,
+                        imagePath: image.imagePath
                     )
                 )
 
-                if let existingPath = picture.existingImage?.imagePath {
-                    replacedImagePaths.append(existingPath)
+            case .added(let imageID, let image):
+                if let imagePath = try await uploadPicture(
+                    image,
+                    userID: userID,
+                    postID: postID,
+                    imageID: imageID,
+                    supabaseManager: supabaseManager
+                ) {
+                    imageInputs.append(
+                        CommunityPostImageInput(
+                            id: imageID,
+                            imagePath: imagePath
+                        )
+                    )
+                } else {
+                    hasImageUploadFailure = true
                 }
-            } else {
-                hasImageUploadFailure = true
 
-                if let existingImage = picture.existingImage {
+            case .replacement(
+                let existingImage,
+                let imageID,
+                let image
+            ):
+                if let imagePath = try await uploadPicture(
+                    image,
+                    userID: userID,
+                    postID: postID,
+                    imageID: imageID,
+                    supabaseManager: supabaseManager
+                ) {
+                    imageInputs.append(
+                        CommunityPostImageInput(
+                            id: imageID,
+                            imagePath: imagePath
+                        )
+                    )
+                    replacedImagePaths.append(existingImage.imagePath)
+                } else {
+                    hasImageUploadFailure = true
                     imageInputs.append(
                         CommunityPostImageInput(
                             id: existingImage.id,

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -78,17 +78,10 @@ final class CommunityComposeReactor: Reactor {
         @Pulse var errorMessage: String?
         
         var isButtonActive: Bool {
-            let normalizedTitle = title.trimmingCharacters(
-                in: .whitespacesAndNewlines
-            )
-            let normalizedBody = body.trimmingCharacters(
-                in: .whitespacesAndNewlines
-            )
-
-            return !normalizedTitle.isEmpty
-                && normalizedTitle.count <= 50
-                && !normalizedBody.isEmpty
-                && body.count <= CommunityComposeView.bodyMaxCount
+            CommunityPostValidation.validate(
+                title: title,
+                content: body
+            ).isValid
                 && !isSaving
                 && !saveCompleted
         }
@@ -283,6 +276,17 @@ final class CommunityComposeReactor: Reactor {
     private func savePost(state: State) -> Observable<Mutation> {
         guard !state.isSaving else { return .empty() }
 
+        let validatedText: (title: String, content: String)
+        switch CommunityPostValidation.validate(
+            title: state.title,
+            content: state.body
+        ) {
+        case let .valid(title, content):
+            validatedText = (title, content)
+        case let .invalid(message):
+            return .just(.setErrorMessage(message))
+        }
+
         let savePostSingle = Single<Bool>.create {
             [communityPostDBManager, supabaseManager] in
             guard let userID = supabaseManager.client.auth.currentUser?.id else {
@@ -300,8 +304,8 @@ final class CommunityComposeReactor: Reactor {
             let input = CommunityPostSaveInput(
                 id: state.postID,
                 category: state.category,
-                title: state.title,
-                content: state.body,
+                title: validatedText.title,
+                content: validatedText.content,
                 images: uploadResult.images
             )
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -15,19 +15,25 @@ final class CommunityComposeReactor: Reactor {
         case viewWillAppear
         case selectCategory(Int)
         case enterTitle(String)
-        case selectPicture([UIImage])
+        case addPictures([UIImage])
+        case replacePicture(index: Int, image: UIImage)
+        case removePicture(index: Int)
         case enterBody(String)
     }
     
     enum Mutation {
         case setCategory(PostCategory)
         case setTitle(String)
+        case appendPictures([UIImage])
+        case replacePicture(index: Int, image: UIImage)
+        case removePicture(index: Int)
         case setBody(String)
     }
     
     struct State {
         var category: PostCategory
         var title: String = ""
+        var pictures: [UIImage] = []
         var body: String = ""
         
         var isButtonActive: Bool {
@@ -49,6 +55,12 @@ final class CommunityComposeReactor: Reactor {
                 .just(.setCategory(PostCategory(rawValue: tag) ?? .plantLife))
         case .enterTitle(let title):
             return .just(.setTitle(title))
+        case .addPictures(let pictures):
+            return .just(.appendPictures(pictures))
+        case let .replacePicture(index, image):
+            return .just(.replacePicture(index: index, image: image))
+        case .removePicture(let index):
+            return .just(.removePicture(index: index))
         case .enterBody(let body):
             return .just(.setBody(body))
         }
@@ -61,6 +73,18 @@ final class CommunityComposeReactor: Reactor {
             newState.category = category
         case .setTitle(let title):
             newState.title = title
+        case .appendPictures(let pictures):
+            newState.pictures.append(contentsOf: pictures)
+        case let .replacePicture(index, image):
+            guard newState.pictures.indices.contains(index) else {
+                return state
+            }
+            newState.pictures[index] = image
+        case .removePicture(let index):
+            guard newState.pictures.indices.contains(index) else {
+                return state
+            }
+            newState.pictures.remove(at: index)
         case .setBody(let body):
             newState.body = body
         }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -5,7 +5,7 @@
 //  Created by 변예린 on 7/9/26.
 //
 
-import Foundation
+import UIKit
 import ReactorKit
 import Supabase
 import Dependencies
@@ -15,6 +15,7 @@ final class CommunityComposeReactor: Reactor {
         case viewWillAppear
         case selectCategory(Int)
         case enterTitle(String)
+        case selectPicture([UIImage])
         case enterBody(String)
     }
     

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -18,6 +18,7 @@ final class CommunityComposeReactor: Reactor {
         case addPictures([UIImage])
         case replacePicture(index: Int, image: UIImage)
         case removePicture(index: Int)
+        case movePicture(from: Int, to: Int)
         case enterBody(String)
     }
     
@@ -27,6 +28,7 @@ final class CommunityComposeReactor: Reactor {
         case appendPictures([UIImage])
         case replacePicture(index: Int, image: UIImage)
         case removePicture(index: Int)
+        case movePicture(from: Int, to: Int)
         case setBody(String)
     }
     
@@ -61,6 +63,8 @@ final class CommunityComposeReactor: Reactor {
             return .just(.replacePicture(index: index, image: image))
         case .removePicture(let index):
             return .just(.removePicture(index: index))
+        case let .movePicture(from, to):
+            return .just(.movePicture(from: from, to: to))
         case .enterBody(let body):
             return .just(.setBody(body))
         }
@@ -85,6 +89,15 @@ final class CommunityComposeReactor: Reactor {
                 return state
             }
             newState.pictures.remove(at: index)
+        case let .movePicture(from, to):
+            guard
+                newState.pictures.indices.contains(from),
+                newState.pictures.indices.contains(to)
+            else {
+                return state
+            }
+            let picture = newState.pictures.remove(at: from)
+            newState.pictures.insert(picture, at: to)
         case .setBody(let body):
             newState.body = body
         }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -25,6 +25,10 @@ final class CommunityComposeReactor: Reactor {
     struct State {
         var category: PostCategory
         var title: String = ""
+        
+        var isButtonActive: Bool {
+            !title.isEmpty
+        }
     }
     
     let initialState = State(category: .plantLife)
@@ -37,9 +41,10 @@ final class CommunityComposeReactor: Reactor {
         case .viewWillAppear:
             return .empty()
         case .selectCategory(let tag):
-            return .just(.setCategory(PostCategory(rawValue: tag) ?? .plantLife))
+            return
+                .just(.setCategory(PostCategory(rawValue: tag) ?? .plantLife))
         case .enterTitle(let title):
-                return .just(.setTitle(title))
+            return .just(.setTitle(title))
         }
     }
     

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -18,25 +18,25 @@ enum CommunityComposeMode {
 struct CommunityComposePicture {
     let existingImage: CommunityPostImage?
     let localImageID: UUID?
-    let previewImage: UIImage?
+    let displayImage: UIImage?
 
-    init(existingImage: CommunityPostImage, previewImage: UIImage? = nil) {
+    init(existingImage: CommunityPostImage, displayImage: UIImage? = nil) {
         self.existingImage = existingImage
         self.localImageID = nil
-        self.previewImage = previewImage
+        self.displayImage = displayImage
     }
 
     init(localImageID: UUID = UUID(), image: UIImage) {
         self.existingImage = nil
         self.localImageID = localImageID
-        self.previewImage = image
+        self.displayImage = image
     }
 
     func replacing(with image: UIImage) -> CommunityComposePicture {
         CommunityComposePicture(
             existingImage: existingImage,
             localImageID: UUID(),
-            previewImage: image
+            displayImage: image
         )
     }
 
@@ -44,18 +44,18 @@ struct CommunityComposePicture {
         CommunityComposePicture(
             existingImage: existingImage,
             localImageID: localImageID,
-            previewImage: image
+            displayImage: image
         )
     }
 
     private init(
         existingImage: CommunityPostImage?,
         localImageID: UUID?,
-        previewImage: UIImage?
+        displayImage: UIImage?
     ) {
         self.existingImage = existingImage
         self.localImageID = localImageID
-        self.previewImage = previewImage
+        self.displayImage = displayImage
     }
 }
 
@@ -371,7 +371,7 @@ final class CommunityComposeReactor: Reactor {
 
             guard
                 let localImageID = picture.localImageID,
-                let localImage = picture.previewImage
+                let localImage = picture.displayImage
             else {
                 if let existingImage = picture.existingImage {
                     imageInputs.append(

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -11,6 +11,9 @@ import Supabase
 import Dependencies
 
 final class CommunityComposeReactor: Reactor {
+    @Dependency(\.communityPostDBManager) private var communityPostDBManager
+    @Dependency(\.supabaseManager) private var supabaseManager
+
     enum Action {
         case viewWillAppear
         case selectCategory(Int)
@@ -21,6 +24,7 @@ final class CommunityComposeReactor: Reactor {
         case replacePicture(index: Int, image: UIImage)
         case removePicture(index: Int)
         case movePicture(from: Int, to: Int)
+        case saveTapped
     }
     
     enum Mutation {
@@ -32,16 +36,37 @@ final class CommunityComposeReactor: Reactor {
         case replacePicture(index: Int, image: UIImage)
         case removePicture(index: Int)
         case movePicture(from: Int, to: Int)
+        case setSaving(Bool)
+        case setSaveCompleted
+        case setWarningMessage(String)
+        case setErrorMessage(String)
     }
     
     struct State {
+        let postID = UUID()
         var category: PostCategory
         var title: String = ""
         var pictures: [UIImage] = []
         var body: String = ""
+        var isSaving = false
+        @Pulse var saveCompleted = false
+        @Pulse var warningMessage: String?
+        @Pulse var errorMessage: String?
         
         var isButtonActive: Bool {
-            !title.isEmpty && !body.isEmpty
+            let normalizedTitle = title.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            let normalizedBody = body.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+
+            return !normalizedTitle.isEmpty
+                && normalizedTitle.count <= 50
+                && !normalizedBody.isEmpty
+                && body.count <= CommunityComposeView.bodyMaxCount
+                && !isSaving
+                && !saveCompleted
         }
     }
     
@@ -69,6 +94,8 @@ final class CommunityComposeReactor: Reactor {
             return .just(.movePicture(from: from, to: to))
         case .enterBody(let body):
             return .just(.setBody(body))
+        case .saveTapped:
+            return savePost(state: currentState)
         }
     }
     
@@ -102,7 +129,155 @@ final class CommunityComposeReactor: Reactor {
             newState.pictures.insert(picture, at: to)
         case .setBody(let body):
             newState.body = body
+        case .setSaving(let isSaving):
+            newState.isSaving = isSaving
+        case .setSaveCompleted:
+            newState.isSaving = false
+            newState.saveCompleted = true
+        case .setWarningMessage(let message):
+            newState.warningMessage = message
+        case .setErrorMessage(let message):
+            newState.isSaving = false
+            newState.errorMessage = message
         }
         return newState
     }
+
+    private func savePost(state: State) -> Observable<Mutation> {
+        guard !state.isSaving else { return .empty() }
+
+        let savePostSingle = Single<Bool>.create {
+            [communityPostDBManager, supabaseManager] in
+            guard let userID = supabaseManager.client.auth.currentUser?.id else {
+                throw AuthError.communityFailed(
+                    "로그인 정보를 확인하지 못했어요. 다시 로그인해주세요."
+                )
+            }
+
+            let uploadResult = try await Self.uploadPictures(
+                state.pictures,
+                userID: userID,
+                postID: state.postID,
+                supabaseManager: supabaseManager
+            )
+
+            _ = try await communityPostDBManager.createPost(
+                input: CommunityPostSaveInput(
+                    id: state.postID,
+                    category: state.category,
+                    title: state.title,
+                    content: state.body,
+                    images: uploadResult.images
+                )
+            )
+
+            return uploadResult.hasImageUploadFailure
+        }
+
+        let saveMutations = savePostSingle
+            .asObservable()
+            .flatMap { hasImageUploadFailure -> Observable<Mutation> in
+                guard hasImageUploadFailure else {
+                    return .just(.setSaveCompleted)
+                }
+
+                return .from([
+                    .setSaveCompleted,
+                    .setWarningMessage(
+                        "업로드하지 못한 사진이 있어요. 잠시 후 다시 시도해주세요."
+                    )
+                ])
+            }
+            .catch { error in
+                guard !(error is CancellationError) else {
+                    return .empty()
+                }
+
+                if let error = error as? AuthError {
+                    return .just(.setErrorMessage(error.userMessage))
+                }
+
+                return .just(
+                    .setErrorMessage(
+                        "게시글을 저장하지 못했어요. 잠시 후 다시 시도해주세요."
+                    )
+                )
+            }
+
+        return .concat(
+            .just(.setSaving(true)),
+            saveMutations
+        )
+    }
+
+    private static func uploadPictures(
+        _ pictures: [UIImage],
+        userID: UUID,
+        postID: UUID,
+        supabaseManager: SupabaseManager
+    ) async throws -> CommunityImageUploadResult {
+        var uploadedImages: [CommunityPostImageInput] = []
+        var hasImageUploadFailure = false
+
+        for picture in pictures {
+            try Task.checkCancellation()
+            let imageID = UUID()
+
+            if let imagePath = try await uploadPicture(
+                picture,
+                userID: userID,
+                postID: postID,
+                imageID: imageID,
+                supabaseManager: supabaseManager
+            ) {
+                uploadedImages.append(
+                    CommunityPostImageInput(
+                        id: imageID,
+                        imagePath: imagePath
+                    )
+                )
+            } else {
+                hasImageUploadFailure = true
+            }
+        }
+
+        return CommunityImageUploadResult(
+            images: uploadedImages,
+            hasImageUploadFailure: hasImageUploadFailure
+        )
+    }
+
+    private static func uploadPicture(
+        _ picture: UIImage,
+        userID: UUID,
+        postID: UUID,
+        imageID: UUID,
+        supabaseManager: SupabaseManager
+    ) async throws -> String? {
+        for attempt in 0..<3 {
+            do {
+                try Task.checkCancellation()
+
+                return try await supabaseManager.uploadCommunityPostImage(
+                    picture,
+                    userID: userID,
+                    postID: postID,
+                    imageID: imageID
+                )
+            } catch {
+                if Task.isCancelled {
+                    throw CancellationError()
+                }
+
+                guard attempt < 2 else { return nil }
+            }
+        }
+
+        return nil
+    }
+}
+
+private struct CommunityImageUploadResult {
+    let images: [CommunityPostImageInput]
+    let hasImageUploadFailure: Bool
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -10,6 +10,55 @@ import ReactorKit
 import Supabase
 import Dependencies
 
+enum CommunityComposeMode {
+    case create
+    case edit(CommunityPost)
+}
+
+struct CommunityComposePicture {
+    let existingImage: CommunityPostImage?
+    let localImageID: UUID?
+    let previewImage: UIImage?
+
+    init(existingImage: CommunityPostImage, previewImage: UIImage? = nil) {
+        self.existingImage = existingImage
+        self.localImageID = nil
+        self.previewImage = previewImage
+    }
+
+    init(localImageID: UUID = UUID(), image: UIImage) {
+        self.existingImage = nil
+        self.localImageID = localImageID
+        self.previewImage = image
+    }
+
+    func replacing(with image: UIImage) -> CommunityComposePicture {
+        CommunityComposePicture(
+            existingImage: existingImage,
+            localImageID: UUID(),
+            previewImage: image
+        )
+    }
+
+    func settingPreview(_ image: UIImage) -> CommunityComposePicture {
+        CommunityComposePicture(
+            existingImage: existingImage,
+            localImageID: localImageID,
+            previewImage: image
+        )
+    }
+
+    private init(
+        existingImage: CommunityPostImage?,
+        localImageID: UUID?,
+        previewImage: UIImage?
+    ) {
+        self.existingImage = existingImage
+        self.localImageID = localImageID
+        self.previewImage = previewImage
+    }
+}
+
 final class CommunityComposeReactor: Reactor {
     @Dependency(\.communityPostDBManager) private var communityPostDBManager
     @Dependency(\.supabaseManager) private var supabaseManager
@@ -36,6 +85,7 @@ final class CommunityComposeReactor: Reactor {
         case replacePicture(index: Int, image: UIImage)
         case removePicture(index: Int)
         case movePicture(from: Int, to: Int)
+        case setExistingPicturePreview(id: UUID, image: UIImage)
         case setSaving(Bool)
         case setSaveCompleted
         case setWarningMessage(String)
@@ -43,11 +93,13 @@ final class CommunityComposeReactor: Reactor {
     }
     
     struct State {
-        let postID = UUID()
+        let mode: CommunityComposeMode
+        let postID: UUID
         var category: PostCategory
-        var title: String = ""
-        var pictures: [UIImage] = []
-        var body: String = ""
+        var title: String
+        var pictures: [CommunityComposePicture]
+        var removedExistingImagePaths: [String] = []
+        var body: String
         var isSaving = false
         @Pulse var saveCompleted = false
         @Pulse var warningMessage: String?
@@ -70,15 +122,38 @@ final class CommunityComposeReactor: Reactor {
         }
     }
     
-    let initialState = State(category: .plantLife)
-    
-    //MARK: Properties
-    private let calendar = Calendar.current
+    let initialState: State
+
+    init(mode: CommunityComposeMode = .create) {
+        switch mode {
+        case .create:
+            initialState = State(
+                mode: mode,
+                postID: UUID(),
+                category: .plantLife,
+                title: "",
+                pictures: [],
+                body: ""
+            )
+
+        case .edit(let post):
+            initialState = State(
+                mode: mode,
+                postID: post.id,
+                category: post.category,
+                title: post.title,
+                pictures: post.images
+                    .sorted { $0.sortOrder < $1.sortOrder }
+                    .map { CommunityComposePicture(existingImage: $0) },
+                body: post.content
+            )
+        }
+    }
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewWillAppear:
-            return .empty()
+            return loadExistingPicturePreviews(state: currentState)
         case .selectCategory(let tag):
             return
                 .just(.setCategory(PostCategory(rawValue: tag) ?? .plantLife))
@@ -107,17 +182,25 @@ final class CommunityComposeReactor: Reactor {
         case .setTitle(let title):
             newState.title = title
         case .appendPictures(let pictures):
-            newState.pictures.append(contentsOf: pictures)
+            newState.pictures.append(
+                contentsOf: pictures.map {
+                    CommunityComposePicture(image: $0)
+                }
+            )
         case let .replacePicture(index, image):
             guard newState.pictures.indices.contains(index) else {
                 return state
             }
-            newState.pictures[index] = image
+            newState.pictures[index] = newState.pictures[index]
+                .replacing(with: image)
         case .removePicture(let index):
             guard newState.pictures.indices.contains(index) else {
                 return state
             }
-            newState.pictures.remove(at: index)
+            let removedPicture = newState.pictures.remove(at: index)
+            if let imagePath = removedPicture.existingImage?.imagePath {
+                newState.removedExistingImagePaths.append(imagePath)
+            }
         case let .movePicture(from, to):
             guard
                 newState.pictures.indices.contains(from),
@@ -127,6 +210,14 @@ final class CommunityComposeReactor: Reactor {
             }
             let picture = newState.pictures.remove(at: from)
             newState.pictures.insert(picture, at: to)
+        case let .setExistingPicturePreview(id, image):
+            guard let index = newState.pictures.firstIndex(where: {
+                $0.existingImage?.id == id && $0.localImageID == nil
+            }) else {
+                return state
+            }
+            newState.pictures[index] = newState.pictures[index]
+                .settingPreview(image)
         case .setBody(let body):
             newState.body = body
         case .setSaving(let isSaving):
@@ -143,6 +234,48 @@ final class CommunityComposeReactor: Reactor {
         return newState
     }
 
+    private func loadExistingPicturePreviews(
+        state: State
+    ) -> Observable<Mutation> {
+        let existingImages = state.pictures.compactMap(\.existingImage)
+
+        return Observable.from(existingImages)
+            .concatMap { [supabaseManager] image in
+                Single<UIImage?>.create {
+                    guard let url = try await supabaseManager
+                        .resolveCommunityPostImageURL(
+                            from: image.imagePath,
+                            cacheKey: image.id.uuidString
+                        )
+                    else {
+                        return nil
+                    }
+
+                    let (data, response) = try await URLSession.shared.data(
+                        from: url
+                    )
+                    guard
+                        let response = response as? HTTPURLResponse,
+                        (200..<300).contains(response.statusCode)
+                    else {
+                        return nil
+                    }
+
+                    return UIImage(data: data)
+                }
+                .asObservable()
+                .compactMap { preview in
+                    preview.map {
+                        Mutation.setExistingPicturePreview(
+                            id: image.id,
+                            image: $0
+                        )
+                    }
+                }
+                .catch { _ in .empty() }
+            }
+    }
+
     private func savePost(state: State) -> Observable<Mutation> {
         guard !state.isSaving else { return .empty() }
 
@@ -154,22 +287,35 @@ final class CommunityComposeReactor: Reactor {
                 )
             }
 
-            let uploadResult = try await Self.uploadPictures(
+            let uploadResult = try await Self.preparePictures(
                 state.pictures,
                 userID: userID,
                 postID: state.postID,
                 supabaseManager: supabaseManager
             )
-
-            _ = try await communityPostDBManager.createPost(
-                input: CommunityPostSaveInput(
-                    id: state.postID,
-                    category: state.category,
-                    title: state.title,
-                    content: state.body,
-                    images: uploadResult.images
-                )
+            let input = CommunityPostSaveInput(
+                id: state.postID,
+                category: state.category,
+                title: state.title,
+                content: state.body,
+                images: uploadResult.images
             )
+
+            switch state.mode {
+            case .create:
+                _ = try await communityPostDBManager.createPost(input: input)
+
+            case .edit:
+                _ = try await communityPostDBManager.updatePost(input: input)
+
+                let deletedPaths = Set(
+                    state.removedExistingImagePaths
+                        + uploadResult.replacedImagePaths
+                )
+                try? await supabaseManager.deleteCommunityPostImages(
+                    paths: Array(deletedPaths)
+                )
+            }
 
             return uploadResult.hasImageUploadFailure
         }
@@ -210,39 +356,68 @@ final class CommunityComposeReactor: Reactor {
         )
     }
 
-    private static func uploadPictures(
-        _ pictures: [UIImage],
+    private static func preparePictures(
+        _ pictures: [CommunityComposePicture],
         userID: UUID,
         postID: UUID,
         supabaseManager: SupabaseManager
     ) async throws -> CommunityImageUploadResult {
-        var uploadedImages: [CommunityPostImageInput] = []
+        var imageInputs: [CommunityPostImageInput] = []
+        var replacedImagePaths: [String] = []
         var hasImageUploadFailure = false
 
         for picture in pictures {
             try Task.checkCancellation()
-            let imageID = UUID()
+
+            guard
+                let localImageID = picture.localImageID,
+                let localImage = picture.previewImage
+            else {
+                if let existingImage = picture.existingImage {
+                    imageInputs.append(
+                        CommunityPostImageInput(
+                            id: existingImage.id,
+                            imagePath: existingImage.imagePath
+                        )
+                    )
+                }
+                continue
+            }
 
             if let imagePath = try await uploadPicture(
-                picture,
+                localImage,
                 userID: userID,
                 postID: postID,
-                imageID: imageID,
+                imageID: localImageID,
                 supabaseManager: supabaseManager
             ) {
-                uploadedImages.append(
+                imageInputs.append(
                     CommunityPostImageInput(
-                        id: imageID,
+                        id: localImageID,
                         imagePath: imagePath
                     )
                 )
+
+                if let existingPath = picture.existingImage?.imagePath {
+                    replacedImagePaths.append(existingPath)
+                }
             } else {
                 hasImageUploadFailure = true
+
+                if let existingImage = picture.existingImage {
+                    imageInputs.append(
+                        CommunityPostImageInput(
+                            id: existingImage.id,
+                            imagePath: existingImage.imagePath
+                        )
+                    )
+                }
             }
         }
 
         return CommunityImageUploadResult(
-            images: uploadedImages,
+            images: imageInputs,
+            replacedImagePaths: replacedImagePaths,
             hasImageUploadFailure: hasImageUploadFailure
         )
     }
@@ -279,5 +454,6 @@ final class CommunityComposeReactor: Reactor {
 
 private struct CommunityImageUploadResult {
     let images: [CommunityPostImageInput]
+    let replacedImagePaths: [String]
     let hasImageUploadFailure: Bool
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -15,21 +15,23 @@ final class CommunityComposeReactor: Reactor {
         case viewWillAppear
         case selectCategory(Int)
         case enterTitle(String)
+        case enterBody(String)
+        
         case addPictures([UIImage])
         case replacePicture(index: Int, image: UIImage)
         case removePicture(index: Int)
         case movePicture(from: Int, to: Int)
-        case enterBody(String)
     }
     
     enum Mutation {
         case setCategory(PostCategory)
         case setTitle(String)
+        case setBody(String)
+        
         case appendPictures([UIImage])
         case replacePicture(index: Int, image: UIImage)
         case removePicture(index: Int)
         case movePicture(from: Int, to: Int)
-        case setBody(String)
     }
     
     struct State {

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -1,0 +1,47 @@
+//
+//  CommunityComposeReactor.swift
+//  LeafLog
+//
+//  Created by 변예린 on 7/9/26.
+//
+
+import Foundation
+import ReactorKit
+import Supabase
+import Dependencies
+
+final class CommunityComposeReactor: Reactor {
+    enum Action {
+        case viewWillAppear
+        case selectCategory(Int)
+    }
+    
+    enum Mutation {
+
+    }
+    
+    struct State {
+        let category: PostCategory
+    }
+    
+    let initialState = State(category: .plantLife)
+    
+    //MARK: Properties
+    private let calendar = Calendar.current
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .viewWillAppear:
+            return .empty()
+
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        
+        }
+        return newState
+    }
+}

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -14,14 +14,17 @@ final class CommunityComposeReactor: Reactor {
     enum Action {
         case viewWillAppear
         case selectCategory(Int)
+        case enterTitle(String)
     }
     
     enum Mutation {
         case setCategory(PostCategory)
+        case setTitle(String)
     }
     
     struct State {
         var category: PostCategory
+        var title: String = ""
     }
     
     let initialState = State(category: .plantLife)
@@ -35,6 +38,8 @@ final class CommunityComposeReactor: Reactor {
             return .empty()
         case .selectCategory(let tag):
             return .just(.setCategory(PostCategory(rawValue: tag) ?? .plantLife))
+        case .enterTitle(let title):
+                return .just(.setTitle(title))
         }
     }
     
@@ -43,6 +48,8 @@ final class CommunityComposeReactor: Reactor {
         switch mutation {
         case .setCategory(let category):
             newState.category = category
+        case .setTitle(let title):
+            newState.title = title
         }
         return newState
     }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeReactor.swift
@@ -17,11 +17,11 @@ final class CommunityComposeReactor: Reactor {
     }
     
     enum Mutation {
-
+        case setCategory(PostCategory)
     }
     
     struct State {
-        let category: PostCategory
+        var category: PostCategory
     }
     
     let initialState = State(category: .plantLife)
@@ -33,15 +33,16 @@ final class CommunityComposeReactor: Reactor {
         switch action {
         case .viewWillAppear:
             return .empty()
-        case .selectCategory:
-            return .empty()
+        case .selectCategory(let tag):
+            return .just(.setCategory(PostCategory(rawValue: tag) ?? .plantLife))
         }
     }
     
     func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         switch mutation {
-        
+        case .setCategory(let category):
+            newState.category = category
         }
         return newState
     }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -15,6 +15,7 @@ final class CommunityComposeViewController: BaseViewController, View {
     //MARK: properties
     let composeView = CommunityComposeView(mode: .create)
     private var pictureDragStartX: CGFloat?
+    private var pictureDragTargetIndex: Int?
     
     //MARK: Lifecycle
     override func loadView() {
@@ -148,7 +149,7 @@ final class CommunityComposeViewController: BaseViewController, View {
     }
 }
 
-//MARK: 사진 선택 기능 관련
+//MARK: 사진 선택 Image Picker 관련
 extension CommunityComposeViewController {
     private typealias PicturePickerRequest = (
         index: Int,
@@ -201,7 +202,10 @@ extension CommunityComposeViewController {
     
         return picker
     }
+}
 
+//MARK: 사진 순서 변경 애니메이션
+extension CommunityComposeViewController {
     // 사진 순서 변경 액션
     private func makePictureMoveAction(
         index: Int,
@@ -216,6 +220,7 @@ extension CommunityComposeViewController {
         switch gesture.state {
         case .began:
             pictureDragStartX = location.x
+            pictureDragTargetIndex = index
             pictureView.superview?.layer.zPosition = 1
             pictureView.transform = CGAffineTransform(scaleX: 1.05, y: 1.05)
 
@@ -226,21 +231,42 @@ extension CommunityComposeViewController {
                 y: 0
             ).scaledBy(x: 1.05, y: 1.05)
 
-        case .ended:
-            resetPictureDrag(pictureView)
             guard
                 let targetIndex = nearestPictureIndex(
                     to: location.x,
                     pictureCount: pictureCount
                 ),
-                targetIndex != index
+                targetIndex != pictureDragTargetIndex
             else {
                 return nil
             }
+            pictureDragTargetIndex = targetIndex
+            updateSiblingPictureTransforms(
+                sourceIndex: index,
+                targetIndex: targetIndex,
+                pictureCount: pictureCount
+            )
+
+        case .ended:
+            guard
+                let targetIndex = nearestPictureIndex(
+                    to: location.x,
+                    pictureCount: pictureCount
+                )
+            else {
+                resetPictureDrag(pictureView, pictureCount: pictureCount)
+                return nil
+            }
+            resetPictureDrag(pictureView, pictureCount: pictureCount)
+            guard targetIndex != index else { return nil }
             return .movePicture(from: index, to: targetIndex)
 
         case .cancelled, .failed:
-            resetPictureDrag(pictureView)
+            resetPictureDrag(
+                pictureView,
+                pictureCount: pictureCount,
+                animated: true
+            )
 
         default:
             break
@@ -249,7 +275,7 @@ extension CommunityComposeViewController {
         return nil
     }
 
-    // 가까운 사진 인덱스 계산
+    // 가장 가까운 사진 인덱스 계산
     private func nearestPictureIndex(
         to locationX: CGFloat,
         pictureCount: Int
@@ -263,18 +289,74 @@ extension CommunityComposeViewController {
     // 사진 중앙 위치 계산
     private func pictureCenterX(at index: Int) -> CGFloat {
         let pictureView = composeView.pictureViews[index]
+        let slotView = pictureView.superview ?? pictureView
         let center = CGPoint(
-            x: pictureView.bounds.midX,
-            y: pictureView.bounds.midY
+            x: slotView.bounds.midX,
+            y: slotView.bounds.midY
         )
-        return pictureView.convert(center, to: composeView).x
+        return slotView.convert(center, to: composeView).x
+    }
+
+    // 드래그 위치에 따라 기존 사진을 한 칸씩 이동
+    private func updateSiblingPictureTransforms(
+        sourceIndex: Int,
+        targetIndex: Int,
+        pictureCount: Int
+    ) {
+        let slotDistance = abs(
+            pictureCenterX(at: 1) - pictureCenterX(at: 0)
+        )
+
+        UIView.animate(
+            withDuration: 0.15,
+            delay: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction]
+        ) {
+            for index in 0..<pictureCount where index != sourceIndex {
+                let translationX: CGFloat
+
+                if sourceIndex < targetIndex,
+                   index > sourceIndex,
+                   index <= targetIndex {
+                    translationX = -slotDistance
+                } else if sourceIndex > targetIndex,
+                          index >= targetIndex,
+                          index < sourceIndex {
+                    translationX = slotDistance
+                } else {
+                    translationX = 0
+                }
+
+                self.composeView.pictureViews[index].transform =
+                    CGAffineTransform(translationX: translationX, y: 0)
+            }
+        }
     }
 
     // 사진 순서 변경 제스처 관련 초기화
-    private func resetPictureDrag(_ pictureView: PictureComposeView) {
+    private func resetPictureDrag(
+        _ pictureView: PictureComposeView,
+        pictureCount: Int,
+        animated: Bool = false
+    ) {
         pictureDragStartX = nil
-        pictureView.transform = .identity
+        pictureDragTargetIndex = nil
         pictureView.superview?.layer.zPosition = 0
+
+        let resetTransforms = {
+            self.composeView.pictureViews.forEach {
+                $0.transform = .identity
+            }
+        }
+
+        if animated {
+            UIView.animate(
+                withDuration: 0.15,
+                animations: resetTransforms
+            )
+        } else {
+            resetTransforms()
+        }
     }
 }
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -60,6 +60,8 @@ final class CommunityComposeViewController: BaseViewController, View {
             .map { CommunityComposeReactor.Action.enterTitle($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+
+        composeView.titleTextField.delegate = self
         
         composeView.rx.pictureViewTap
             .withLatestFrom(reactor.state.map(\.pictures.count)) { index, pictureCount in
@@ -115,7 +117,10 @@ final class CommunityComposeViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
-        
+        composeView.saveButton.rx.tap
+            .map { CommunityComposeReactor.Action.saveTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
     }
     
     private func bindState(reactor: CommunityComposeReactor) {
@@ -146,6 +151,36 @@ final class CommunityComposeViewController: BaseViewController, View {
                 view.saveButton.isEnabled = isActive
             }
             .disposed(by: disposeBag)
+
+        state.map(\.isSaving)
+            .distinctUntilChanged()
+            .drive(with: self) { viewController, isSaving in
+                viewController.setSaving(isSaving)
+            }
+            .disposed(by: disposeBag)
+
+        reactor.pulse(\.$errorMessage)
+            .compactMap { $0 }
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { viewController, message in
+                viewController.steps.accept(AppStep.alert("오류", message))
+            }
+            .disposed(by: disposeBag)
+
+        reactor.pulse(\.$warningMessage)
+            .compactMap { $0 }
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { viewController, message in
+                viewController.steps.accept(AppStep.alert("안내", message))
+            }
+            .disposed(by: disposeBag)
+    }
+
+    private func setSaving(_ isSaving: Bool) {
+        composeView.isUserInteractionEnabled = !isSaving
+        navigationController?
+            .interactivePopGestureRecognizer?
+            .isEnabled = !isSaving
     }
 }
 
@@ -360,8 +395,26 @@ extension CommunityComposeViewController {
     }
 }
 
-//MARK: UITextView Delegate
-extension CommunityComposeViewController: UITextViewDelegate {
+//MARK: Text Input Delegate
+extension CommunityComposeViewController: UITextFieldDelegate, UITextViewDelegate {
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        let currentText = textField.text ?? ""
+        guard let textRange = Range(range, in: currentText) else {
+            return false
+        }
+
+        let updatedText = currentText.replacingCharacters(
+            in: textRange,
+            with: string
+        )
+
+        return updatedText.count <= 50
+    }
+
     // 글자수 제한 기능
     func textView(
         _ textView: UITextView,

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -175,8 +175,10 @@ final class CommunityComposeViewController: BaseViewController, View {
             .disposed(by: disposeBag)
         
         state.map(\.pictures)
-            .drive(with: composeView) { view, pictures in
-                view.applyPictures(pictures.map(\.displayImage))
+            .map { $0.map(\.imageSource) }
+            .distinctUntilChanged()
+            .drive(with: composeView) { view, imageSources in
+                view.applyPictures(imageSources)
             }
             .disposed(by: disposeBag)
 
@@ -215,6 +217,21 @@ final class CommunityComposeViewController: BaseViewController, View {
         navigationController?
             .interactivePopGestureRecognizer?
             .isEnabled = !isSaving
+    }
+}
+
+private extension CommunityComposePicture {
+    var imageSource: PictureComposeView.ImageSource {
+        switch self {
+        case .existing(let image, let displayURL):
+            .remote(
+                url: displayURL,
+                cacheKey: image.id.uuidString
+            )
+        case .added(_, let displayImage),
+             .replacement(_, _, let displayImage):
+            .local(displayImage)
+        }
     }
 }
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -60,17 +60,6 @@ final class CommunityComposeViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        composeView.rx.pictureViewTap
-            .compactMap { [weak self] index -> PHPickerViewController? in
-                return self?.makeImagePicker()
-            }
-            .withUnretained(self)
-            .do(onNext: { $0.present($1, animated: true) })
-            .flatMap { $1.rx.selectedImages.take(1) }
-            .map { CommunityComposeReactor.Action.selectPicture($0) }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
         composeView.bodyTextView.rx.setDelegate(self)
             .disposed(by: disposeBag)
 
@@ -100,6 +89,12 @@ final class CommunityComposeViewController: BaseViewController, View {
             }
             .disposed(by: disposeBag)
         
+        state.map(\.pictures)
+            .drive(with: composeView) { view, pictures in
+                view.applyPictures(pictures)
+            }
+            .disposed(by: disposeBag)
+
         state.map(\.isButtonActive)
             .drive(with: composeView) { view, isActive in
                 view.saveButton.isEnabled = isActive
@@ -115,7 +110,6 @@ extension CommunityComposeViewController {
             pictureView.onPictureSelectionRequested = { [weak self, weak pictureView] in
                 guard let self, let pictureView else { return }
 
-               
             }
         }
     }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -508,7 +508,7 @@ extension CommunityComposeViewController: UITextFieldDelegate, UITextViewDelegat
             with: string
         )
 
-        return updatedText.count <= 50
+        return updatedText.count <= CommunityPostValidation.titleMaxCount
     }
 
     // 글자수 제한 기능
@@ -523,12 +523,14 @@ extension CommunityComposeViewController: UITextFieldDelegate, UITextViewDelegat
         }
 
         let updatedText = currentText.replacingCharacters(in: textRange, with: text)
-        if updatedText.count <= CommunityComposeView.bodyMaxCount {
+        if updatedText.count <= CommunityPostValidation.contentMaxCount {
             return true
         }
 
         let replaceCount = currentText[textRange].count // 글자를 붙여넣기할 때 붙여넣을 글자의 수
-        let remainingCount = CommunityComposeView.bodyMaxCount - currentText.count + replaceCount
+        let remainingCount = CommunityPostValidation.contentMaxCount
+            - currentText.count
+            + replaceCount
         guard remainingCount > 0 else {
             return false
         }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -14,6 +14,7 @@ import RxCocoa
 final class CommunityComposeViewController: BaseViewController, View {
     //MARK: properties
     let composeView = CommunityComposeView(mode: .create)
+    private var pictureDragStartX: CGFloat?
     
     //MARK: Lifecycle
     override func loadView() {
@@ -90,6 +91,20 @@ final class CommunityComposeViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
+        composeView.rx.pictureViewLongPress
+            .withLatestFrom(reactor.state.map(\.pictures.count)) { event, pictureCount in
+                (event, pictureCount)
+            }
+            .compactMap { [weak self] event, pictureCount in
+                self?.makePictureMoveAction(
+                    index: event.index,
+                    pictureCount: pictureCount,
+                    gesture: event.gesture
+                )
+            }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
         composeView.bodyTextView.rx.setDelegate(self)
             .disposed(by: disposeBag)
 
@@ -141,6 +156,7 @@ extension CommunityComposeViewController {
         picker: PHPickerViewController
     )
 
+    // 사진 선택 수 제한 반영 imagePicker 생성
     private func makePicturePickerRequest(
         index: Int,
         pictureCount: Int
@@ -160,6 +176,7 @@ extension CommunityComposeViewController {
         )
     }
 
+    // 사진 선택 시 리액터에 전달할 액션 생성 - replace 혹은 add
     private static func makePictureAction(
         request: PicturePickerRequest,
         images: [UIImage]
@@ -173,6 +190,7 @@ extension CommunityComposeViewController {
         return .addPictures(images)
     }
 
+    // 이미지 피커 생성
     private func makeImagePicker(selectionLimit: Int) -> PHPickerViewController {
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
         configuration.filter = .images
@@ -182,6 +200,81 @@ extension CommunityComposeViewController {
         let picker = PHPickerViewController(configuration: configuration)
     
         return picker
+    }
+
+    // 사진 순서 변경 액션
+    private func makePictureMoveAction(
+        index: Int,
+        pictureCount: Int,
+        gesture: UILongPressGestureRecognizer
+    ) -> CommunityComposeReactor.Action? {
+        guard index < pictureCount else { return nil }
+
+        let pictureView = composeView.pictureViews[index]
+        let location = gesture.location(in: composeView)
+
+        switch gesture.state {
+        case .began:
+            pictureDragStartX = location.x
+            pictureView.superview?.layer.zPosition = 1
+            pictureView.transform = CGAffineTransform(scaleX: 1.05, y: 1.05)
+
+        case .changed:
+            guard let startX = pictureDragStartX else { return nil }
+            pictureView.transform = CGAffineTransform(
+                translationX: location.x - startX,
+                y: 0
+            ).scaledBy(x: 1.05, y: 1.05)
+
+        case .ended:
+            resetPictureDrag(pictureView)
+            guard
+                let targetIndex = nearestPictureIndex(
+                    to: location.x,
+                    pictureCount: pictureCount
+                ),
+                targetIndex != index
+            else {
+                return nil
+            }
+            return .movePicture(from: index, to: targetIndex)
+
+        case .cancelled, .failed:
+            resetPictureDrag(pictureView)
+
+        default:
+            break
+        }
+
+        return nil
+    }
+
+    // 가까운 사진 인덱스 계산
+    private func nearestPictureIndex(
+        to locationX: CGFloat,
+        pictureCount: Int
+    ) -> Int? {
+        (0..<pictureCount).min { lhs, rhs in
+            abs(pictureCenterX(at: lhs) - locationX)
+                < abs(pictureCenterX(at: rhs) - locationX)
+        }
+    }
+
+    // 사진 중앙 위치 계산
+    private func pictureCenterX(at index: Int) -> CGFloat {
+        let pictureView = composeView.pictureViews[index]
+        let center = CGPoint(
+            x: pictureView.bounds.midX,
+            y: pictureView.bounds.midY
+        )
+        return pictureView.convert(center, to: composeView).x
+    }
+
+    // 사진 순서 변경 제스처 관련 초기화
+    private func resetPictureDrag(_ pictureView: PictureComposeView) {
+        pictureDragStartX = nil
+        pictureView.transform = .identity
+        pictureView.superview?.layer.zPosition = 0
     }
 }
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -26,7 +26,6 @@ final class CommunityComposeViewController: BaseViewController, View {
         }
 
         super.init(nibName: nil, bundle: nil)
-        reactor = CommunityComposeReactor(mode: mode)
     }
 
     required init?(coder: NSCoder) {
@@ -177,7 +176,7 @@ final class CommunityComposeViewController: BaseViewController, View {
         
         state.map(\.pictures)
             .drive(with: composeView) { view, pictures in
-                view.applyPictures(pictures.map(\.previewImage))
+                view.applyPictures(pictures.map(\.displayImage))
             }
             .disposed(by: disposeBag)
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -24,7 +24,6 @@ final class CommunityComposeViewController: BaseViewController, View {
         super.viewDidLoad()
         hidesBottomBarWhenPushed = true
         navigationController?.navigationBar.isHidden = true
-        setPictureActions()
     }
     
     //MARK: Bind
@@ -60,6 +59,32 @@ final class CommunityComposeViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        composeView.rx.pictureViewTap
+            .withLatestFrom(reactor.state.map(\.pictures.count)) { index, pictureCount in
+                (index, pictureCount)
+            }
+            .compactMap { [weak self] index, pictureCount in
+                self?.makePicturePickerRequest(
+                    index: index,
+                    pictureCount: pictureCount
+                )
+            }
+            .withUnretained(self)
+            .do(onNext: { viewController, request in
+                viewController.present(request.picker, animated: true)
+            })
+            .flatMap { _, request in
+                request.picker.rx.selectedImages
+                    .take(1)
+                    .map { images in (request, images) }
+            }
+            .observe(on: MainScheduler.instance)
+            .compactMap { request, images in
+                Self.makePictureAction(request: request, images: images)
+            }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
         composeView.bodyTextView.rx.setDelegate(self)
             .disposed(by: disposeBag)
 
@@ -105,19 +130,49 @@ final class CommunityComposeViewController: BaseViewController, View {
 
 //MARK: 사진 선택 기능 관련
 extension CommunityComposeViewController {
-    private func setPictureActions() {
-        composeView.pictureViews.forEach { pictureView in
-            pictureView.onPictureSelectionRequested = { [weak self, weak pictureView] in
-                guard let self, let pictureView else { return }
+    private typealias PicturePickerRequest = (
+        index: Int,
+        replacesExisting: Bool,
+        picker: PHPickerViewController
+    )
 
-            }
-        }
+    private func makePicturePickerRequest(
+        index: Int,
+        pictureCount: Int
+    ) -> PicturePickerRequest? {
+        guard index <= pictureCount else { return nil }
+
+        let replacesExisting = index < pictureCount
+        let selectionLimit = replacesExisting
+            ? 1
+            : composeView.pictureViews.count - pictureCount
+        guard selectionLimit > 0 else { return nil }
+
+        return (
+            index,
+            replacesExisting,
+            makeImagePicker(selectionLimit: selectionLimit)
+        )
     }
 
-    private func makeImagePicker() -> PHPickerViewController {
+    private static func makePictureAction(
+        request: PicturePickerRequest,
+        images: [UIImage]
+    ) -> CommunityComposeReactor.Action? {
+        if request.replacesExisting {
+            guard let image = images.first else { return nil }
+            return .replacePicture(index: request.index, image: image)
+        }
+
+        guard !images.isEmpty else { return nil }
+        return .addPictures(images)
+    }
+
+    private func makeImagePicker(selectionLimit: Int) -> PHPickerViewController {
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
         configuration.filter = .images
-        configuration.selectionLimit = 3
+        configuration.selection = .ordered
+        configuration.selectionLimit = selectionLimit
 
         let picker = PHPickerViewController(configuration: configuration)
     

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -14,8 +14,8 @@ import RxCocoa
 final class CommunityComposeViewController: BaseViewController, View {
     //MARK: properties
     let composeView: CommunityComposeView
-    private var pictureDragStartX: CGFloat?
-    private var pictureDragTargetIndex: Int?
+    private var pictureDragStartX: CGFloat? // 사진 순서 변경용 드래그 시작 지점 좌표
+    private var pictureDragTargetIndex: Int? // 사진 순서 변경용 타겟 사진 순서 인덱스
 
     init(mode: CommunityComposeMode = .create) {
         switch mode {
@@ -39,7 +39,6 @@ final class CommunityComposeViewController: BaseViewController, View {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        hidesBottomBarWhenPushed = true
         navigationController?.navigationBar.isHidden = true
     }
     

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -41,6 +41,15 @@ final class CommunityComposeViewController: BaseViewController, View {
                 self?.steps.accept(AppStep.pageBack)
             })
             .disposed(by: disposeBag)
+        
+        // 안내문
+        composeView.titleView.rx.rightButtonTap
+            .subscribe(onNext: { [weak self] _ in
+                self?.steps.accept(AppStep.composeNotice)
+            })
+            .disposed(by: disposeBag)
+        
+        
     }
     
     private func bindState(reactor: CameraClassificationReactor) {

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -14,7 +14,6 @@ import RxCocoa
 final class CommunityComposeViewController: BaseViewController, View {
     //MARK: properties
     let composeView = CommunityComposeView(mode: .create)
-    private weak var selectedPictureView: PictureComposeView?
     
     //MARK: Lifecycle
     override func loadView() {
@@ -61,8 +60,8 @@ final class CommunityComposeViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        composeView.pictureViews.rx.tap
-            .compactMap { [weak self] _ -> PHPickerViewController? in
+        composeView.rx.pictureViewTap
+            .compactMap { [weak self] index -> PHPickerViewController? in
                 return self?.makeImagePicker()
             }
             .withUnretained(self)
@@ -116,7 +115,7 @@ extension CommunityComposeViewController {
             pictureView.onPictureSelectionRequested = { [weak self, weak pictureView] in
                 guard let self, let pictureView else { return }
 
-                selectedPictureView = pictureView
+               
             }
         }
     }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -37,9 +37,43 @@ final class CommunityComposeViewController: BaseViewController, View {
         view = composeView
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        tabBarController?.tabBar.isHidden = true
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationController?.navigationBar.isHidden = true
+        setKeyboardDismissGesture()
+    }
+
+    override func setKeyboardDismissGesture() {
+        let tapGesture = UITapGestureRecognizer()
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+
+        tapGesture.rx.event
+            .filter { [weak self] gesture in
+                guard let self else { return false }
+
+                let location = gesture.location(in: view)
+                guard let touchedView = view.hitTest(location, with: nil) else {
+                    return true
+                }
+
+                let inputViews = [
+                    composeView.titleTextField,
+                    composeView.bodyTextView
+                ]
+
+                return !inputViews.contains {
+                    touchedView === $0 || touchedView.isDescendant(of: $0)
+                }
+            }
+            .subscribe(with: self) { viewController, _ in
+                viewController.view.endEditing(true)
+            }
+            .disposed(by: disposeBag)
     }
     
     //MARK: Bind

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -85,6 +85,7 @@ final class CommunityComposeViewController: BaseViewController, View {
         composeView.titleTextField.delegate = self
         
         composeView.rx.pictureViewTap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
             .withLatestFrom(reactor.state.map(\.pictures.count)) { index, pictureCount in
                 (index, pictureCount)
             }
@@ -140,6 +141,7 @@ final class CommunityComposeViewController: BaseViewController, View {
             .disposed(by: disposeBag)
 
         composeView.saveButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
             .map { CommunityComposeReactor.Action.saveTapped }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -85,6 +85,11 @@ final class CommunityComposeViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
+        composeView.rx.pictureRemoveButtonTap
+            .map { CommunityComposeReactor.Action.removePicture(index: $0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
         composeView.bodyTextView.rx.setDelegate(self)
             .disposed(by: disposeBag)
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -209,6 +209,14 @@ final class CommunityComposeViewController: BaseViewController, View {
                 viewController.steps.accept(AppStep.alert("안내", message))
             }
             .disposed(by: disposeBag)
+        
+        //TODO: 저장 성공 시 글 상세 화면으로 넘어가도록 step 변경 필요
+        reactor.pulse(\.$saveCompleted)
+            .map { $0 }
+            .subscribe(with: self) { viewController, isCompleted in
+                if isCompleted { viewController.steps.accept(AppStep.pageBack) }
+            }
+            .disposed(by: disposeBag)
     }
 
     private func setSaving(_ isSaving: Bool) {

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -21,20 +21,18 @@ final class CommunityComposeViewController: BaseViewController, View {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.reactor = CameraClassificationReactor()
         hidesBottomBarWhenPushed = true
         navigationController?.navigationBar.isHidden = true
-        
-        
     }
     
     //MARK: Bind
-    func bind(reactor: CameraClassificationReactor) {
+    func bind(reactor: CommunityComposeReactor) {
         bindAction(reactor: reactor)
         bindState(reactor: reactor)
     }
     
-    private func bindAction(reactor: CameraClassificationReactor) {
+    private func bindAction(reactor: CommunityComposeReactor) {
+        //MARK: TitleView
         // 뒤로가기
         composeView.titleView.rx.backButtonTap
             .subscribe(onNext: { [weak self] _ in
@@ -49,10 +47,14 @@ final class CommunityComposeViewController: BaseViewController, View {
             })
             .disposed(by: disposeBag)
         
-        
+        //MARK: Body
+        composeView.rx.categoryButtonTap
+            .map { CommunityComposeReactor.Action.selectCategory($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
     }
     
-    private func bindState(reactor: CameraClassificationReactor) {
+    private func bindState(reactor: CommunityComposeReactor) {
         
     }
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -79,7 +79,13 @@ final class CommunityComposeViewController: BaseViewController, View {
         
         state.map(\.category)
             .drive { [weak composeView] category in
-                composeView?.selectCategory(category)
+                composeView?.applySelectedCategory(category)
+            }
+            .disposed(by: disposeBag)
+        
+        state.map(\.isButtonActive)
+            .drive { [weak composeView] isActive in
+                composeView?.saveButton.isEnabled = isActive
             }
             .disposed(by: disposeBag)
     }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -44,10 +44,15 @@ final class CommunityComposeViewController: BaseViewController, View {
         composeView.titleView.rx.rightButtonTap
             .subscribe(onNext: { [weak self] _ in
                 self?.steps.accept(AppStep.composeNotice)
-            })
+            }) 
             .disposed(by: disposeBag)
         
         //MARK: Body
+        composeView.rx.categoryButtonTap
+            .map { CommunityComposeReactor.Action.selectCategory($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         composeView.bodyTextView.rx.setDelegate(self)
             .disposed(by: disposeBag)
 
@@ -61,10 +66,7 @@ final class CommunityComposeViewController: BaseViewController, View {
             })
             .disposed(by: disposeBag)
 
-        composeView.rx.categoryButtonTap
-            .map { CommunityComposeReactor.Action.selectCategory($0) }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
+        
     }
     
     private func bindState(reactor: CommunityComposeReactor) {
@@ -79,6 +81,7 @@ final class CommunityComposeViewController: BaseViewController, View {
 
 //MARK: Delegate
 extension CommunityComposeViewController: UITextViewDelegate {
+    // 글자수 제한 기능
     func textView(
         _ textView: UITextView,
         shouldChangeTextIn range: NSRange,

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -13,9 +13,25 @@ import RxCocoa
 
 final class CommunityComposeViewController: BaseViewController, View {
     //MARK: properties
-    let composeView = CommunityComposeView(mode: .create)
+    let composeView: CommunityComposeView
     private var pictureDragStartX: CGFloat?
     private var pictureDragTargetIndex: Int?
+
+    init(mode: CommunityComposeMode = .create) {
+        switch mode {
+        case .create:
+            composeView = CommunityComposeView(mode: .create)
+        case .edit:
+            composeView = CommunityComposeView(mode: .edit)
+        }
+
+        super.init(nibName: nil, bundle: nil)
+        reactor = CommunityComposeReactor(mode: mode)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     //MARK: Lifecycle
     override func loadView() {
@@ -35,6 +51,12 @@ final class CommunityComposeViewController: BaseViewController, View {
     }
     
     private func bindAction(reactor: CommunityComposeReactor) {
+        rx.viewWillAppear
+            .take(1)
+            .map { _ in CommunityComposeReactor.Action.viewWillAppear }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
         //MARK: TitleView
         // 뒤로가기
         composeView.titleView.rx.backButtonTap
@@ -57,6 +79,7 @@ final class CommunityComposeViewController: BaseViewController, View {
             .disposed(by: disposeBag)
         
         composeView.titleTextField.rx.text.orEmpty
+            .skip(1)
             .map { CommunityComposeReactor.Action.enterTitle($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -112,6 +135,7 @@ final class CommunityComposeViewController: BaseViewController, View {
             .disposed(by: disposeBag)
 
         composeView.bodyTextView.rx.text.orEmpty
+            .skip(1)
             .distinctUntilChanged()
             .map { CommunityComposeReactor.Action.enterBody($0) }
             .bind(to: reactor.action)
@@ -124,16 +148,27 @@ final class CommunityComposeViewController: BaseViewController, View {
     }
     
     private func bindState(reactor: CommunityComposeReactor) {
-        let state = reactor.state.asDriver(onErrorJustReturn: .init(category: .plantLife))
+        let state = reactor.state.asDriver(onErrorDriveWith: .empty())
         
         state.map(\.category)
             .drive(with: composeView) { view, category in
                 view.applySelectedCategory(category)
             }
             .disposed(by: disposeBag)
+
+        state.map(\.title)
+            .distinctUntilChanged()
+            .drive(with: composeView) { view, title in
+                guard view.titleTextField.text != title else { return }
+                view.titleTextField.text = title
+            }
+            .disposed(by: disposeBag)
         
         state.map(\.body)
             .drive(with: composeView) { view, text in
+                if view.bodyTextView.text != text {
+                    view.bodyTextView.text = text
+                }
                 let count = text.count
                 view.updatePlaceholderVisibility(count) // 텍스트뷰 플레이스홀더 레이블 표시 UI 설정
                 view.updateCount(count) // 텍스트 초과 표시 UI 설정
@@ -142,7 +177,7 @@ final class CommunityComposeViewController: BaseViewController, View {
         
         state.map(\.pictures)
             .drive(with: composeView) { view, pictures in
-                view.applyPictures(pictures)
+                view.applyPictures(pictures.map(\.previewImage))
             }
             .disposed(by: disposeBag)
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -7,12 +7,14 @@
 
 import UIKit
 import Dependencies
+import PhotosUI
 import ReactorKit
 import RxCocoa
 
 final class CommunityComposeViewController: BaseViewController, View {
     //MARK: properties
     let composeView = CommunityComposeView(mode: .create)
+    private weak var selectedPictureView: PictureComposeView?
     
     //MARK: Lifecycle
     override func loadView() {
@@ -23,6 +25,7 @@ final class CommunityComposeViewController: BaseViewController, View {
         super.viewDidLoad()
         hidesBottomBarWhenPushed = true
         navigationController?.navigationBar.isHidden = true
+        setPictureActions()
     }
     
     //MARK: Bind
@@ -55,6 +58,17 @@ final class CommunityComposeViewController: BaseViewController, View {
         
         composeView.titleTextField.rx.text.orEmpty
             .map { CommunityComposeReactor.Action.enterTitle($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        composeView.pictureViews.rx.tap
+            .compactMap { [weak self] _ -> PHPickerViewController? in
+                return self?.makeImagePicker()
+            }
+            .withUnretained(self)
+            .do(onNext: { $0.present($1, animated: true) })
+            .flatMap { $1.rx.selectedImages.take(1) }
+            .map { CommunityComposeReactor.Action.selectPicture($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
@@ -95,12 +109,30 @@ final class CommunityComposeViewController: BaseViewController, View {
     }
 }
 
-@available(iOS 17.0, *)
-#Preview {
-  CommunityComposeViewController()
+//MARK: 사진 선택 기능 관련
+extension CommunityComposeViewController {
+    private func setPictureActions() {
+        composeView.pictureViews.forEach { pictureView in
+            pictureView.onPictureSelectionRequested = { [weak self, weak pictureView] in
+                guard let self, let pictureView else { return }
+
+                selectedPictureView = pictureView
+            }
+        }
+    }
+
+    private func makeImagePicker() -> PHPickerViewController {
+        var configuration = PHPickerConfiguration(photoLibrary: .shared())
+        configuration.filter = .images
+        configuration.selectionLimit = 3
+
+        let picker = PHPickerViewController(configuration: configuration)
+    
+        return picker
+    }
 }
 
-//MARK: Delegate
+//MARK: UITextView Delegate
 extension CommunityComposeViewController: UITextViewDelegate {
     // 글자수 제한 기능
     func textView(
@@ -141,4 +173,9 @@ extension CommunityComposeViewController: UITextViewDelegate {
 
         return false
     }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+  CommunityComposeViewController()
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -48,6 +48,19 @@ final class CommunityComposeViewController: BaseViewController, View {
             .disposed(by: disposeBag)
         
         //MARK: Body
+        composeView.bodyTextView.rx.setDelegate(self)
+            .disposed(by: disposeBag)
+
+        composeView.bodyTextView.rx.text.orEmpty
+            .map { $0.count }
+            .distinctUntilChanged()
+            .withUnretained(self)
+            .bind(onNext: { `self`, count in
+                self.composeView.updatePlaceholderVisibility(count)
+                self.composeView.updateCount(count)
+            })
+            .disposed(by: disposeBag)
+
         composeView.rx.categoryButtonTap
             .map { CommunityComposeReactor.Action.selectCategory($0) }
             .bind(to: reactor.action)
@@ -62,4 +75,46 @@ final class CommunityComposeViewController: BaseViewController, View {
 @available(iOS 17.0, *)
 #Preview {
   CommunityComposeViewController()
+}
+
+//MARK: Delegate
+extension CommunityComposeViewController: UITextViewDelegate {
+    func textView(
+        _ textView: UITextView,
+        shouldChangeTextIn range: NSRange,
+        replacementText text: String
+    ) -> Bool {
+        let currentText = textView.text ?? ""
+        guard let textRange = Range(range, in: currentText) else {
+            return false
+        }
+
+        let updatedText = currentText.replacingCharacters(in: textRange, with: text)
+        if updatedText.count <= CommunityComposeView.bodyMaxCount {
+            return true
+        }
+
+        let replaceCount = currentText[textRange].count // 글자를 붙여넣기할 때 붙여넣을 글자의 수
+        let remainingCount = CommunityComposeView.bodyMaxCount - currentText.count + replaceCount
+        guard remainingCount > 0 else {
+            return false
+        }
+
+        // 최대 글자 수 까지만 글자를 적용하여 textView에 반영
+        let limitedText = String(text.prefix(remainingCount))
+        let limitedUpdatedText = currentText.replacingCharacters(in: textRange, with: limitedText)
+        textView.text = limitedUpdatedText
+        textView.selectedRange = NSRange(
+            location: range.location + (limitedText as NSString).length,
+            length: 0
+        )
+        
+        // NotificationCenter를 통해 textView.text의 변경을 알림 -> bodyTextView.rx.tex.orEmpty에서 감지
+        NotificationCenter.default.post(
+            name: UITextView.textDidChangeNotification,
+            object: textView
+        )
+
+        return false
+    }
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -432,6 +432,8 @@ extension CommunityComposeViewController {
         targetIndex: Int,
         pictureCount: Int
     ) {
+        guard pictureCount >= 2 else { return }
+
         let slotDistance = abs(
             pictureCenterX(at: 1) - pictureCenterX(at: 0)
         )

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -62,13 +62,9 @@ final class CommunityComposeViewController: BaseViewController, View {
             .disposed(by: disposeBag)
 
         composeView.bodyTextView.rx.text.orEmpty
-            .map { $0.count }
             .distinctUntilChanged()
-            .withUnretained(self)
-            .bind(onNext: { `self`, count in
-                self.composeView.updatePlaceholderVisibility(count)
-                self.composeView.updateCount(count)
-            })
+            .map { CommunityComposeReactor.Action.enterBody($0) }
+            .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
         
@@ -78,14 +74,22 @@ final class CommunityComposeViewController: BaseViewController, View {
         let state = reactor.state.asDriver(onErrorJustReturn: .init(category: .plantLife))
         
         state.map(\.category)
-            .drive { [weak composeView] category in
-                composeView?.applySelectedCategory(category)
+            .drive(with: composeView) { view, category in
+                view.applySelectedCategory(category)
+            }
+            .disposed(by: disposeBag)
+        
+        state.map(\.body)
+            .drive(with: composeView) { view, text in
+                let count = text.count
+                view.updatePlaceholderVisibility(count) // 텍스트뷰 플레이스홀더 레이블 표시 UI 설정
+                view.updateCount(count) // 텍스트 초과 표시 UI 설정
             }
             .disposed(by: disposeBag)
         
         state.map(\.isButtonActive)
-            .drive { [weak composeView] isActive in
-                composeView?.saveButton.isEnabled = isActive
+            .drive(with: composeView) { view, isActive in
+                view.saveButton.isEnabled = isActive
             }
             .disposed(by: disposeBag)
     }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityComposeViewController.swift
@@ -53,6 +53,11 @@ final class CommunityComposeViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        composeView.titleTextField.rx.text.orEmpty
+            .map { CommunityComposeReactor.Action.enterTitle($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         composeView.bodyTextView.rx.setDelegate(self)
             .disposed(by: disposeBag)
 
@@ -70,7 +75,13 @@ final class CommunityComposeViewController: BaseViewController, View {
     }
     
     private func bindState(reactor: CommunityComposeReactor) {
+        let state = reactor.state.asDriver(onErrorJustReturn: .init(category: .plantLife))
         
+        state.map(\.category)
+            .drive { [weak composeView] category in
+                composeView?.selectCategory(category)
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/CommunityInfoViewController.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/CommunityInfoViewController.swift
@@ -9,20 +9,40 @@ import SnapKit
 import Then
 import UIKit
 
-final class CommunityInfoViewController: BaseViewController {
+final class CommunityInfoViewController: UIViewController {
     private let infoView = CommunityInfoView()
+    private let dimmedView = UIView().then {
+        $0.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         view.backgroundColor = .clear
         
+        // layout
+        view.addSubview(dimmedView)
         view.addSubview(infoView)
+        
+        dimmedView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
         
         infoView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
         }
+        
+        // action
+        dimmedView.addGestureRecognizer(
+            UITapGestureRecognizer(target: self, action: #selector(dismissInfoView))
+        )
+        
+        infoView.closeButton.addTarget(self, action: #selector(dismissInfoView), for: .touchUpInside)
+    }
+    
+    @objc private func dismissInfoView() {
+        dismiss(animated: false)
     }
 }
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -92,6 +92,7 @@ final class CommunityComposeView: UIView {
         }
         
         setLayout()
+        applyPictures([])
     }
 
     required init?(coder: NSCoder) {
@@ -105,7 +106,18 @@ final class CommunityComposeView: UIView {
             $0.alignment = .fill
         }
         
-        let pictureViewHorizontalStack = UIStackView(arrangedSubviews: pictureViews).then {
+        let pictureSlots = pictureViews.map { pictureView in
+            let slotView = UIView()
+            slotView.addSubview(pictureView)
+
+            pictureView.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
+
+            return slotView
+        }
+
+        let pictureViewHorizontalStack = UIStackView(arrangedSubviews: pictureSlots).then {
             $0.axis = .horizontal
             $0.distribution = .fillEqually
             $0.spacing = 12
@@ -187,9 +199,9 @@ final class CommunityComposeView: UIView {
             $0.width.equalToSuperview()
         }
         
-        pictureViews.forEach { pictureView in
-            pictureView.snp.makeConstraints {
-                $0.height.equalTo(pictureView.snp.width)
+        pictureSlots.forEach { slotView in
+            slotView.snp.makeConstraints {
+                $0.height.equalTo(slotView.snp.width)
             }
         }
         
@@ -217,9 +229,12 @@ extension CommunityComposeView {
     
     // Picture
     func applyPictures(_ pictures: [UIImage]) {
+        let visiblePictureCount = min(pictures.count + 1, pictureViews.count)
+
         for (index, pictureView) in pictureViews.enumerated() {
             let image = pictures.indices.contains(index) ? pictures[index] : nil
             pictureView.setImage(image)
+            pictureView.isHidden = index >= visiblePictureCount
         }
     }
     
@@ -339,6 +354,14 @@ extension Reactive where Base: CommunityComposeView {
             base.pictureViews.enumerated()
             .map { index, view in
                 view.rx.tap.map { index }
+            })
+    }
+
+    var pictureRemoveButtonTap: Observable<Int> {
+        Observable.merge(
+            base.pictureViews.enumerated()
+            .map { index, view in
+                view.rx.cancelButtonTap.map { index }
             })
     }
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -364,4 +364,15 @@ extension Reactive where Base: CommunityComposeView {
                 view.rx.cancelButtonTap.map { index }
             })
     }
+
+    var pictureViewLongPress: Observable<(
+        index: Int,
+        gesture: UILongPressGestureRecognizer
+    )> {
+        Observable.merge(
+            base.pictureViews.enumerated()
+            .map { index, view in
+                view.rx.longPress.map { (index, $0) }
+            })
+    }
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -244,9 +244,10 @@ extension CommunityComposeView {
     }
     
     // TextView
-    static let bodyMaxCount = 1000
-
-    func updateCount(_ current: Int, max: Int = CommunityComposeView.bodyMaxCount) {
+    func updateCount(
+        _ current: Int,
+        max: Int = CommunityPostValidation.contentMaxCount
+    ) {
         if current >= max {
             let text = "최대 1,000자까지 입력할 수 있어요. \(current)/\(max)"
             bodyCountLabel.text = text

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -228,12 +228,15 @@ extension CommunityComposeView {
     }
     
     // Picture
-    func applyPictures(_ pictures: [UIImage]) {
+    func applyPictures(_ pictures: [UIImage?]) {
         let visiblePictureCount = min(pictures.count + 1, pictureViews.count)
 
         for (index, pictureView) in pictureViews.enumerated() {
             let image = pictures.indices.contains(index) ? pictures[index] : nil
-            pictureView.setImage(image)
+            pictureView.setImage(
+                image,
+                isOccupied: pictures.indices.contains(index)
+            )
             pictureView.isHidden = index >= visiblePictureCount
         }
     }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -65,6 +65,10 @@ final class CommunityComposeView: UIView {
         $0.textContainer.lineFragmentPadding = 0
     }
     
+    let bodyCountLabel = UILabel(config: .body12).then {
+        $0.textAlignment = .right
+    }
+    
     private let bodyPlaceholderLabel = UILabel(text: "게시글 내용을 입력해주세요.", config: .body14, color: .grayScale300)
     
     let saveButton = BottomSaveButton(title: "")
@@ -83,6 +87,9 @@ final class CommunityComposeView: UIView {
         }
         
         setLayout()
+        
+        //TODO: 기능 구현 시 삭제
+        updateCount(0)
     }
 
     required init?(coder: NSCoder) {
@@ -108,10 +115,15 @@ final class CommunityComposeView: UIView {
             $0.spacing = 6
         }
         
+        let bodyVerticalStack = UIStackView(arrangedSubviews: [bodyTextView, bodyCountLabel]).then {
+            $0.axis = .vertical
+            $0.spacing = 6
+        }
+        
         let categoryStack = makeVerticalStackView(title: "카테고리*", style: .attributed, views: [buttonStack])
         let titleStack = makeVerticalStackView(title: "제목*", style: .attributed, views: [titleTextField])
         let pictureStack = makeVerticalStackView(title: "사진 첨부 (선택)", style: .plain, views: [pictureViewStack])
-        let bodyStack = makeVerticalStackView(title: "내용*", style: .attributed, views: [bodyTextView])
+        let bodyStack = makeVerticalStackView(title: "내용*", style: .attributed, views: [bodyVerticalStack])
         
         let stackView = UIStackView(arrangedSubviews: [categoryStack, titleStack, pictureStack, bodyStack]).then {
             $0.axis = .vertical
@@ -190,6 +202,29 @@ final class CommunityComposeView: UIView {
         }
     }
  
+}
+
+//MARK: Configure
+extension CommunityComposeView {
+    func updateCount(_ current: Int, max: Int = 1000) {
+        let text = "\(current) / \(max)"
+        let attributedString = NSMutableAttributedString(
+            string: text,
+            attributes: [
+                .foregroundColor: UIColor.grayScale300,
+                .font: UIFont.systemFont(ofSize: 12)
+            ]
+        )
+
+        let currentRange = (text as NSString).range(of: "\(current)")
+        attributedString.addAttribute(
+            .foregroundColor,
+            value: UIColor.grayScale900,
+            range: currentRange
+        )
+
+        bodyCountLabel.attributedText = attributedString
+    }
 }
 
 //MARK: Components

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -228,13 +228,15 @@ extension CommunityComposeView {
     }
     
     // Picture
-    func applyPictures(_ pictures: [UIImage?]) {
+    func applyPictures(_ pictures: [PictureComposeView.ImageSource]) {
         let visiblePictureCount = min(pictures.count + 1, pictureViews.count)
 
         for (index, pictureView) in pictureViews.enumerated() {
-            let image = pictures.indices.contains(index) ? pictures[index] : nil
+            let source = pictures.indices.contains(index)
+                ? pictures[index]
+                : nil
             pictureView.setImage(
-                image,
+                source,
                 isOccupied: pictures.indices.contains(index)
             )
             pictureView.isHidden = index >= visiblePictureCount

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -92,6 +92,7 @@ final class CommunityComposeView: UIView {
         }
         
         setLayout()
+        updatePictureVisibility()
     }
 
     required init?(coder: NSCoder) {
@@ -212,6 +213,13 @@ extension CommunityComposeView {
     func applySelectedCategory(_ category: PostCategory) {
         [categoryDailyButton, categoryQuestionButton, categoryPlanetButton].forEach {
             $0.isSelected = $0.tag == category.rawValue
+        }
+    }
+    
+    // Picture
+    func updatePictureVisibility() {
+        for i in 1..<pictureViews.count {
+            pictureViews[i].isHidden = pictureViews[i].imageView.image == nil
         }
     }
     

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -92,9 +92,6 @@ final class CommunityComposeView: UIView {
         }
         
         setLayout()
-        
-        //TODO: 기능 구현 시 삭제
-        updateCount(0)
     }
 
     required init?(coder: NSCoder) {
@@ -327,5 +324,11 @@ extension Reactive where Base: CommunityComposeView {
             .map { _ in base.categoryPlanetButton.tag }
         
         return Observable.merge([dailyTap, questionTap, planetTap])
+    }
+    
+    var pictureViewTap: Observable<Int> {
+        base.pictureViews.enumerated().forEach {
+            $0.element.rx.tap
+        }
     }
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -211,6 +211,14 @@ final class CommunityComposeView: UIView {
 
 //MARK: Configure
 extension CommunityComposeView {
+    // Category
+    func applySelectedCategory(_ category: PostCategory) {
+        [categoryDailyButton, categoryQuestionButton, categoryPlanetButton].forEach {
+            $0.isSelected = $0.tag == category.rawValue
+        }
+    }
+    
+    // TextView
     static let bodyMaxCount = 1000
 
     func updateCount(_ current: Int, max: Int = CommunityComposeView.bodyMaxCount) {

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -34,6 +34,12 @@ final class CommunityComposeView: UIView {
         $0.placeholder = "제목을 입력해주세요."
     }
 
+    let pictureViews = [
+        PictureComposeView(),
+        PictureComposeView(),
+        PictureComposeView()
+    ]
+    
     let bodyTextView = UITextView().then {
         $0.font = .systemFont(ofSize: 14, weight: .regular)
         $0.textColor = .label
@@ -86,10 +92,16 @@ final class CommunityComposeView: UIView {
             $0.alignment = .fill
         }
         
+        let pictureViewStack = UIStackView(arrangedSubviews: pictureViews).then {
+            $0.axis = .horizontal
+            $0.distribution = .fillEqually
+            $0.spacing = 12
+            $0.alignment = .center
+        }
+        
         let categoryStack = makeVerticalStackView(title: "카테고리*", style: .attributed, views: [buttonStack])
         let titleStack = makeVerticalStackView(title: "제목*", style: .attributed, views: [titleTextField])
-        //TODO: custom comp 만들기
-        let pictureStack = makeVerticalStackView(title: "사진 첨부 (선택)", style: .plain, views: [])
+        let pictureStack = makeVerticalStackView(title: "사진 첨부 (선택)", style: .plain, views: [pictureViewStack])
         let bodyStack = makeVerticalStackView(title: "내용*", style: .attributed, views: [bodyTextView])
         
         let stackView = UIStackView(arrangedSubviews: [categoryStack, titleStack, pictureStack, bodyStack]).then {
@@ -144,8 +156,18 @@ final class CommunityComposeView: UIView {
             $0.width.equalToSuperview()
         }
         
+        pictureStack.snp.makeConstraints {
+            $0.width.equalToSuperview()
+        }
+        
         bodyStack.snp.makeConstraints {
             $0.width.equalToSuperview()
+        }
+        
+        pictureViews.forEach { pictureView in
+            pictureView.snp.makeConstraints {
+                $0.height.equalTo(pictureView.snp.width)
+            }
         }
         
         bodyTextView.addSubview(bodyPlaceholderLabel)

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -148,7 +148,7 @@ final class CommunityComposeView: UIView {
         scrollView.snp.makeConstraints {
             $0.top.equalTo(titleView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalTo(saveButton.snp.top).inset(24)
+            $0.bottom.equalTo(saveButton.snp.top).offset(-24)
         }
         
         saveButton.snp.makeConstraints {
@@ -211,24 +211,36 @@ final class CommunityComposeView: UIView {
 
 //MARK: Configure
 extension CommunityComposeView {
-    func updateCount(_ current: Int, max: Int = 1000) {
-        let text = "\(current) / \(max)"
-        let attributedString = NSMutableAttributedString(
-            string: text,
-            attributes: [
-                .foregroundColor: UIColor.grayScale300,
-                .font: UIFont.systemFont(ofSize: 12)
-            ]
-        )
+    static let bodyMaxCount = 1000
 
-        let currentRange = (text as NSString).range(of: "\(current)")
-        attributedString.addAttribute(
-            .foregroundColor,
-            value: UIColor.grayScale900,
-            range: currentRange
-        )
-
-        bodyCountLabel.attributedText = attributedString
+    func updateCount(_ current: Int, max: Int = CommunityComposeView.bodyMaxCount) {
+        if current >= max {
+            let text = "최대 1,000자까지 입력할 수 있어요. \(current)/\(max)"
+            bodyCountLabel.text = text
+            bodyCountLabel.apply(.body12, color: .subRed)
+        } else {
+            let text = "\(current)/\(max)"
+            let attributedString = NSMutableAttributedString(
+                string: text,
+                attributes: [
+                    .foregroundColor: UIColor.grayScale300,
+                    .font: UIFont.systemFont(ofSize: 12)
+                ]
+            )
+            
+            let currentRange = (text as NSString).range(of: "\(current)")
+            attributedString.addAttribute(
+                .foregroundColor,
+                value: UIColor.grayScale900,
+                range: currentRange
+            )
+            
+            bodyCountLabel.attributedText = attributedString
+        }
+    }
+    
+    func updatePlaceholderVisibility(_ count: Int) {
+        bodyPlaceholderLabel.isHidden = count > 0 ? true : false
     }
 }
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -40,6 +40,10 @@ final class CommunityComposeView: UIView {
         PictureComposeView()
     ]
     
+    private let pictureNoticeLabel = UILabel(text: "최대 3장까지 첨부 가능", config: .body12, color: .grayScale300).then {
+        $0.textAlignment = .right
+    }
+    
     let bodyTextView = UITextView().then {
         $0.font = .systemFont(ofSize: 14, weight: .regular)
         $0.textColor = .label
@@ -92,11 +96,16 @@ final class CommunityComposeView: UIView {
             $0.alignment = .fill
         }
         
-        let pictureViewStack = UIStackView(arrangedSubviews: pictureViews).then {
+        let pictureViewHorizontalStack = UIStackView(arrangedSubviews: pictureViews).then {
             $0.axis = .horizontal
             $0.distribution = .fillEqually
             $0.spacing = 12
             $0.alignment = .center
+        }
+        
+        let pictureViewStack = UIStackView(arrangedSubviews: [pictureViewHorizontalStack, pictureNoticeLabel]).then {
+            $0.axis = .vertical
+            $0.spacing = 6
         }
         
         let categoryStack = makeVerticalStackView(title: "카테고리*", style: .attributed, views: [buttonStack])
@@ -157,7 +166,7 @@ final class CommunityComposeView: UIView {
         }
         
         pictureStack.snp.makeConstraints {
-            $0.width.equalToSuperview()
+            $0.width.equalTo(stackView.snp.width)
         }
         
         bodyStack.snp.makeConstraints {

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -92,7 +92,6 @@ final class CommunityComposeView: UIView {
         }
         
         setLayout()
-        updatePictureVisibility()
     }
 
     required init?(coder: NSCoder) {
@@ -217,9 +216,10 @@ extension CommunityComposeView {
     }
     
     // Picture
-    func updatePictureVisibility() {
-        for i in 1..<pictureViews.count {
-            pictureViews[i].isHidden = pictureViews[i].imageView.image == nil
+    func applyPictures(_ pictures: [UIImage]) {
+        for (index, pictureView) in pictureViews.enumerated() {
+            let image = pictures.indices.contains(index) ? pictures[index] : nil
+            pictureView.setImage(image)
         }
     }
     

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -327,8 +327,10 @@ extension Reactive where Base: CommunityComposeView {
     }
     
     var pictureViewTap: Observable<Int> {
-        base.pictureViews.enumerated().forEach {
-            $0.element.rx.tap
-        }
+        Observable.merge(
+            base.pictureViews.enumerated()
+            .map { index, view in
+                view.rx.tap.map { index }
+            })
     }
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityComposeView.swift
@@ -9,6 +9,8 @@ import UIKit
 import Kingfisher
 import SnapKit
 import Then
+import RxCocoa
+import RxSwift
 
 final class CommunityComposeView: UIView {
     // MARK: - UI Components
@@ -20,14 +22,17 @@ final class CommunityComposeView: UIView {
     }
     private let contentView = UIView()
     
-    let categoryDailyButton = UIButton(config: .lSize, title: "식물 일상").then {
+    let categoryDailyButton = UIButton(config: .lSize, title: PostCategory.plantLife.title).then {
         $0.layer.cornerRadius = 8
+        $0.tag = PostCategory.plantLife.rawValue
     }
-    let categoryQuestionButton = UIButton(config: .lSize, title: "식물 고민").then {
+    let categoryQuestionButton = UIButton(config: .lSize, title: PostCategory.plantHelp.title).then {
         $0.layer.cornerRadius = 8
+        $0.tag = PostCategory.plantHelp.rawValue
     }
-    let categoryPlanetButton = UIButton(config: .lSize, title: "초록별 여행").then {
+    let categoryPlanetButton = UIButton(config: .lSize, title: PostCategory.greenTrip.title).then {
         $0.layer.cornerRadius = 8
+        $0.tag = PostCategory.greenTrip.rawValue
     }
     
     let titleTextField = DesignTextField().then {
@@ -286,5 +291,21 @@ extension CommunityComposeView {
     enum TitleStyle {
         case plain
         case attributed
+    }
+}
+
+//MARK: Reactive
+extension Reactive where Base: CommunityComposeView {
+    var categoryButtonTap: Observable<Int> {
+        let dailyTap = base.categoryDailyButton.rx.tap
+            .map { _ in base.categoryDailyButton.tag }
+        
+        let questionTap = base.categoryQuestionButton.rx.tap
+            .map { _ in base.categoryQuestionButton.tag }
+        
+        let planetTap = base.categoryPlanetButton.rx.tap
+            .map { _ in base.categoryPlanetButton.tag }
+        
+        return Observable.merge([dailyTap, questionTap, planetTap])
     }
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityPictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/CommunityPictureComposeView.swift
@@ -1,7 +1,0 @@
-//
-//  CommunityPictureComposeView.swift
-//  LeafLog
-//
-//  Created by 변예린 on 7/5/26.
-//
-

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
@@ -51,7 +51,6 @@ final class PictureComposeView: BaseCardView {
     
     //MARK: Gesture
     fileprivate let tapGesture = UITapGestureRecognizer()
-    var onPictureSelectionRequested: (() -> Void)?
     
     override init(frame: CGRect = .zero, cornerRadius: CGFloat = 12) {
         super.init(frame: frame, cornerRadius: cornerRadius)
@@ -103,14 +102,6 @@ extension PictureComposeView: UIGestureRecognizerDelegate {
     private func setAction() {
         tapGesture.delegate = self
         addGestureRecognizer(tapGesture)
-    }
-
-    @objc private func didTapPictureView() {
-        onPictureSelectionRequested?()
-    }
-
-    @objc private func didTapCancelButton() {
-        setImage(nil)
     }
 
     func gestureRecognizer(

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
@@ -94,6 +94,7 @@ extension PictureComposeView {
         imageView.isHidden = !hasImage
         cancelButton.isHidden = !hasImage
         addStack.isHidden = hasImage
+        dashedBorderLayer.isHidden = hasImage
     }
 }
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
@@ -1,0 +1,44 @@
+//
+//  PictureComposeView.swift
+//  LeafLog
+//
+//  Created by 변예린 on 7/8/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class PictureComposeView: BaseCardView {
+    private let dashedBorderLayer = CAShapeLayer()
+    
+    override init(frame: CGRect = .zero, cornerRadius: CGFloat = 12) {
+        super.init(frame: frame, cornerRadius: cornerRadius)
+        
+        backgroundColor = .grayScale50
+        
+        dashedBorderLayer.fillColor = UIColor.clear.cgColor
+        dashedBorderLayer.strokeColor = UIColor.grayScale100.cgColor
+        dashedBorderLayer.lineWidth = 1
+        dashedBorderLayer.lineDashPattern = [6, 4]
+        dashedBorderLayer.zPosition = 1
+        
+        layer.addSublayer(dashedBorderLayer)
+        
+    }
+    
+    @available(*, unavailable)
+    @MainActor required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        dashedBorderLayer.frame = bounds
+        dashedBorderLayer.path = UIBezierPath(
+            roundedRect: bounds.insetBy(dx: 0.5, dy: 0.5),
+            cornerRadius: layer.cornerRadius
+        ).cgPath
+    }
+}

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Kingfisher
 import SnapKit
 import Then
 import RxCocoa
@@ -14,6 +15,7 @@ import RxSwift
 final class PictureComposeView: BaseCardView {
     //MARK: Components
     private let dashedBorderLayer = CAShapeLayer()
+    private var currentImageSource: ImageSource?
     
     private let plusImageView = UIImageView(image: .plus).then {
         $0.tintColor = .primary800
@@ -90,8 +92,54 @@ final class PictureComposeView: BaseCardView {
 
 //MARK: Configure
 extension PictureComposeView {
-    func setImage(_ image: UIImage?, isOccupied: Bool) {
-        imageView.image = image
+    enum ImageSource: Equatable {
+        case local(UIImage)
+        case remote(url: URL?, cacheKey: String)
+
+        static func == (lhs: ImageSource, rhs: ImageSource) -> Bool {
+            switch (lhs, rhs) {
+            case let (.local(lhsImage), .local(rhsImage)):
+                lhsImage === rhsImage
+            case let (
+                .remote(lhsURL, lhsCacheKey),
+                .remote(rhsURL, rhsCacheKey)
+            ):
+                lhsURL == rhsURL && lhsCacheKey == rhsCacheKey
+            default:
+                false
+            }
+        }
+    }
+
+    func setImage(_ source: ImageSource?, isOccupied: Bool) {
+        if currentImageSource != source {
+            currentImageSource = source
+            imageView.kf.cancelDownloadTask()
+
+            switch source {
+            case .local(let image):
+                imageView.image = image
+
+            case .remote(let url, let cacheKey):
+                imageView.image = nil
+                guard let url else { break }
+
+                let resource = KF.ImageResource(
+                    downloadURL: url,
+                    cacheKey: cacheKey
+                )
+                imageView.kf.setImage(
+                    with: resource,
+                    options: [
+                        .cacheOriginalImage,
+                        .transition(.fade(0.2))
+                    ]
+                )
+
+            case nil:
+                imageView.image = nil
+            }
+        }
 
         imageView.isHidden = !isOccupied
         cancelButton.isHidden = !isOccupied

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
@@ -90,14 +90,13 @@ final class PictureComposeView: BaseCardView {
 
 //MARK: Configure
 extension PictureComposeView {
-    func setImage(_ image: UIImage?) {
+    func setImage(_ image: UIImage?, isOccupied: Bool) {
         imageView.image = image
 
-        let hasImage = image != nil
-        imageView.isHidden = !hasImage
-        cancelButton.isHidden = !hasImage
-        addStack.isHidden = hasImage
-        dashedBorderLayer.isHidden = hasImage
+        imageView.isHidden = !isOccupied
+        cancelButton.isHidden = !isOccupied
+        addStack.isHidden = isOccupied
+        dashedBorderLayer.isHidden = isOccupied
     }
 }
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
@@ -12,6 +12,18 @@ import Then
 final class PictureComposeView: BaseCardView {
     private let dashedBorderLayer = CAShapeLayer()
     
+    private let plusImageView = UIImageView(image: .plus).then {
+        $0.tintColor = .primary800
+    }
+    
+    private let pictureAddLabel = UILabel(text: "사진 추가", config: .label12, color: .primary800)
+    
+    private(set) lazy var addStack = UIStackView(arrangedSubviews: [plusImageView, pictureAddLabel]).then {
+        $0.axis = .vertical
+        $0.spacing = 4
+        $0.alignment = .center
+    }
+    
     override init(frame: CGRect = .zero, cornerRadius: CGFloat = 12) {
         super.init(frame: frame, cornerRadius: cornerRadius)
         
@@ -25,6 +37,7 @@ final class PictureComposeView: BaseCardView {
         
         layer.addSublayer(dashedBorderLayer)
         
+        setLayout()
     }
     
     @available(*, unavailable)
@@ -40,5 +53,20 @@ final class PictureComposeView: BaseCardView {
             roundedRect: bounds.insetBy(dx: 0.5, dy: 0.5),
             cornerRadius: layer.cornerRadius
         ).cgPath
+    }
+}
+
+//MARK: Layout
+extension PictureComposeView {
+    private func setLayout() {
+        addSubview(addStack)
+        
+        addStack.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        plusImageView.snp.makeConstraints {
+            $0.width.height.equalTo(24)
+        }
     }
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
@@ -8,10 +8,11 @@
 import UIKit
 import SnapKit
 import Then
+import RxCocoa
+import RxSwift
 
 final class PictureComposeView: BaseCardView {
-    var onPictureSelectionRequested: (() -> Void)?
-
+    //MARK: Components
     private let dashedBorderLayer = CAShapeLayer()
     
     private let plusImageView = UIImageView(image: .plus).then {
@@ -47,6 +48,10 @@ final class PictureComposeView: BaseCardView {
         $0.clipsToBounds = true
         $0.isHidden = true
     }
+    
+    //MARK: Gesture
+    fileprivate let tapGesture = UITapGestureRecognizer()
+    var onPictureSelectionRequested: (() -> Void)?
     
     override init(frame: CGRect = .zero, cornerRadius: CGFloat = 12) {
         super.init(frame: frame, cornerRadius: cornerRadius)
@@ -96,11 +101,8 @@ extension PictureComposeView {
 //MARK: Action
 extension PictureComposeView: UIGestureRecognizerDelegate {
     private func setAction() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapPictureView))
         tapGesture.delegate = self
         addGestureRecognizer(tapGesture)
-
-        cancelButton.addTarget(self, action: #selector(didTapCancelButton), for: .touchUpInside)
     }
 
     @objc private func didTapPictureView() {
@@ -150,5 +152,16 @@ extension PictureComposeView {
         plusImageView.snp.makeConstraints {
             $0.width.height.equalTo(24)
         }
+    }
+}
+
+extension Reactive where Base:  PictureComposeView {
+    var tap: ControlEvent<Void> {
+        let source = base.tapGesture.rx.event.map { _ in () }
+        return ControlEvent(events: source)
+    }
+    
+    var cancelButtonTap: ControlEvent<Void> {
+        base.cancelButton.rx.tap
     }
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
@@ -51,6 +51,9 @@ final class PictureComposeView: BaseCardView {
     
     //MARK: Gesture
     fileprivate let tapGesture = UITapGestureRecognizer()
+    fileprivate let longPressGesture = UILongPressGestureRecognizer().then {
+        $0.minimumPressDuration = 0.3
+    }
     
     override init(frame: CGRect = .zero, cornerRadius: CGFloat = 12) {
         super.init(frame: frame, cornerRadius: cornerRadius)
@@ -102,7 +105,10 @@ extension PictureComposeView {
 extension PictureComposeView: UIGestureRecognizerDelegate {
     private func setAction() {
         tapGesture.delegate = self
+        longPressGesture.delegate = self
+        tapGesture.require(toFail: longPressGesture)
         addGestureRecognizer(tapGesture)
+        addGestureRecognizer(longPressGesture)
     }
 
     func gestureRecognizer(
@@ -155,5 +161,9 @@ extension Reactive where Base:  PictureComposeView {
     
     var cancelButtonTap: ControlEvent<Void> {
         base.cancelButton.rx.tap
+    }
+
+    var longPress: ControlEvent<UILongPressGestureRecognizer> {
+        ControlEvent(events: base.longPressGesture.rx.event)
     }
 }

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
@@ -10,6 +10,8 @@ import SnapKit
 import Then
 
 final class PictureComposeView: BaseCardView {
+    var onPictureSelectionRequested: (() -> Void)?
+
     private let dashedBorderLayer = CAShapeLayer()
     
     private let plusImageView = UIImageView(image: .plus).then {
@@ -27,6 +29,9 @@ final class PictureComposeView: BaseCardView {
     let imageView = UIImageView().then {
         $0.layer.cornerRadius = 12
         $0.clipsToBounds = true
+        $0.contentMode = .scaleAspectFill
+        $0.isUserInteractionEnabled = true
+        $0.isHidden = true
     }
     
     
@@ -40,6 +45,7 @@ final class PictureComposeView: BaseCardView {
         $0.imageView?.contentMode = .scaleAspectFit
         $0.layer.cornerRadius = 12
         $0.clipsToBounds = true
+        $0.isHidden = true
     }
     
     override init(frame: CGRect = .zero, cornerRadius: CGFloat = 12) {
@@ -56,6 +62,7 @@ final class PictureComposeView: BaseCardView {
         layer.addSublayer(dashedBorderLayer)
         
         setLayout()
+        setAction()
     }
     
     @available(*, unavailable)
@@ -71,6 +78,45 @@ final class PictureComposeView: BaseCardView {
             roundedRect: bounds.insetBy(dx: 0.5, dy: 0.5),
             cornerRadius: layer.cornerRadius
         ).cgPath
+    }
+}
+
+//MARK: Configure
+extension PictureComposeView {
+    func setImage(_ image: UIImage?) {
+        imageView.image = image
+
+        let hasImage = image != nil
+        imageView.isHidden = !hasImage
+        cancelButton.isHidden = !hasImage
+        addStack.isHidden = hasImage
+    }
+}
+
+//MARK: Action
+extension PictureComposeView: UIGestureRecognizerDelegate {
+    private func setAction() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapPictureView))
+        tapGesture.delegate = self
+        addGestureRecognizer(tapGesture)
+
+        cancelButton.addTarget(self, action: #selector(didTapCancelButton), for: .touchUpInside)
+    }
+
+    @objc private func didTapPictureView() {
+        onPictureSelectionRequested?()
+    }
+
+    @objc private func didTapCancelButton() {
+        setImage(nil)
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldReceive touch: UITouch
+    ) -> Bool {
+        guard let touchedView = touch.view else { return true }
+        return !touchedView.isDescendant(of: cancelButton)
     }
 }
 

--- a/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
+++ b/LeafLog/LeafLog/Scenes/Community/Compose/View/PictureComposeView.swift
@@ -24,6 +24,24 @@ final class PictureComposeView: BaseCardView {
         $0.alignment = .center
     }
     
+    let imageView = UIImageView().then {
+        $0.layer.cornerRadius = 12
+        $0.clipsToBounds = true
+    }
+    
+    
+    let cancelButton = UIButton().then {
+        var configuration = UIButton.Configuration.filled()
+        configuration.baseBackgroundColor = .black.withAlphaComponent(0.5)
+        configuration.baseForegroundColor = .white
+        configuration.image = UIImage(resource: .x)
+        $0.configuration = configuration
+        
+        $0.imageView?.contentMode = .scaleAspectFit
+        $0.layer.cornerRadius = 12
+        $0.clipsToBounds = true
+    }
+    
     override init(frame: CGRect = .zero, cornerRadius: CGFloat = 12) {
         super.init(frame: frame, cornerRadius: cornerRadius)
         
@@ -60,8 +78,26 @@ final class PictureComposeView: BaseCardView {
 extension PictureComposeView {
     private func setLayout() {
         addSubview(addStack)
+        addSubview(imageView)
         
         addStack.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        imageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        imageView.addSubview(cancelButton)
+        
+        cancelButton.snp.makeConstraints {
+            $0.width.height.equalTo(24)
+            $0.top.trailing.equalToSuperview().inset(8)
+            
+        }
+        
+        cancelButton.imageView?.snp.makeConstraints {
+            $0.width.height.equalTo(16)
             $0.center.equalToSuperview()
         }
         

--- a/LeafLog/LeafLog/Service/Auth/AuthError.swift
+++ b/LeafLog/LeafLog/Service/Auth/AuthError.swift
@@ -32,6 +32,9 @@ enum AuthError: Error {
     /// 알림 목록 저장/조회 작업이 실패했을 때
     case notificationFailed(String)
 
+    /// 커뮤니티 게시글 저장/조회 작업이 실패했을 때
+    case communityFailed(String)
+
     /// 회원탈퇴 처리 중 실패했을 때
     case withdrawalFailed(String)
 }
@@ -45,6 +48,7 @@ extension AuthError {
              .plantFailed(let message),
              .careFailed(let message),
              .notificationFailed(let message),
+             .communityFailed(let message),
              .withdrawalFailed(let message):
             return message
         case .cancelled:

--- a/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
+++ b/LeafLog/LeafLog/Util/Custom/TitleHeaderView.swift
@@ -117,4 +117,8 @@ extension Reactive where Base: TitleHeaderView {
     var backButtonTap: ControlEvent<Void> {
         base.backButton.rx.tap
     }
+    
+    var rightButtonTap: ControlEvent<Void> {
+        base.rightButton.rx.tap
+    }
 }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #178

## 🛠 작업 내용 (What I did)
- 커뮤니티 게시글 작성·수정 화면과 Reactor 상태 처리 구현
- 카테고리, 제목, 본문 입력 검증 및 저장 버튼 상태 바인딩
- Supabase 게시글 생성·수정 RPC 연동
- 게시글 이미지 최대 3장 선택, 교체, 삭제, 순서 변경 구현
- 게시글 이미지 JPEG 최적화, 업로드 재시도, 일부 실패 안내 구현
- 비공개 Storage 이미지의 signed URL 발급 및 Kingfisher 표시 구현
- 작성한 게시글 조회와 작성·수정 임시 진입 화면 구현
- 저장 중 화면 상호작용 차단 및 저장 성공 후 화면 전환 구현

## 💻 구현 상세 (Implementation Details)
- 작성 모드와 수정 모드를 하나의 `CommunityComposeReactor`에서 처리합니다.
- 수정 이미지 상태를 `existing`, `added`, `replacement`로 구분하여 기존 이미지 유지와 사용자 삭제 의사를 분리했습니다.
- 이미지 업로드는 게시글별 Storage 경로를 사용하며, 실패 시 재시도 후 성공한 이미지만 게시글에 반영합니다.
- 비공개 이미지 데이터 접근은 Supabase signed URL 발급과 Kingfisher 캐싱으로 처리합니다.
- 게시글 생성과 수정은 별도 RPC를 호출하며 수정 요청은 작성자 권한 검증을 전제로 합니다.
- Supabase SQL·마이그레이션 파일은 저장소 정책에 따라 PR에 포함하지 않았습니다.

## 📸 스크린샷 (Screenshots)
- 없음

## 🧐 리뷰 포인트 (Review Points)
- 작성·수정 모드의 이미지 상태 전환과 기존 이미지 삭제 시점이 적절한지 확인 부탁드립니다.
- 이미지 일부 업로드 실패 시 성공한 이미지만 저장하고 경고를 표시하는 흐름을 확인 부탁드립니다.
- Reactor, DB Manager, Supabase Manager, View 사이의 책임 분리가 적절한지 확인 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 정상적으로 통과되었나요?
- [x] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [x] 불필요한 주석이나 디버그 코드를 삭제했나요?

## Summary by Sourcery

앱 전반에 커뮤니티 글 생성·편집 기능을 추가하고, 이에 따른 UI, 네비게이션 플로우, 게시글 및 이미지용 백엔드 연동을 구현했습니다.

New Features:
- 카테고리, 제목, 본문, 저장 버튼 상태에 대한 검증을 지원하는 커뮤니티 글 작성 화면을 도입하여, 생성 및 편집 모드를 모두 지원합니다.
- 커뮤니티 글에 최대 세 장까지 이미지를 첨부할 수 있도록 하고, 이미지 선택, 교체, 삭제, 드래그 앤 드롭을 통한 순서 변경을 지원합니다.
- Supabase 기반 RPC를 통해 커뮤니티 글 생성 및 수정 기능을 통합하고, 게시글별 이미지를 전용 스토리지 버킷에 업로드하며, 비공개 이미지에 대한 서명된 URL을 해석합니다.
- 사용자가 새 글을 시작하거나 가장 최근 글을 불러와 편집할 수 있는 임시 커뮤니티 탭 진입 화면을 추가합니다.
- 독립적인 네비게이션 플로우와 작성 알림 오버레이를 갖춘 새로운 Community 탭을 메인 탭 바에 등록합니다.

Enhancements:
- 커뮤니티 게시글 이미지 업로드에 JPEG 최적화, 용량 제한, 재시도 로직을 도입해 성능과 안정성을 향상합니다.
- AuthError와 SupabaseManager를 확장하여 커뮤니티 관련 오류와 이미지 URL 해석을 기존 리소스와 함께 처리할 수 있도록 합니다.
- 데이터베이스 매핑 및 로컬라이즈된 제목을 포함한 PostCategory를 비롯한 재사용 가능한 게시글 및 이미지 모델을 추가하여 커뮤니티 데이터 처리 방식을 표준화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add community post creation and editing across the app, including UI, navigation flow, and backend integration for posts and images.

New Features:
- Introduce community post compose screen supporting both create and edit modes with validation for category, title, body, and save button state.
- Add image attachment to community posts with support for up to three images, selection, replacement, deletion, and drag-and-drop reordering.
- Integrate Supabase-backed community post creation and update via RPC, including per-post image uploads to a dedicated storage bucket and signed URL resolution for private images.
- Add temporary community tab entry screen that lets users start a new post or load and edit their latest post.
- Register a new Community tab in the main tab bar with its own navigation flow and compose notice overlay.

Enhancements:
- Implement JPEG optimization, size limits, and retry logic for community post image uploads to improve performance and reliability.
- Extend AuthError and SupabaseManager to handle community-specific failures and image URL resolution alongside existing resources.
- Add reusable post and image models, including PostCategory with database mapping and localized titles, to standardize community data handling.

</details>